### PR TITLE
feat: add single post page template

### DIFF
--- a/header.php
+++ b/header.php
@@ -82,6 +82,12 @@
         $vite->get_deferred_style('section-blog-listing', 'src/scss/sections/blog-listing.scss');
     }
 
+    // Single post — breadcrumb + single-post
+    if (is_single()) {
+        echo $vite->get_critical_css('src/scss/sections/breadcrumb-about-us.scss', 'critical-breadcrumb-single');
+        $vite->get_deferred_style('section-single-post', 'src/scss/sections/single-post.scss');
+    }
+
      // Header — loaded as separate <link> (not inline)
      $header_css = $vite->get_asset('src/scss/layout/header-one.scss');
      if ($header_css) {

--- a/inc/vite-integration.php
+++ b/inc/vite-integration.php
@@ -7,7 +7,7 @@
 class Vite_Icons_Integration {
     private static $instance = null;
     private $is_development = false;
-    private $vite_server = 'http://100.95.59.103:3000';
+    private $vite_server = 'http://localhost:3000';
 
     public static function get_instance() {
         if (self::$instance == null) {

--- a/inc/vite-integration.php
+++ b/inc/vite-integration.php
@@ -7,7 +7,7 @@
 class Vite_Icons_Integration {
     private static $instance = null;
     private $is_development = false;
-    private $vite_server = 'http://localhost:3000';
+    private $vite_server = 'http://100.95.59.103:3000';
 
     public static function get_instance() {
         if (self::$instance == null) {

--- a/single.php
+++ b/single.php
@@ -1,37 +1,7 @@
-<?php get_header(); ?>
+<?php
+get_header();
 
-<main id="main-content">
-    <?php if (have_posts()) : while (have_posts()) : the_post(); ?>
-        <article <?php post_class(); ?>>
-            <header class="entry-header">
-                <h1><?php the_title(); ?></h1>
-                <div class="entry-meta">
-                    <?php the_date(); ?> por <?php the_author(); ?>
-                </div>
-            </header>
+get_template_part('templates/breadcrumb');
+get_template_part('templates/single-post');
 
-            <?php if (has_post_thumbnail()) : ?>
-                <div class="post-thumbnail">
-                    <?php the_post_thumbnail('large'); ?>
-                </div>
-            <?php endif; ?>
-
-            <div class="entry-content">
-                <?php the_content(); ?>
-            </div>
-
-            <footer class="entry-footer">
-                <?php the_tags('<span class="tags-links">Tags: ', ', ', '</span>'); ?>
-            </footer>
-        </article>
-
-        <?php 
-        if (comments_open() || get_comments_number()) :
-            comments_template();
-        endif;
-        ?>
-
-    <?php endwhile; endif; ?>
-</main>
-
-<?php get_footer(); ?>
+get_footer();

--- a/src/scss/sections/single-post.scss
+++ b/src/scss/sections/single-post.scss
@@ -1,0 +1,395 @@
+// ============================================
+// Single Post — Full post layout + content typography
+// ============================================
+@use '../base/variables' as *;
+@use '../base/mixins' as *;
+
+// ─── Section ────────────────────────────────────────────────────────
+.single-post {
+  background-color: $color-white;
+}
+
+// ─── Container Column (col-8 reference) ─────────────────────────────
+// Centered inside .container — max-width 860px
+.single-post__container {
+  width: 100%;
+  max-width: 860px;
+  margin-inline: auto;
+  padding-top: $space-12;
+  padding-bottom: $space-12;
+
+  @include breakpoint($breakpoint-md) {
+    padding-top: $space-16;
+    padding-bottom: $space-16;
+  }
+}
+
+// ─── Featured Image ─────────────────────────────────────────────────
+.single-post__featured-image {
+  width: 100%;
+  max-width: 900px;
+  aspect-ratio: 9 / 5;
+  object-fit: cover;
+  margin-inline: auto;
+  margin-bottom: $space-8;
+  border-radius: $radius-lg;
+  overflow: hidden;
+  background-color: $color-gray-100;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+}
+
+// ─── Header ─────────────────────────────────────────────────────────
+.single-post__header {
+  margin-bottom: $space-10;
+}
+
+.single-post__title {
+  font-size: $font-size-3xl;
+  font-weight: $font-weight-bold;
+  line-height: $line-height-tight;
+  color: $color-black;
+  margin-bottom: $space-4;
+
+  @include breakpoint($breakpoint-md) {
+    font-size: $font-size-4xl;
+  }
+}
+
+.single-post__meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: $space-2;
+  font-size: $font-size-sm;
+  color: $color-gray-500;
+  line-height: $line-height-normal;
+}
+
+.single-post__meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: $space-1;
+  color: $color-gray-500;
+
+  svg {
+    flex-shrink: 0;
+    opacity: 0.7;
+  }
+}
+
+.single-post__meta-date,
+.single-post__meta-author {
+  color: $color-gray-500;
+}
+
+.single-post__meta-sep {
+  color: $color-gray-400;
+  font-size: $font-size-xs;
+}
+
+.single-post__meta-tags {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: $space-2;
+}
+
+.single-post__meta-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: $color-gray-500;
+  font-size: $font-size-xs;
+
+  svg {
+    flex-shrink: 0;
+    opacity: 0.6;
+  }
+}
+
+// ─── Content ────────────────────────────────────────────────────────
+.single-post__content {
+  font-size: $font-size-base;
+  line-height: $line-height-relaxed;
+  color: $color-gray-700;
+
+  @include breakpoint($breakpoint-md) {
+    font-size: $font-size-lg;
+  }
+
+  // Paragraphs
+  p {
+    margin-bottom: $space-6;
+    line-height: $line-height-relaxed;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  // Headings within content
+  h2, h3, h4, h5, h6 {
+    font-weight: $font-weight-bold;
+    line-height: $line-height-tight;
+    color: $color-black;
+    margin-top: $space-10;
+    margin-bottom: $space-4;
+  }
+
+  h2 { font-size: $font-size-2xl; }
+  h3 { font-size: $font-size-xl; }
+  h4 { font-size: $font-size-lg; }
+
+  // Inline elements
+  strong {
+    font-weight: $font-weight-bold;
+  }
+
+  em {
+    font-style: italic;
+  }
+
+  u {
+    text-decoration: underline;
+  }
+
+  s {
+    text-decoration: line-through;
+    color: $color-gray-500;
+  }
+
+  // Inline links
+  a {
+    color: $color-primary;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    transition: color $transition-fast;
+
+    &:hover {
+      color: $color-primary-hover;
+    }
+
+    @include focus-ring;
+  }
+
+  // Images — full width (block)
+  img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    margin: $space-8 0;
+    border-radius: $radius-md;
+    background-color: $color-gray-100;
+  }
+
+  // Images — floated right
+  img[style*="float: right"],
+  img[style*="float:right"],
+  .alignright {
+    float: right;
+    margin: 0 0 $space-4 $space-6;
+    max-width: 50%;
+
+    @include breakpoint-down($breakpoint-md) {
+      float: none;
+      max-width: 100%;
+      margin-left: 0;
+    }
+  }
+
+  // Images — floated left
+  img[style*="float: left"],
+  img[style*="float:left"],
+  .alignleft {
+    float: left;
+    margin: 0 $space-6 $space-4 0;
+    max-width: 50%;
+
+    @include breakpoint-down($breakpoint-md) {
+      float: none;
+      max-width: 100%;
+      margin-right: 0;
+    }
+  }
+
+  // Clearfix after floated elements
+  &::after {
+    content: '';
+    display: table;
+    clear: both;
+  }
+
+  // Lists
+  ul, ol {
+    margin: 0 0 $space-6 $space-6;
+    padding: 0;
+  }
+
+  li {
+    margin-bottom: $space-2;
+    line-height: $line-height-relaxed;
+
+    & > ul,
+    & > ol {
+      margin-top: $space-2;
+      margin-bottom: 0;
+    }
+  }
+
+  ul li {
+    list-style-type: disc;
+  }
+
+  ol li {
+    list-style-type: decimal;
+  }
+
+  // Blockquote
+  blockquote {
+    margin: $space-8 0;
+    padding: $space-6 $space-8;
+    border-left: 4px solid $color-primary;
+    background-color: $color-gray-50;
+    border-radius: 0 $radius-md $radius-md 0;
+
+    p:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  // Code
+  code {
+    font-family: $font-family-mono;
+    font-size: 0.875em;
+    padding: 0.125em 0.375em;
+    background-color: $color-gray-100;
+    border-radius: $radius-sm;
+    color: $color-gray-800;
+  }
+
+  pre {
+    margin: $space-6 0;
+    padding: $space-6;
+    background-color: $color-gray-900;
+    border-radius: $radius-md;
+    overflow-x: auto;
+
+    code {
+      background: none;
+      padding: 0;
+      color: $color-gray-100;
+      font-size: $font-size-sm;
+    }
+  }
+
+  // Horizontal rule
+  hr {
+    border: none;
+    border-top: 1px solid $color-gray-200;
+    margin: $space-10 0;
+  }
+
+  // Tables
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: $space-8 0;
+    font-size: $font-size-sm;
+    overflow-x: auto;
+    display: block;
+
+    @include breakpoint($breakpoint-md) {
+      display: table;
+    }
+
+    th, td {
+      padding: $space-3 $space-4;
+      text-align: left;
+      border: 1px solid $color-gray-200;
+    }
+
+    th {
+      background-color: $color-gray-50;
+      font-weight: $font-weight-semibold;
+      color: $color-gray-800;
+    }
+
+    tr:nth-child(even) td {
+      background-color: $color-gray-50;
+    }
+
+    tr:hover td {
+      background-color: $color-gray-100;
+    }
+  }
+}
+
+// ─── Post Navigation ────────────────────────────────────────────────
+.single-post__navigation {
+  display: flex;
+  flex-direction: column;
+  gap: $space-4;
+  margin-top: $space-12;
+  padding-top: $space-8;
+  border-top: 1px solid $color-gray-200;
+
+  @include breakpoint($breakpoint-md) {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .nav-links {
+    display: flex;
+    flex-direction: column;
+    gap: $space-4;
+
+    @include breakpoint($breakpoint-md) {
+      flex-direction: row;
+      justify-content: space-between;
+      width: 100%;
+    }
+  }
+
+  .nav-previous,
+  .nav-next {
+    a {
+      display: inline-flex;
+      align-items: center;
+      gap: $space-2;
+      padding: $space-3 $space-6;
+      font-size: $font-size-sm;
+      font-weight: $font-weight-medium;
+      color: $color-primary;
+      background-color: transparent;
+      border: 2px solid $color-primary;
+      border-radius: $radius-md;
+      text-decoration: none;
+      transition: background-color $transition-fast,
+                  color $transition-fast,
+                  box-shadow $transition-fast;
+
+      &:hover {
+        background-color: $color-primary;
+        color: $color-white;
+        box-shadow: 0 4px 12px rgba($color-primary, 0.3);
+      }
+
+      @include focus-ring;
+    }
+  }
+
+  .nav-next {
+    text-align: right;
+
+    a {
+      flex-direction: row-reverse;
+    }
+  }
+}

--- a/templates/breadcrumb.php
+++ b/templates/breadcrumb.php
@@ -14,7 +14,9 @@
     <div class="breadcrumb-page__overlay"></div>
 
     <div class="container breadcrumb-page__content">
-        <h1 class="breadcrumb-page__title"><?php echo esc_html( get_the_title() ); ?></h1>
+        <?php if ( ! is_single() ) : ?>
+            <h1 class="breadcrumb-page__title"><?php echo esc_html( get_the_title() ); ?></h1>
+        <?php endif; ?>
 
         <nav class="breadcrumb-page__nav" aria-label="Breadcrumb">
             <?php if ( function_exists( 'yoast_breadcrumb' ) ) : ?>

--- a/templates/single-post.php
+++ b/templates/single-post.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Template Part: Single Post
+ *
+ * @package SimpleRMS
+ */
+
+while ( have_posts() ) : the_post();
+?>
+
+<article class="single-post">
+
+    <div class="container">
+
+        <div class="single-post__container">
+
+            <div class="single-post__featured-image">
+                <?php if ( has_post_thumbnail() ) : ?>
+                    <?php the_post_thumbnail('full'); ?>
+                <?php endif; ?>
+            </div>
+
+    <div class="single-post__header">
+        <h1 class="single-post__title"><?php the_title(); ?></h1>
+        <div class="single-post__meta">
+            <span class="single-post__meta-item">
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+                <time class="single-post__meta-date"><?php echo esc_html( get_the_date( 'F j, Y' ) ); ?></time>
+            </span>
+            <span class="single-post__meta-sep">&middot;</span>
+            <span class="single-post__meta-item">
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+                <span class="single-post__meta-author"><?php echo esc_html( get_the_author() ); ?></span>
+            </span>
+            <?php
+            $tags = get_the_tags();
+            if ( $tags ) :
+                ?>
+                <span class="single-post__meta-sep">&middot;</span>
+                <span class="single-post__meta-tags">
+                    <?php foreach ( $tags as $tag ) : ?>
+                        <span class="single-post__meta-tag">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg>
+                            <?php echo esc_html( $tag->name ); ?>
+                        </span>
+                    <?php endforeach; ?>
+                </span>
+            <?php endif; ?>
+        </div>
+    </div>
+
+            <div class="single-post__content">
+                <?php the_content(); ?>
+            </div>
+
+            <nav class="single-post__navigation">
+                <?php
+                the_post_navigation([
+                    'prev_text' => '&laquo; %title',
+                    'next_text' => '%title &raquo;',
+                ]);
+                ?>
+            </nav>
+
+        </div><!-- .single-post__container -->
+
+    </div><!-- .container -->
+</article>
+
+<?php endwhile; ?>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -79,6 +79,8 @@ export default defineConfig({
         'contact-map':  path.resolve(__dirname, 'src/scss/sections/contact-map.scss'),
         // Internal page: Blog
         'blog-listing': path.resolve(__dirname, 'src/scss/sections/blog-listing.scss'),
+        // Single post
+        'single-post': path.resolve(__dirname, 'src/scss/sections/single-post.scss'),
         // Internal page breadcrumbs
         'breadcrumb-about-us': path.resolve(__dirname, 'src/scss/sections/breadcrumb-about-us.scss'),
         // Footer


### PR DESCRIPTION
## Summary

Add the single post page template for the blog.

### Changes
- **single.php** — WordPress single post template that renders breadcrumb + single-post template parts
- **templates/single-post.php** — Full post layout with featured image, H1 title, meta row (date · author · tags with icons), post content, and prev/next navigation
- **templates/breadcrumb.php** — H1 hidden on single posts (title already shown in post header)
- **src/scss/sections/single-post.scss** — Complete stylesheet with:
  - Featured image: 900x500, aspect-ratio 9/5, centered
  - Content column: max-width 860px, centered inside .container
  - Full content typography: bold, italic, underline, strikethrough, links, lists, tables, floated images, blockquotes
  - Post navigation: prev/next with button styling
- **vite.config.ts** — Register single-post.scss entry
- **header.php** — Load single-post CSS deferred + breadcrumb CSS for `is_single()`
- **Post content** — Updated post ID 1 with rich HTML for testing all content elements
- **Featured image** — Added to post ID 1 for visual testing

### Testing
Visit `/hola-mundo/` to see the single post with all content elements styled correctly.