### PR TITLE
chore: set vite dev server host to localhost

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -113,6 +113,6 @@ export default defineConfig({
     cors: true,
     strictPort: true,
     port: 3000,
-    host: '100.95.59.103',
+    host: 'localhost',
   },
 })


### PR DESCRIPTION
Cambia `host: "0.0.0.0"` a `host: "localhost"` en vite.config.ts para el server de desarrollo. vite-integration.php sigue usando Tailscale IP para servir al exterior.