### PR TITLE
feat(wizard): add landing builder foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ wp-content/backup-db/
 .atl/
 .claude/
 .windsurf/
+
+# Local untracked docs (do not commit)
+Wizard ai harness prompt guide.md
+wizard-prd.html

--- a/inc/wizard/class-ai-content-harness.php
+++ b/inc/wizard/class-ai-content-harness.php
@@ -325,7 +325,39 @@ PROMPT;
 		return strtr( $template, self::get_editorial_rule_replacements() );
 	}
 
+	/**
+	 * Layouts that may receive landing keyword context.
+	 *
+	 * @var string[]
+	 */
+	private const KEYWORD_LAYOUTS = [
+		'hero',
+		'seo-content',
+	];
+
 	public function get_layer2( string $page_type = self::PAGE_HOME ): string {
+		if ( self::PAGE_LANDING === $page_type ) {
+			return <<<'PROMPT'
+PAGE CONTEXT: Landing Page
+
+You are writing content for a dedicated landing page with a single conversion goal. Visitors arrive with a specific intent (organic search or paid campaign) and should be guided toward one clear action.
+
+Editorial purpose:
+- Focus the page on one primary offer, service, or search intent without inventing proof.
+- Keep the conversion path clear: promise, proof/trust, process or value, and call to action.
+- Align section roles with a typical landing order: hero, SEO content, trust/value sections (vision/mission, badges, portfolio), social proof, and closing SEO content.
+- Give each section a distinct job so the page does not repeat the same headline pattern or praise language.
+
+Ads vs SEO intent:
+- SEO landings support organic discovery, trust, and long-form helpful copy around a search intent.
+- Ads landings support paid traffic with a tighter offer focus and stronger conversion urgency, still without inventing guarantees or proof.
+
+Tone: Specific, confident, local, and human. Never generic brochure copy, corporate jargon, exaggerated claims, or keyword stuffing.
+
+Write for visitors who already have intent. Content should feel purposeful and conversion-ready, not like a broad Home page overview.
+PROMPT;
+		}
+
 		if ( self::PAGE_HOME !== $page_type ) {
 			$this->log_warning( sprintf( 'Unsupported AI content harness page type "%s"; falling back to PAGE_HOME.', $page_type ) );
 		}
@@ -347,7 +379,64 @@ Write for a general audience discovering this business. Content should feel like
 PROMPT;
 	}
 
-	public function get_layer3( string $layout, int $item_count, array $client_context ): string {
+	/**
+	 * Whether a layout may consume landing keyword placeholders.
+	 */
+	public function is_keyword_layout( string $layout ): bool {
+		return in_array( $this->normalize_layout_key( $layout ), self::KEYWORD_LAYOUTS, true );
+	}
+
+	/**
+	 * Whether a layout is reusable/canonical-eligible (not keyword-driven).
+	 */
+	public function is_reusable_layout( string $layout ): bool {
+		$layout = $this->normalize_layout_key( $layout );
+
+		return '' !== $layout && ! $this->is_keyword_layout( $layout );
+	}
+
+	/**
+	 * Normalize landing keyword context: drop empties and clamp subkeywords to 0–10.
+	 *
+	 * @param array<string,mixed> $keywords Raw keyword payload.
+	 *
+	 * @return array{primary_keyword:string,subkeywords:string[]}
+	 */
+	public function normalize_keywords( array $keywords ): array {
+		$primary = trim( \sanitize_text_field( (string) ( $keywords['primary_keyword'] ?? $keywords['keyword'] ?? '' ) ) );
+		$raw     = $keywords['subkeywords'] ?? $keywords['sub_keywords'] ?? [];
+
+		if ( is_string( $raw ) ) {
+			$raw = preg_split( '/[\n,]+/', $raw ) ?: [];
+		}
+
+		$subkeywords = [];
+
+		foreach ( is_array( $raw ) ? $raw : [] as $item ) {
+			$item = trim( \sanitize_text_field( (string) $item ) );
+
+			if ( '' === $item ) {
+				continue;
+			}
+
+			$subkeywords[] = $item;
+
+			if ( count( $subkeywords ) >= 10 ) {
+				break;
+			}
+		}
+
+		return [
+			'primary_keyword' => $primary,
+			'subkeywords'     => $subkeywords,
+		];
+	}
+
+	/**
+	 * @param array<string,mixed> $client_context Approved client context.
+	 * @param array<string,mixed> $keywords       Optional landing keywords (PAGE_LANDING only).
+	 */
+	public function get_layer3( string $layout, int $item_count, array $client_context, string $page_type = self::PAGE_HOME, array $keywords = [] ): string {
 		$layout        = $this->normalize_layout_key( $layout );
 		$fillable      = $this->get_fillable_fields( $layout );
 		$blocked       = $this->get_blocked_fields( $layout );
@@ -355,19 +444,36 @@ PROMPT;
 		$client_json   = false === $client_json ? '{}' : $client_json;
 		$service_rules = isset( self::SERVICE_DESCRIPTION_FIELDS[ $layout ] ) ? sprintf( ' For service repeaters, preserve the order of client_json.company_services. Service names/titles and service-specific benefits must come only from company_services[].service_name and service_short_description; return descriptions only in %s.', (string) self::SERVICE_DESCRIPTION_FIELDS[ $layout ]['description'] ) : '';
 		$layout_rules  = $this->layout_rules( $layout, $item_count );
+		$normalized    = $this->normalize_keywords( $keywords );
+		$inject_kw     = self::PAGE_LANDING === $page_type && $this->is_keyword_layout( $layout );
+		$primary       = $inject_kw ? $normalized['primary_keyword'] : '';
+		$subkeywords   = $inject_kw ? implode( ', ', $normalized['subkeywords'] ) : '';
+		$keyword_block = '';
 
-		$template = "Layout: {{layout}}\nRequested item count: {{item_count}}\nAllowed JSON keys: {{fillable_fields}}\nBlocked JSON keys: {{blocked_fields}}\nClient JSON: {{client_json}}\nReturn one compact JSON object using only allowed keys. Do not include blocked or unknown keys.{{service_rules}}\n\n{{layout_rules}}";
+		if ( $inject_kw ) {
+			$keyword_block = "\n\nKEYWORD CONTEXT (mandatory for this section only):\n"
+				. '- Primary keyword: {{primary_keyword}}' . "\n"
+				. '- Subkeywords: {{subkeywords}}' . "\n"
+				. "- Naturally incorporate the primary keyword in headlines and body copy where it fits.\n"
+				. "- Use subkeywords sparingly and only when natural. Do not keyword-stuff.\n"
+				. "- Do not invent services, locations, or proof to force keyword usage.";
+		}
+
+		$template = "Layout: {{layout}}\nRequested item count: {{item_count}}\nAllowed JSON keys: {{fillable_fields}}\nBlocked JSON keys: {{blocked_fields}}\nClient JSON: {{client_json}}\nReturn one compact JSON object using only allowed keys. Do not include blocked or unknown keys.{{service_rules}}\n\n{{layout_rules}}{{keyword_block}}";
 
 		return strtr(
 			$template,
 			[
-				'{{layout}}'          => $layout,
-				'{{item_count}}'      => (string) max( 0, $item_count ),
-				'{{fillable_fields}}' => implode( ', ', $fillable ),
-				'{{blocked_fields}}'  => implode( ', ', $blocked ),
-				'{{client_json}}'     => $client_json,
-				'{{service_rules}}'   => $service_rules,
-				'{{layout_rules}}'    => $layout_rules,
+				'{{layout}}'           => $layout,
+				'{{item_count}}'       => (string) max( 0, $item_count ),
+				'{{fillable_fields}}'  => implode( ', ', $fillable ),
+				'{{blocked_fields}}'   => implode( ', ', $blocked ),
+				'{{client_json}}'      => $client_json,
+				'{{service_rules}}'    => $service_rules,
+				'{{layout_rules}}'     => $layout_rules,
+				'{{keyword_block}}'    => $keyword_block,
+				'{{primary_keyword}}'  => '' !== $primary ? $primary : '(none provided)',
+				'{{subkeywords}}'      => '' !== $subkeywords ? $subkeywords : '(none)',
 			]
 		);
 	}

--- a/inc/wizard/class-canonical-section-store.php
+++ b/inc/wizard/class-canonical-section-store.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * Canonical reusable section store.
+ *
+ * @package Simple_RMS_Theme
+ */
+
+namespace Inc\Wizard;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * First-write store for neutral reusable section payloads.
+ *
+ * Backed by a dedicated option so full payloads stay out of wizard state.
+ */
+class Canonical_Section_Store {
+	public const OPTION_KEY = 'rms_wizard_canonical_sections';
+
+	/**
+	 * Layouts that must never be stored as canonical content.
+	 *
+	 * @var string[]
+	 */
+	private const EXCLUDED_LAYOUTS = [
+		'hero',
+		'seo-content',
+	];
+
+	/**
+	 * Lazy-loaded option payload.
+	 *
+	 * @var array<string,array<string,mixed>>|null
+	 */
+	private $sections = null;
+
+	/**
+	 * Whether the in-memory cache has been loaded from the option.
+	 *
+	 * @var bool
+	 */
+	private $loaded = false;
+
+	/**
+	 * Return whether a layout has a non-empty canonical payload.
+	 */
+	public function has( string $layout ): bool {
+		$layout = $this->normalize_layout( $layout );
+
+		if ( '' === $layout || $this->is_excluded_layout( $layout ) ) {
+			return false;
+		}
+
+		$entry = $this->get_entry( $layout );
+
+		return is_array( $entry['payload'] ?? null ) && [] !== $entry['payload'];
+	}
+
+	/**
+	 * Return the canonical payload for a layout, or an empty array.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function get( string $layout ): array {
+		$layout = $this->normalize_layout( $layout );
+
+		if ( '' === $layout || $this->is_excluded_layout( $layout ) ) {
+			return [];
+		}
+
+		$entry   = $this->get_entry( $layout );
+		$payload = $entry['payload'] ?? null;
+
+		return is_array( $payload ) ? $payload : [];
+	}
+
+	/**
+	 * Write a layout payload only when the store is empty for that layout.
+	 *
+	 * @param string               $layout Layout key.
+	 * @param array<string,mixed>  $row    Prepared ACF flexible-content row.
+	 *
+	 * @return bool True when a first-write occurred.
+	 */
+	public function set_if_empty( string $layout, array $row ): bool {
+		$layout = $this->normalize_layout( $layout );
+
+		if ( '' === $layout || $this->is_excluded_layout( $layout ) || [] === $row ) {
+			return false;
+		}
+
+		if ( $this->has( $layout ) ) {
+			return false;
+		}
+
+		return $this->write_entry( $layout, $row );
+	}
+
+	/**
+	 * Explicitly replace an existing (or empty) canonical payload.
+	 *
+	 * Callers must gate this behind user confirmation.
+	 *
+	 * @param string               $layout Layout key.
+	 * @param array<string,mixed>  $row    Prepared ACF flexible-content row.
+	 *
+	 * @return bool True when the entry was written.
+	 */
+	public function replace( string $layout, array $row ): bool {
+		$layout = $this->normalize_layout( $layout );
+
+		if ( '' === $layout || $this->is_excluded_layout( $layout ) || [] === $row ) {
+			return false;
+		}
+
+		return $this->write_entry( $layout, $row );
+	}
+
+	/**
+	 * Return a compact summary for wizard state (no full payloads).
+	 *
+	 * @return array<string,array{has_payload:bool,generated_at:string}>
+	 */
+	public function summary(): array {
+		$sections = $this->all();
+		$summary  = [];
+
+		foreach ( $sections as $layout => $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$payload = is_array( $entry['payload'] ?? null ) ? $entry['payload'] : [];
+
+			if ( [] === $payload ) {
+				continue;
+			}
+
+			$summary[ $layout ] = [
+				'has_payload'  => true,
+				'generated_at' => (string) ( $entry['generated_at'] ?? '' ),
+			];
+		}
+
+		return $summary;
+	}
+
+	/**
+	 * Return the full store map (lazy-loaded).
+	 *
+	 * @return array<string,array<string,mixed>>
+	 */
+	public function all(): array {
+		$this->ensure_loaded();
+
+		return is_array( $this->sections ) ? $this->sections : [];
+	}
+
+	/**
+	 * Drop the in-memory cache so the next read hits the option again.
+	 */
+	public function reset_cache(): void {
+		$this->sections = null;
+		$this->loaded   = false;
+	}
+
+	/**
+	 * Lazy-load the option once per request/instance.
+	 */
+	private function ensure_loaded(): void {
+		if ( $this->loaded ) {
+			return;
+		}
+
+		$stored = \get_option( self::OPTION_KEY, [] );
+
+		if ( ! is_array( $stored ) ) {
+			$stored = [];
+		}
+
+		$normalized = [];
+
+		foreach ( $stored as $layout => $entry ) {
+			$layout = $this->normalize_layout( (string) $layout );
+
+			if ( '' === $layout || $this->is_excluded_layout( $layout ) || ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$payload = is_array( $entry['payload'] ?? null ) ? $entry['payload'] : [];
+
+			if ( [] === $payload ) {
+				continue;
+			}
+
+			$normalized[ $layout ] = [
+				'payload'      => $payload,
+				'generated_at' => (string) ( $entry['generated_at'] ?? '' ),
+			];
+		}
+
+		$this->sections = $normalized;
+		$this->loaded   = true;
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private function get_entry( string $layout ): array {
+		$sections = $this->all();
+		$entry    = $sections[ $layout ] ?? [];
+
+		return is_array( $entry ) ? $entry : [];
+	}
+
+	/**
+	 * Persist one layout entry and refresh the local cache only after success.
+	 *
+	 * Success requires the full stored entry (payload + generated_at) to match
+	 * what we intended to write. Post-state reads are authoritative because
+	 * update_option() can return false for identical values.
+	 *
+	 * @param string              $layout Layout key.
+	 * @param array<string,mixed> $row    Prepared row payload.
+	 */
+	private function write_entry( string $layout, array $row ): bool {
+		$this->ensure_loaded();
+
+		$entry = [
+			'payload'      => $row,
+			'generated_at' => \current_time( 'mysql', true ),
+		];
+
+		$sections            = is_array( $this->sections ) ? $this->sections : [];
+		$sections[ $layout ] = $entry;
+
+		// Never mutate the in-memory cache before a real persistence outcome.
+		$saved = \update_option( self::OPTION_KEY, $sections, false );
+
+		if ( $saved ) {
+			$this->sections = $sections;
+			$this->loaded   = true;
+
+			return true;
+		}
+
+		// update_option() returns false when the DB value is already identical.
+		// Reload and require the full normalized entry to match (not payload alone).
+		$this->reset_cache();
+		$persisted = $this->get_entry( $layout );
+
+		return is_array( $persisted )
+			&& ( $persisted['payload'] ?? null ) === $entry['payload']
+			&& (string) ( $persisted['generated_at'] ?? '' ) === (string) $entry['generated_at'];
+	}
+
+	private function normalize_layout( string $layout ): string {
+		return \sanitize_key( $layout );
+	}
+
+	private function is_excluded_layout( string $layout ): bool {
+		return in_array( $layout, self::EXCLUDED_LAYOUTS, true );
+	}
+}

--- a/inc/wizard/class-content-builder.php
+++ b/inc/wizard/class-content-builder.php
@@ -50,6 +50,16 @@ class Content_Builder {
 	}
 
 	/**
+	 * Post meta keys allowed through build_page() meta_input.
+	 *
+	 * @var string[]
+	 */
+	private const META_INPUT_WHITELIST = [
+		'_wp_page_template',
+		'rms_landing_type',
+	];
+
+	/**
 	 * Build one page from a definition array.
 	 *
 	 * @param array<string,mixed> $page Page definition.
@@ -79,6 +89,12 @@ class Content_Builder {
 			'post_name'    => $slug,
 			'post_content' => $content,
 		];
+
+		$meta_input = $this->whitelisted_meta_input( is_array( $page['meta_input'] ?? null ) ? $page['meta_input'] : [] );
+
+		if ( [] !== $meta_input ) {
+			$post_data['meta_input'] = $meta_input;
+		}
 
 		if ( $post_id > 0 ) {
 			$post_data['ID'] = $post_id;
@@ -111,6 +127,45 @@ class Content_Builder {
 	 */
 	public function fallback_image_url(): string {
 		return \trailingslashit( \get_template_directory_uri() ) . 'assets/images/wizard-placeholder.svg';
+	}
+
+	/**
+	 * Sanitize and whitelist meta_input for insert/update.
+	 *
+	 * Only `_wp_page_template` and `rms_landing_type` are accepted.
+	 *
+	 * @param array<string,mixed> $meta Raw meta_input map.
+	 *
+	 * @return array<string,string>
+	 */
+	private function whitelisted_meta_input( array $meta ): array {
+		$clean = [];
+
+		foreach ( self::META_INPUT_WHITELIST as $key ) {
+			if ( ! array_key_exists( $key, $meta ) ) {
+				continue;
+			}
+
+			if ( '_wp_page_template' === $key ) {
+				$value = \sanitize_text_field( (string) $meta[ $key ] );
+
+				if ( '' !== $value ) {
+					$clean[ $key ] = $value;
+				}
+
+				continue;
+			}
+
+			if ( 'rms_landing_type' === $key ) {
+				$value = \sanitize_key( (string) $meta[ $key ] );
+
+				if ( in_array( $value, [ 'seo', 'ads' ], true ) ) {
+					$clean[ $key ] = $value;
+				}
+			}
+		}
+
+		return $clean;
 	}
 
 	private function save_page_sections( int $post_id, array $sections ): void {

--- a/inc/wizard/class-menu-builder.php
+++ b/inc/wizard/class-menu-builder.php
@@ -154,6 +154,391 @@ class Menu_Builder {
 		return $deleted;
 	}
 
+	/**
+	 * Append page links to a menu without duplicating existing page items.
+	 *
+	 * Best-effort for SEO eligibility paths: failures are reported in the
+	 * structured result (and logged) so callers can warn without fail-closing.
+	 * Ads/ineligible removal remains fail-closed via `remove_page_items()`.
+	 *
+	 * @param int        $menu_id  Menu term ID.
+	 * @param array<int> $page_ids Page post IDs to ensure are present.
+	 *
+	 * @return array{
+	 *   created: array<int,int>,
+	 *   already_present: array<int,int>,
+	 *   failed_page_ids: array<int,int>,
+	 *   verified: bool
+	 * }
+	 */
+	public function append_page_items( int $menu_id, array $page_ids ): array {
+		$menu_id = \absint( $menu_id );
+		$empty   = [
+			'created'          => [],
+			'already_present'  => [],
+			'failed_page_ids'  => [],
+			'verified'         => true,
+		];
+
+		if ( $menu_id <= 0 ) {
+			return $empty;
+		}
+
+		$existing_page_ids = $this->menu_page_ids( $menu_id );
+		$created           = [];
+		$already_present   = [];
+		$create_failed     = [];
+		$requested         = [];
+		$position          = count( $existing_page_ids ) + 1;
+
+		foreach ( $page_ids as $page_id ) {
+			$page_id = \absint( $page_id );
+
+			if ( $page_id <= 0 || 'page' !== \get_post_type( $page_id ) ) {
+				continue;
+			}
+
+			$requested[] = $page_id;
+
+			if ( in_array( $page_id, $existing_page_ids, true ) ) {
+				$already_present[] = $page_id;
+				continue;
+			}
+
+			$item_id = \wp_update_nav_menu_item(
+				$menu_id,
+				0,
+				[
+					'menu-item-object-id' => $page_id,
+					'menu-item-object'    => 'page',
+					'menu-item-type'      => 'post_type',
+					'menu-item-status'    => 'publish',
+					'menu-item-position'  => $position,
+				]
+			);
+
+			if ( \is_wp_error( $item_id ) ) {
+				$create_failed[] = $page_id;
+				$this->logger->log(
+					'error',
+					'Wizard menu item append failed.',
+					[
+						'menu_id'       => $menu_id,
+						'page_id'       => $page_id,
+						'error_code'    => $item_id->get_error_code(),
+						'error_message' => $item_id->get_error_message(),
+					]
+				);
+				continue;
+			}
+
+			$created[]           = (int) $item_id;
+			$existing_page_ids[] = $page_id;
+			$position++;
+		}
+
+		// Bust object cache so read-back reflects freshly written items.
+		if ( function_exists( 'clean_term_cache' ) ) {
+			\clean_term_cache( $menu_id, 'nav_menu' );
+		}
+
+		$present_after = $this->menu_page_ids( $menu_id );
+		$failed        = [];
+
+		foreach ( array_values( array_unique( $requested ) ) as $page_id ) {
+			if ( ! in_array( $page_id, $present_after, true ) ) {
+				$failed[] = $page_id;
+			}
+		}
+
+		// Prefer create-time failures when read-back also missed them.
+		$failed = array_values( array_unique( array_merge( $create_failed, $failed ) ) );
+		$ok     = [] === $failed;
+
+		if ( [] !== $created ) {
+			$this->logger->log(
+				'info',
+				'Wizard menu items appended.',
+				[
+					'menu_id'    => $menu_id,
+					'item_count' => count( $created ),
+					'created'    => $created,
+				]
+			);
+		}
+
+		if ( ! $ok ) {
+			$this->logger->log(
+				'warning',
+				'Wizard menu item append incomplete after verification.',
+				[
+					'menu_id'          => $menu_id,
+					'failed_page_ids'  => $failed,
+					'already_present'  => array_values( array_unique( $already_present ) ),
+					'created'          => $created,
+					'requested'        => array_values( array_unique( $requested ) ),
+				]
+			);
+		}
+
+		return [
+			'created'         => $created,
+			'already_present' => array_values( array_unique( $already_present ) ),
+			'failed_page_ids' => $failed,
+			'verified'        => $ok,
+		];
+	}
+
+	/**
+	 * Remove nav items that point at the given page IDs.
+	 *
+	 * Verifies via read-back that target page IDs are no longer present.
+	 *
+	 * @param int        $menu_id  Menu term ID.
+	 * @param array<int> $page_ids Page post IDs to remove from the menu.
+	 *
+	 * @return array{deleted:array<int,int>,failed_page_ids:array<int,int>,verified:bool}
+	 */
+	public function remove_page_items( int $menu_id, array $page_ids ): array {
+		$menu_id  = \absint( $menu_id );
+		$page_ids = array_values(
+			array_unique(
+				array_filter(
+					array_map( 'absint', $page_ids )
+				)
+			)
+		);
+
+		$empty = [
+			'deleted'          => [],
+			'failed_page_ids'  => [],
+			'verified'         => true,
+		];
+
+		if ( $menu_id <= 0 || [] === $page_ids ) {
+			return $empty;
+		}
+
+		$items = \wp_get_nav_menu_items( $menu_id );
+
+		if ( empty( $items ) || ! is_array( $items ) ) {
+			// Nothing to remove — already verified absent.
+			return $empty;
+		}
+
+		$deleted = [];
+
+		foreach ( $items as $item ) {
+			$object_id = (int) ( $item->object_id ?? 0 );
+			$type      = (string) ( $item->type ?? '' );
+			$object    = (string) ( $item->object ?? '' );
+
+			if ( 'post_type' !== $type || 'page' !== $object ) {
+				continue;
+			}
+
+			if ( ! in_array( $object_id, $page_ids, true ) ) {
+				continue;
+			}
+
+			$item_id = (int) ( $item->ID ?? 0 );
+
+			if ( $item_id <= 0 ) {
+				continue;
+			}
+
+			$result = \wp_delete_post( $item_id, true );
+
+			if ( $result ) {
+				$deleted[] = $item_id;
+			} else {
+				$this->logger->log(
+					'error',
+					'Wizard menu item delete failed.',
+					[
+						'menu_id'  => $menu_id,
+						'item_id'  => $item_id,
+						'page_id'  => $object_id,
+					]
+				);
+			}
+		}
+
+		// Bust nav menu item cache so read-back is not stale.
+		\wp_cache_delete( $menu_id, 'nav_menu_items' );
+		if ( function_exists( 'clean_term_cache' ) ) {
+			\clean_term_cache( $menu_id, 'nav_menu' );
+		}
+
+		$still_present = array_values(
+			array_intersect( $this->menu_page_ids( $menu_id ), $page_ids )
+		);
+		$verified      = [] === $still_present;
+
+		if ( [] !== $deleted ) {
+			$this->logger->log(
+				'info',
+				'Wizard menu items removed for pages.',
+				[
+					'menu_id'    => $menu_id,
+					'page_ids'   => $page_ids,
+					'item_count' => count( $deleted ),
+					'verified'   => $verified,
+				]
+			);
+		}
+
+		if ( ! $verified ) {
+			$this->logger->log(
+				'error',
+				'Wizard menu page removal failed read-back verification.',
+				[
+					'menu_id'         => $menu_id,
+					'page_ids'        => $page_ids,
+					'failed_page_ids' => $still_present,
+					'deleted_items'   => $deleted,
+				]
+			);
+		}
+
+		return [
+			'deleted'         => $deleted,
+			'failed_page_ids' => $still_present,
+			'verified'        => $verified,
+		];
+	}
+
+	/**
+	 * Final-state landing menu reconciliation across configured menus.
+	 *
+	 * Eligible SEO landings are present idempotently; Ads / ineligible landings are removed.
+	 * Removal is verified via read-back; failures are reported in the return payload.
+	 * SEO append is best-effort: `append_failed_page_ids` is reported but does not
+	 * flip `verified` (Ads removal remains fail-closed).
+	 *
+	 * @param array<int>                        $menu_ids       Menu term IDs to reconcile.
+	 * @param array<int,array<string,mixed>>    $landing_pages  Landing state rows.
+	 *
+	 * @return array{
+	 *   appended:array<int,int>,
+	 *   removed:array<int,int>,
+	 *   removal_failed_page_ids:array<int,int>,
+	 *   append_failed_page_ids:array<int,int>,
+	 *   verified:bool
+	 * }
+	 */
+	public function reconcile_landing_menu_items( array $menu_ids, array $landing_pages ): array {
+		$eligible_ids   = [];
+		$ineligible_ids = [];
+
+		foreach ( $landing_pages as $landing ) {
+			if ( ! is_array( $landing ) ) {
+				continue;
+			}
+
+			$page_id = \absint( $landing['id'] ?? 0 );
+
+			if ( $page_id <= 0 || 'page' !== \get_post_type( $page_id ) ) {
+				continue;
+			}
+
+			$type          = \sanitize_key( (string) ( $landing['landing_type'] ?? '' ) );
+			$menu_eligible = array_key_exists( 'menu_eligible', $landing )
+				? (bool) $landing['menu_eligible']
+				: ( 'seo' === $type );
+
+			if ( 'seo' === $type && $menu_eligible ) {
+				$eligible_ids[] = $page_id;
+			} else {
+				$ineligible_ids[] = $page_id;
+			}
+		}
+
+		$eligible_ids   = array_values( array_unique( $eligible_ids ) );
+		$ineligible_ids = array_values( array_unique( $ineligible_ids ) );
+		$appended       = [];
+		$removed        = [];
+		$failed_pages   = [];
+		$append_failed  = [];
+
+		foreach ( $menu_ids as $menu_id ) {
+			$menu_id = \absint( $menu_id );
+
+			if ( $menu_id <= 0 ) {
+				continue;
+			}
+
+			if ( [] !== $ineligible_ids ) {
+				$removal      = $this->remove_page_items( $menu_id, $ineligible_ids );
+				$removed      = array_merge( $removed, is_array( $removal['deleted'] ?? null ) ? $removal['deleted'] : [] );
+				$failed       = is_array( $removal['failed_page_ids'] ?? null ) ? $removal['failed_page_ids'] : [];
+				$failed_pages = array_merge( $failed_pages, $failed );
+			}
+
+			if ( [] !== $eligible_ids ) {
+				$append_result = $this->append_page_items( $menu_id, $eligible_ids );
+				$created       = is_array( $append_result['created'] ?? null ) ? $append_result['created'] : [];
+				$failed_append = is_array( $append_result['failed_page_ids'] ?? null ) ? $append_result['failed_page_ids'] : [];
+				$appended      = array_merge( $appended, $created );
+				$append_failed = array_merge( $append_failed, $failed_append );
+			}
+		}
+
+		$failed_pages  = array_values( array_unique( array_map( 'absint', $failed_pages ) ) );
+		$append_failed = array_values( array_unique( array_map( 'absint', $append_failed ) ) );
+		// verified tracks Ads/ineligible removal only (fail-closed). SEO append is best-effort.
+		$verified = [] === $failed_pages;
+
+		if ( [] !== $append_failed ) {
+			$this->logger->log(
+				'warning',
+				'Landing menu reconciliation SEO append incomplete (best-effort; Ads removal still authoritative).',
+				[
+					'menu_ids'               => array_values( array_map( 'absint', $menu_ids ) ),
+					'append_failed_page_ids' => $append_failed,
+					'removal_failed_page_ids'=> $failed_pages,
+				]
+			);
+		}
+
+		return [
+			'appended'                 => $appended,
+			'removed'                  => $removed,
+			'removal_failed_page_ids'  => $failed_pages,
+			'append_failed_page_ids'   => $append_failed,
+			'verified'                 => $verified,
+		];
+	}
+
+	/**
+	 * Page object IDs currently linked in a menu.
+	 *
+	 * @return array<int,int>
+	 */
+	private function menu_page_ids( int $menu_id ): array {
+		$items = \wp_get_nav_menu_items( $menu_id );
+
+		if ( empty( $items ) || ! is_array( $items ) ) {
+			return [];
+		}
+
+		$page_ids = [];
+
+		foreach ( $items as $item ) {
+			if ( 'post_type' !== (string) ( $item->type ?? '' ) || 'page' !== (string) ( $item->object ?? '' ) ) {
+				continue;
+			}
+
+			$page_id = (int) ( $item->object_id ?? 0 );
+
+			if ( $page_id > 0 ) {
+				$page_ids[] = $page_id;
+			}
+		}
+
+		return array_values( array_unique( $page_ids ) );
+	}
+
 	private function delete_menu_items( int $menu_id ): void {
 		$items = \wp_get_nav_menu_items( $menu_id );
 

--- a/inc/wizard/class-state-manager.php
+++ b/inc/wizard/class-state-manager.php
@@ -36,6 +36,8 @@ class State_Manager {
             'menu_config'            => [],
             'selected_home_sections' => [],
             'home_sections'          => [],
+            'landing_pages'          => [],
+            'canonical_sections'     => [],
             'logs'                   => self::LOG_OPTION,
             'locks'                  => [],
             'updated_at'             => '',
@@ -114,6 +116,10 @@ class State_Manager {
     /**
      * Determine whether the wizard is complete and locked.
      *
+     * Effective unlock overrides make the wizard editable without clearing
+     * the durable `rms_wizard_completed` option. Stale unlock markers are
+     * ignored while controlled unlock is disabled.
+     *
      * @return bool
      */
     public function is_completed(): bool {
@@ -121,6 +127,22 @@ class State_Manager {
             return false;
         }
 
+        if ( ! (bool) \get_option( self::COMPLETED_OPTION, false ) ) {
+            return false;
+        }
+
+        // Only an effective unlock (controlled unlock enabled + marker) bypasses lock.
+        if ( class_exists( __NAMESPACE__ . '\\Wizard_Unlock_Controller' ) && Wizard_Unlock_Controller::is_unlocked() ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Whether the durable completion flag is set (ignores unlock override).
+     */
+    public function has_completion_flag(): bool {
         return (bool) \get_option( self::COMPLETED_OPTION, false );
     }
 

--- a/inc/wizard/class-step-controller.php
+++ b/inc/wizard/class-step-controller.php
@@ -30,11 +30,8 @@ class Step_Controller {
 	 * Single source of truth for currently required wizard steps.
 	 * Consumed by complete() and step services (e.g. maybe_mark_completed).
 	 *
-	 * PR2 keeps the existing 7-step completion surface. `landing-page-builder`
-	 * backend class exists, but required/dispatch/UI activation is deferred to
-	 * Phase 3 (menu/SEO/noindex + admin UI) so Ads landings cannot go live
-	 * without final-state controls and the UI cannot show 7/7 while an 8th
-	 * invisible step is required.
+	 * Phase 3 activates `landing-page-builder` atomically with admin UI +
+	 * Ads noindex/menu final-state sync (tasks 3.1–3.7).
 	 *
 	 * @var string[]
 	 */
@@ -46,15 +43,12 @@ class Step_Controller {
 		'menu-setup',
 		'ia-generation',
 		'home-page-builder',
+		'landing-page-builder',
 	];
 
 	/**
 	 * Steps that may be dispatched by execute_step() right now.
 	 * Must stay in sync with dispatch_step() cases.
-	 *
-	 * PR2: `landing-page-builder` is intentionally NOT dispatchable until
-	 * Phase 3 wires UI + noindex/menu final-state sync. The dispatch case and
-	 * `Step_Landing_Page_Builder` class remain for that activation.
 	 *
 	 * @var string[]
 	 */
@@ -66,6 +60,7 @@ class Step_Controller {
 		'menu-setup',
 		'ia-generation',
 		'home-page-builder',
+		'landing-page-builder',
 		'unlock',
 		'relock',
 	];
@@ -260,8 +255,6 @@ class Step_Controller {
 			case 'home-page-builder':
 				return ( new Step_Home_Page_Builder( $this->logger, $this->state_manager ) )->run( $payload );
 
-			// Kept for Phase 3 activation. Not reachable until REQUIRED_STEPS +
-			// DISPATCHABLE_STEPS + UI re-include `landing-page-builder` together.
 			case 'landing-page-builder':
 				return ( new Step_Landing_Page_Builder( $this->logger, $this->state_manager ) )->run( $payload );
 
@@ -367,10 +360,6 @@ class Step_Controller {
 			'generate_pages'    => 'generate-pages',
 			'menu_setup'        => 'menu-setup',
 			'home_page_builder' => 'home-page-builder',
-			// Phase 3 activation: re-enable `landing_page_builder` alias together
-			// with DISPATCHABLE_STEPS, REQUIRED_STEPS, dispatch case, and admin UI.
-			// Alias alone is safe (unknown-step reject runs before status writes)
-			// but must not be treated as "live" until that full activation set lands.
 			'landing_page_builder' => 'landing-page-builder',
 		];
 

--- a/inc/wizard/class-step-controller.php
+++ b/inc/wizard/class-step-controller.php
@@ -14,6 +14,28 @@ defined( 'ABSPATH' ) || exit;
  */
 class Step_Controller {
 	private const LOCK_NAME = 'step_execution';
+
+	/**
+	 * Pseudo-steps allowed while the wizard is completed/locked.
+	 * These must never write current_step or step_status.
+	 *
+	 * @var string[]
+	 */
+	private const COMPLETED_GATE_ALLOWLIST = [
+		'unlock',
+		'relock',
+	];
+
+	/**
+	 * Single source of truth for currently required wizard steps.
+	 * Consumed by complete() and step services (e.g. maybe_mark_completed).
+	 *
+	 * Phase 1 keeps the existing 7-step completion path valid. Append
+	 * `landing-page-builder` only when that step is registered/dispatched
+	 * (Phase 2+), never while the runtime/UI is absent.
+	 *
+	 * @var string[]
+	 */
 	private const REQUIRED_STEPS = [
 		'dependencies',
 		'acf-import',
@@ -24,12 +46,43 @@ class Step_Controller {
 		'home-page-builder',
 	];
 
+	/**
+	 * Steps that may be dispatched by execute_step() right now.
+	 * Must stay in sync with dispatch_step() cases.
+	 *
+	 * Phase 1 intentionally omits `landing-page-builder` until Phase 2
+	 * registers its runtime. Unknown/unimplemented steps must be rejected
+	 * before any current_step / step_status writes.
+	 *
+	 * @var string[]
+	 */
+	private const DISPATCHABLE_STEPS = [
+		'dependencies',
+		'acf-import',
+		'client-data',
+		'generate-pages',
+		'menu-setup',
+		'ia-generation',
+		'home-page-builder',
+		'unlock',
+		'relock',
+	];
+
 	private $state_manager;
 	private $logger;
 
 	public function __construct( ?State_Manager $state_manager = null, ?Logger $logger = null ) {
 		$this->state_manager = $state_manager ?? new State_Manager();
 		$this->logger        = $logger ?? new Logger();
+	}
+
+	/**
+	 * Shared required-step list used for completion checks.
+	 *
+	 * @return string[]
+	 */
+	public static function get_required_steps(): array {
+		return self::REQUIRED_STEPS;
 	}
 
 	/**
@@ -45,9 +98,16 @@ class Step_Controller {
 	 * @return array<string,mixed>
 	 */
 	public function get_resume_state(): array {
-		$state           = $this->state_manager->get_state();
-		$state['locked'] = $this->state_manager->is_completed();
-		$state['logs']   = $this->logger->all();
+		$state                         = $this->state_manager->get_state();
+		$state['locked']               = $this->state_manager->is_completed();
+		$state['completed_flag']       = $this->state_manager->has_completion_flag();
+		$state['force_unlocked']       = Wizard_Unlock_Controller::is_force_unlocked();
+		$state['controlled_unlock_ui'] = Wizard_Unlock_Controller::is_controlled_unlock_enabled();
+		$state['unlocked']             = Wizard_Unlock_Controller::is_unlocked();
+		$state['has_unlock_marker']    = Wizard_Unlock_Controller::has_unlock_marker();
+		$state['unlocked_at']          = (string) \get_option( Wizard_Unlock_Controller::UNLOCKED_AT_OPTION, '' );
+		$state['unlocked_by']          = (int) \get_option( Wizard_Unlock_Controller::UNLOCKED_BY_OPTION, 0 );
+		$state['logs']                 = $this->logger->all();
 
 		return $state;
 	}
@@ -67,7 +127,15 @@ class Step_Controller {
 
 		$step = $this->normalize_step( $step );
 
-		if ( $this->state_manager->is_completed() && 'state' !== $step ) {
+		// Reject unknown/unimplemented steps before lock or status writes so
+		// premature aliases (e.g. landing-page-builder before Phase 2 runtime)
+		// cannot pollute current_step / step_status.
+		if ( ! $this->is_dispatchable_step( $step ) ) {
+			return new \WP_Error( 'rms_wizard_unknown_step', \__( 'Unknown setup wizard step.', 'simple-rms-theme' ), [ 'status' => 400 ] );
+		}
+
+		// unlock/relock are the only pseudo-steps allowed through the completed gate.
+		if ( $this->state_manager->is_completed() && ! $this->is_completed_gate_allowlisted( $step ) ) {
 			return new \WP_Error( 'rms_wizard_locked', \__( 'The setup wizard is already complete.', 'simple-rms-theme' ), [ 'status' => 423 ] );
 		}
 
@@ -75,9 +143,15 @@ class Step_Controller {
 			return new \WP_Error( 'rms_wizard_busy', \__( 'Another setup wizard action is already running.', 'simple-rms-theme' ), [ 'status' => 409 ] );
 		}
 
+		$progress_status_written = false;
+
 		try {
-			$this->state_manager->set_current_step( $step );
-			$this->state_manager->set_step_status( $step, 'running' );
+			// Pseudo-steps (unlock/relock) must not pollute current_step or step_status.
+			if ( ! $this->is_completed_gate_allowlisted( $step ) ) {
+				$this->state_manager->set_current_step( $step );
+				$this->state_manager->set_step_status( $step, 'running' );
+				$progress_status_written = true;
+			}
 
 			$result = $this->dispatch_step( $step, $payload );
 
@@ -91,6 +165,38 @@ class Step_Controller {
 				'result'  => $result,
 				'state'   => $this->get_resume_state(),
 			];
+		} catch ( \Throwable $throwable ) {
+			// Progress steps must not remain "running" after an unexpected failure.
+			// Unlock/relock never set progress status, so they skip this path.
+			if ( $progress_status_written ) {
+				$failed_saved = $this->state_manager->set_step_status( $step, 'failed' );
+
+				if ( ! $failed_saved ) {
+					$this->logger->log(
+						'error',
+						'Setup wizard could not mark step status as failed after unexpected error.',
+						[
+							'step'    => $step,
+							'message' => $throwable->getMessage(),
+						]
+					);
+				}
+			}
+
+			$this->logger->log(
+				'error',
+				'Setup wizard step threw an unexpected error.',
+				[
+					'step'    => $step,
+					'message' => $throwable->getMessage(),
+				]
+			);
+
+			return new \WP_Error(
+				'rms_wizard_step_exception',
+				\__( 'The setup wizard step failed unexpectedly.', 'simple-rms-theme' ),
+				[ 'status' => 500 ]
+			);
 		} finally {
 			$this->state_manager->release_lock( self::LOCK_NAME );
 		}
@@ -107,7 +213,7 @@ class Step_Controller {
 		}
 
 		$state    = $this->state_manager->get_state();
-		$required = self::REQUIRED_STEPS;
+		$required = self::get_required_steps();
 
 		foreach ( $required as $step ) {
 			if ( 'complete' !== ( $state['step_status'][ $step ] ?? '' ) ) {
@@ -152,8 +258,15 @@ class Step_Controller {
 			case 'home-page-builder':
 				return ( new Step_Home_Page_Builder( $this->logger, $this->state_manager ) )->run( $payload );
 
+			case 'unlock':
+				return ( new Wizard_Unlock_Controller( $this->state_manager, $this->logger ) )->unlock();
+
+			case 'relock':
+				return ( new Wizard_Unlock_Controller( $this->state_manager, $this->logger ) )->relock();
+
 			default:
-				$this->state_manager->set_step_status( $step, 'failed' );
+				// Defense in depth: execute_step() already rejects non-dispatchable
+				// steps before status writes. Never mark unknown steps failed here.
 				return new \WP_Error( 'rms_wizard_unknown_step', \__( 'Unknown setup wizard step.', 'simple-rms-theme' ), [ 'status' => 400 ] );
 		}
 	}
@@ -238,18 +351,35 @@ class Step_Controller {
 	private function normalize_step( string $step ): string {
 		$step = \sanitize_key( $step );
 
+		// Do not alias landing_page_builder → landing-page-builder until Phase 2
+		// registers dispatch + runtime. Premature normalization would make an
+		// unimplemented step look "real" before the dispatchability guard runs.
 		$aliases = [
-			'acf_import'       => 'acf-import',
-			'client_data'      => 'client-data',
-			'ai-generation'    => 'ia-generation',
-			'ai_generation'    => 'ia-generation',
-			'ia_generation'    => 'ia-generation',
+			'acf_import'        => 'acf-import',
+			'client_data'       => 'client-data',
+			'ai-generation'     => 'ia-generation',
+			'ai_generation'     => 'ia-generation',
+			'ia_generation'     => 'ia-generation',
 			'generate_pages'    => 'generate-pages',
 			'menu_setup'        => 'menu-setup',
 			'home_page_builder' => 'home-page-builder',
 		];
 
 		return $aliases[ $step ] ?? $step;
+	}
+
+	/**
+	 * Whether a step may bypass the completed/locked gate.
+	 */
+	private function is_completed_gate_allowlisted( string $step ): bool {
+		return in_array( $step, self::COMPLETED_GATE_ALLOWLIST, true );
+	}
+
+	/**
+	 * Whether a normalized step has a live dispatch path.
+	 */
+	private function is_dispatchable_step( string $step ): bool {
+		return in_array( $step, self::DISPATCHABLE_STEPS, true );
 	}
 
 	private function dependencies_are_active( array $status ): bool {

--- a/inc/wizard/class-step-controller.php
+++ b/inc/wizard/class-step-controller.php
@@ -30,9 +30,11 @@ class Step_Controller {
 	 * Single source of truth for currently required wizard steps.
 	 * Consumed by complete() and step services (e.g. maybe_mark_completed).
 	 *
-	 * Phase 1 keeps the existing 7-step completion path valid. Append
-	 * `landing-page-builder` only when that step is registered/dispatched
-	 * (Phase 2+), never while the runtime/UI is absent.
+	 * PR2 keeps the existing 7-step completion surface. `landing-page-builder`
+	 * backend class exists, but required/dispatch/UI activation is deferred to
+	 * Phase 3 (menu/SEO/noindex + admin UI) so Ads landings cannot go live
+	 * without final-state controls and the UI cannot show 7/7 while an 8th
+	 * invisible step is required.
 	 *
 	 * @var string[]
 	 */
@@ -50,9 +52,9 @@ class Step_Controller {
 	 * Steps that may be dispatched by execute_step() right now.
 	 * Must stay in sync with dispatch_step() cases.
 	 *
-	 * Phase 1 intentionally omits `landing-page-builder` until Phase 2
-	 * registers its runtime. Unknown/unimplemented steps must be rejected
-	 * before any current_step / step_status writes.
+	 * PR2: `landing-page-builder` is intentionally NOT dispatchable until
+	 * Phase 3 wires UI + noindex/menu final-state sync. The dispatch case and
+	 * `Step_Landing_Page_Builder` class remain for that activation.
 	 *
 	 * @var string[]
 	 */
@@ -258,6 +260,11 @@ class Step_Controller {
 			case 'home-page-builder':
 				return ( new Step_Home_Page_Builder( $this->logger, $this->state_manager ) )->run( $payload );
 
+			// Kept for Phase 3 activation. Not reachable until REQUIRED_STEPS +
+			// DISPATCHABLE_STEPS + UI re-include `landing-page-builder` together.
+			case 'landing-page-builder':
+				return ( new Step_Landing_Page_Builder( $this->logger, $this->state_manager ) )->run( $payload );
+
 			case 'unlock':
 				return ( new Wizard_Unlock_Controller( $this->state_manager, $this->logger ) )->unlock();
 
@@ -351,9 +358,6 @@ class Step_Controller {
 	private function normalize_step( string $step ): string {
 		$step = \sanitize_key( $step );
 
-		// Do not alias landing_page_builder → landing-page-builder until Phase 2
-		// registers dispatch + runtime. Premature normalization would make an
-		// unimplemented step look "real" before the dispatchability guard runs.
 		$aliases = [
 			'acf_import'        => 'acf-import',
 			'client_data'       => 'client-data',
@@ -363,6 +367,11 @@ class Step_Controller {
 			'generate_pages'    => 'generate-pages',
 			'menu_setup'        => 'menu-setup',
 			'home_page_builder' => 'home-page-builder',
+			// Phase 3 activation: re-enable `landing_page_builder` alias together
+			// with DISPATCHABLE_STEPS, REQUIRED_STEPS, dispatch case, and admin UI.
+			// Alias alone is safe (unknown-step reject runs before status writes)
+			// but must not be treated as "live" until that full activation set lands.
+			'landing_page_builder' => 'landing-page-builder',
 		];
 
 		return $aliases[ $step ] ?? $step;

--- a/inc/wizard/class-step-generate-pages.php
+++ b/inc/wizard/class-step-generate-pages.php
@@ -49,6 +49,15 @@ class Step_Generate_Pages {
 			return $roles;
 		}
 
+		// Fail closed: never select/update/assign residual SEO/Ads landings via generate-pages.
+		$landing_conflict = $this->reject_selected_landing_slugs( array_keys( $pages ) );
+
+		if ( \is_wp_error( $landing_conflict ) ) {
+			$this->state_manager->set_step_status( self::STEP, 'failed' );
+
+			return $landing_conflict;
+		}
+
 		if ( ! $this->confirmed_cleanup( $payload ) ) {
 			$this->state_manager->set_step_status( self::STEP, 'pending' );
 
@@ -65,7 +74,15 @@ class Step_Generate_Pages {
 
 		foreach ( $pages as $slug => $page ) {
 			$existing = \get_page_by_path( $slug, \OBJECT, 'page' );
-			$post_id  = $this->content_builder->build_page(
+
+			// Defense-in-depth: residual landings must never be updated/published here.
+			if ( $existing && $this->is_landing_page( (int) $existing->ID ) ) {
+				$this->state_manager->set_step_status( self::STEP, 'failed' );
+
+				return $this->landing_slug_conflict_error( $slug, (int) $existing->ID );
+			}
+
+			$post_id = $this->content_builder->build_page(
 				[
 					'id'      => $existing ? (int) $existing->ID : 0,
 					'title'   => $page['title'],
@@ -79,6 +96,12 @@ class Step_Generate_Pages {
 				$this->state_manager->set_step_status( self::STEP, 'failed' );
 
 				return new \WP_Error( 'rms_wizard_page_create_failed', \__( 'One or more selected pages could not be created.', 'simple-rms-theme' ), [ 'status' => 500 ] );
+			}
+
+			if ( $this->is_landing_page( $post_id ) ) {
+				$this->state_manager->set_step_status( self::STEP, 'failed' );
+
+				return $this->landing_slug_conflict_error( $slug, $post_id );
 			}
 
 			$role = '';
@@ -97,7 +120,13 @@ class Step_Generate_Pages {
 			];
 		}
 
-		$this->assign_reading_pages( $generated_pages, $roles['home_slug'], $roles['blog_slug'] );
+		$reading = $this->assign_reading_pages( $generated_pages, $roles['home_slug'], $roles['blog_slug'] );
+
+		if ( \is_wp_error( $reading ) ) {
+			$this->state_manager->set_step_status( self::STEP, 'failed' );
+
+			return $reading;
+		}
 
 		$state['created_posts']   = $created_posts;
 		$state['generated_pages'] = $generated_pages;
@@ -198,7 +227,8 @@ class Step_Generate_Pages {
 	}
 
 	private function delete_unselected_pages( array $selected_slugs ): void {
-		$page_ids = \get_posts(
+		$protected_slugs = $this->protected_landing_slugs();
+		$page_ids        = \get_posts(
 			[
 				'post_type'      => 'page',
 				'post_status'    => 'any',
@@ -214,8 +244,109 @@ class Step_Generate_Pages {
 				continue;
 			}
 
+			// Primary guard: never hard-delete wizard landing pages on generate-pages cleanup.
+			if ( $this->is_landing_page( (int) $page_id ) ) {
+				continue;
+			}
+
+			// Defense-in-depth: protect slugs still tracked in state.landing_pages.
+			if ( in_array( $post->post_name, $protected_slugs, true ) ) {
+				continue;
+			}
+
 			\wp_delete_post( (int) $page_id, true );
 		}
+	}
+
+	/**
+	 * Reject payload slugs that already resolve to residual SEO/Ads landing pages.
+	 *
+	 * @param string[] $slugs
+	 *
+	 * @return true|\WP_Error
+	 */
+	private function reject_selected_landing_slugs( array $slugs ) {
+		foreach ( $slugs as $slug ) {
+			$slug = \sanitize_title( (string) $slug );
+
+			if ( '' === $slug ) {
+				continue;
+			}
+
+			$existing = \get_page_by_path( $slug, \OBJECT, 'page' );
+
+			if ( $existing && $this->is_landing_page( (int) $existing->ID ) ) {
+				return $this->landing_slug_conflict_error( $slug, (int) $existing->ID );
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Whether a page is a wizard SEO/Ads landing (post meta rms_landing_type).
+	 */
+	private function is_landing_page( int $post_id ): bool {
+		if ( $post_id <= 0 ) {
+			return false;
+		}
+
+		$landing_type = \sanitize_key( (string) \get_post_meta( $post_id, 'rms_landing_type', true ) );
+
+		return in_array( $landing_type, [ 'seo', 'ads' ], true );
+	}
+
+	/**
+	 * Operator-facing error when generate-pages collides with a landing page.
+	 */
+	private function landing_slug_conflict_error( string $slug, int $post_id ): \WP_Error {
+		$this->logger->log(
+			'error',
+			'Generate-pages rejected slug that belongs to an existing landing page.',
+			[
+				'slug'    => $slug,
+				'post_id' => $post_id,
+			]
+		);
+
+		return new \WP_Error(
+			'rms_wizard_page_slug_is_landing',
+			sprintf(
+				/* translators: %s: page slug. */
+				\__( 'Slug "%s" belongs to an existing landing page and cannot be selected, updated, or assigned as Home/Blog by generate-pages.', 'simple-rms-theme' ),
+				$slug
+			),
+			[
+				'status'  => 400,
+				'slug'    => $slug,
+				'post_id' => $post_id,
+			]
+		);
+	}
+
+	/**
+	 * Slugs from state.landing_pages that must survive generate-pages cleanup.
+	 *
+	 * @return string[]
+	 */
+	private function protected_landing_slugs(): array {
+		$state    = $this->state_manager->get_state();
+		$landings = is_array( $state['landing_pages'] ?? null ) ? $state['landing_pages'] : [];
+		$slugs    = [];
+
+		foreach ( $landings as $landing ) {
+			if ( ! is_array( $landing ) ) {
+				continue;
+			}
+
+			$slug = \sanitize_title( (string) ( $landing['slug'] ?? '' ) );
+
+			if ( '' !== $slug ) {
+				$slugs[] = $slug;
+			}
+		}
+
+		return array_values( array_unique( $slugs ) );
 	}
 
 	private function generate_page_content( string $title, string $slug, array $client_data, array $ai_config ): string {
@@ -244,7 +375,14 @@ class Step_Generate_Pages {
 		return '<p>' . \esc_html( $company ) . ' provides reliable, professional service with clear communication from start to finish.</p><p>This ' . \esc_html( $title ) . ' page was generated by the setup wizard and can be refined after launch.</p>';
 	}
 
-	private function assign_reading_pages( array $generated_pages, string $home_slug, string $blog_slug ): void {
+	/**
+	 * Assign Reading settings. Never promote a landing page to Home/Blog.
+	 *
+	 * @param array<int,array<string,mixed>> $generated_pages
+	 *
+	 * @return true|\WP_Error
+	 */
+	private function assign_reading_pages( array $generated_pages, string $home_slug, string $blog_slug ) {
 		$ids_by_slug = [];
 
 		foreach ( $generated_pages as $page ) {
@@ -252,11 +390,29 @@ class Step_Generate_Pages {
 		}
 
 		if ( ! empty( $ids_by_slug[ $home_slug ] ) ) {
+			$home_id = (int) $ids_by_slug[ $home_slug ];
+
+			if ( $this->is_landing_page( $home_id ) ) {
+				return $this->landing_slug_conflict_error( $home_slug, $home_id );
+			}
+
 			\update_option( 'show_on_front', 'page', false );
-			\update_option( 'page_on_front', $ids_by_slug[ $home_slug ], false );
+			\update_option( 'page_on_front', $home_id, false );
 		}
 
-		\update_option( 'page_for_posts', '' !== $blog_slug && ! empty( $ids_by_slug[ $blog_slug ] ) ? $ids_by_slug[ $blog_slug ] : 0, false );
+		if ( '' !== $blog_slug && ! empty( $ids_by_slug[ $blog_slug ] ) ) {
+			$blog_id = (int) $ids_by_slug[ $blog_slug ];
+
+			if ( $this->is_landing_page( $blog_id ) ) {
+				return $this->landing_slug_conflict_error( $blog_slug, $blog_id );
+			}
+
+			\update_option( 'page_for_posts', $blog_id, false );
+		} else {
+			\update_option( 'page_for_posts', 0, false );
+		}
+
+		return true;
 	}
 
 	private function available_pages(): array {

--- a/inc/wizard/class-step-home-page-builder.php
+++ b/inc/wizard/class-step-home-page-builder.php
@@ -21,14 +21,16 @@ class Step_Home_Page_Builder {
 	private $layout_repository;
 	private $harness;
 	private $reviewer;
+	private $canonical_store;
 
-	public function __construct( ?Logger $logger = null, ?State_Manager $state_manager = null, ?Content_Builder $content_builder = null, ?Flexible_Content_Layouts $layout_repository = null, ?AI_Content_Harness $harness = null, ?AI_Content_Reviewer $reviewer = null ) {
+	public function __construct( ?Logger $logger = null, ?State_Manager $state_manager = null, ?Content_Builder $content_builder = null, ?Flexible_Content_Layouts $layout_repository = null, ?AI_Content_Harness $harness = null, ?AI_Content_Reviewer $reviewer = null, ?Canonical_Section_Store $canonical_store = null ) {
 		$this->logger            = $logger ?? new Logger();
 		$this->state_manager     = $state_manager ?? new State_Manager();
 		$this->content_builder   = $content_builder ?? new Content_Builder( $this->logger, $this->state_manager );
 		$this->layout_repository = $layout_repository ?? new Flexible_Content_Layouts();
 		$this->harness           = $harness ?? new AI_Content_Harness();
 		$this->reviewer          = $reviewer;
+		$this->canonical_store   = $canonical_store ?? new Canonical_Section_Store();
 	}
 
 	/**
@@ -115,6 +117,7 @@ class Step_Home_Page_Builder {
 		$state['selected_home_sections'] = $sections;
 		$state['home_section_rows']      = $section_rows;
 		$state['home_sections']          = $prepared_sections;
+		$state['canonical_sections']     = $this->first_write_canonical_sections( $prepared_sections );
 
 		$this->state_manager->save_state( $state );
 		$this->state_manager->set_step_status( self::STEP, 'complete' );
@@ -122,6 +125,33 @@ class Step_Home_Page_Builder {
 		$this->logger->log( 'info', 'Wizard Home page sections built.', [ 'post_id' => $post_id, 'sections' => $sections ] );
 
 		return [ 'post_id' => $post_id, 'sections' => $sections ];
+	}
+
+	/**
+	 * First-write reusable prepared rows into the canonical store.
+	 *
+	 * Skips keyword layouts (hero / seo-content). Never overwrites existing entries.
+	 *
+	 * @param array<int,array<string,mixed>> $prepared_sections Prepared ACF rows.
+	 *
+	 * @return array<string,array{has_payload:bool,generated_at:string}>
+	 */
+	private function first_write_canonical_sections( array $prepared_sections ): array {
+		foreach ( $prepared_sections as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+
+			$layout = \sanitize_key( (string) ( $row['acf_fc_layout'] ?? '' ) );
+
+			if ( '' === $layout || ! $this->harness->is_reusable_layout( $layout ) ) {
+				continue;
+			}
+
+			$this->canonical_store->set_if_empty( $layout, $row );
+		}
+
+		return $this->canonical_store->summary();
 	}
 
 	private function selected_section_rows( array $payload ): array {

--- a/inc/wizard/class-step-home-page-builder.php
+++ b/inc/wizard/class-step-home-page-builder.php
@@ -510,7 +510,8 @@ class Step_Home_Page_Builder {
 
 	private function maybe_mark_completed(): void {
 		$state    = $this->state_manager->get_state();
-		$required = [ 'dependencies', 'acf-import', 'client-data', 'generate-pages', 'menu-setup', 'ia-generation', 'home-page-builder' ];
+		// Shared source of truth via Step_Controller::get_required_steps().
+		$required = Step_Controller::get_required_steps();
 
 		foreach ( $required as $step ) {
 			if ( 'complete' !== ( $state['step_status'][ $step ] ?? '' ) ) {

--- a/inc/wizard/class-step-landing-page-builder.php
+++ b/inc/wizard/class-step-landing-page-builder.php
@@ -1,0 +1,2089 @@
+<?php
+/**
+ * Wizard Landing page builder step service.
+ *
+ * @package Simple_RMS_Theme
+ */
+
+namespace Inc\Wizard;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Builds N SEO/Ads landing pages from canonical reusable sections + keyword copy.
+ *
+ * Phase 2 backend scope: identity preflight, lazy canonical bootstrap, page upsert
+ * with template/type meta, and state persistence. Menu/Yoast/noindex final-state
+ * sync remains Phase 3.
+ *
+ * PR2 safety: class is implemented but NOT active in REQUIRED_STEPS / DISPATCHABLE_STEPS
+ * until Phase 3 wires UI + Ads noindex/menu final-state sync.
+ */
+class Step_Landing_Page_Builder {
+	private const STEP     = 'landing-page-builder';
+	private const TEMPLATE = 'pages/landing-page.php';
+
+	/**
+	 * Default section order aligned with pages/landing-page.php.
+	 *
+	 * @var array<int,array{layout:string}>
+	 */
+	private const DEFAULT_SECTIONS = [
+		[ 'layout' => 'hero' ],
+		[ 'layout' => 'seo-content' ],
+		[ 'layout' => 'vision-mission-v1' ],
+		[ 'layout' => 'badges' ],
+		[ 'layout' => 'portfolio-v1' ],
+		[ 'layout' => 'seo-content' ],
+		[ 'layout' => 'testimonials-v1' ],
+		[ 'layout' => 'seo-content' ],
+	];
+
+	private $logger;
+	private $state_manager;
+	private $content_builder;
+	private $layout_repository;
+	private $harness;
+	private $reviewer;
+	private $canonical_store;
+
+	public function __construct(
+		?Logger $logger = null,
+		?State_Manager $state_manager = null,
+		?Content_Builder $content_builder = null,
+		?Flexible_Content_Layouts $layout_repository = null,
+		?AI_Content_Harness $harness = null,
+		?AI_Content_Reviewer $reviewer = null,
+		?Canonical_Section_Store $canonical_store = null
+	) {
+		$this->logger            = $logger ?? new Logger();
+		$this->state_manager     = $state_manager ?? new State_Manager();
+		$this->content_builder   = $content_builder ?? new Content_Builder( $this->logger, $this->state_manager );
+		$this->layout_repository = $layout_repository ?? new Flexible_Content_Layouts();
+		$this->harness           = $harness ?? new AI_Content_Harness();
+		$this->reviewer          = $reviewer;
+		$this->canonical_store   = $canonical_store ?? new Canonical_Section_Store();
+	}
+
+	/**
+	 * Run the Landing page builder.
+	 *
+	 * @param array<string,mixed> $payload Step payload.
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function run( array $payload ) {
+		if ( $this->truthy( $payload['skip_all'] ?? false ) ) {
+			if ( ! $this->mark_step_status( 'complete' ) ) {
+				return new \WP_Error(
+					'rms_wizard_landing_status_persist_failed',
+					\__( 'Landing step completed but status could not be persisted.', 'simple-rms-theme' ),
+					[ 'status' => 500 ]
+				);
+			}
+			$this->maybe_mark_completed();
+			$state = $this->state_manager->get_state();
+
+			return [
+				'skipped'       => true,
+				'landing_pages' => is_array( $state['landing_pages'] ?? null ) ? $state['landing_pages'] : [],
+			];
+		}
+
+		$state     = $this->state_manager->get_state();
+		$ai_config = is_array( $state['ai_config'] ?? null ) ? $state['ai_config'] : [];
+
+		if ( ! $this->has_ai_config( $ai_config ) ) {
+			$this->mark_step_status( 'failed' );
+
+			return new \WP_Error( 'rms_wizard_ai_config_required', \__( 'AI configuration required. Complete the IA Generation step first.', 'simple-rms-theme' ), [ 'status' => 400 ] );
+		}
+
+		$client_data = is_array( $state['client_data'] ?? null ) ? $state['client_data'] : [];
+		$missing     = $this->harness->validate_required_context( $client_data );
+
+		if ( [] !== $missing ) {
+			$this->mark_step_status( 'failed' );
+
+			return new \WP_Error(
+				'rms_wizard_landing_required_client_data_missing',
+				sprintf(
+					/* translators: %s: comma-separated missing client data keys. */
+					\__( 'Missing required client data: %s. Complete your client profile before generating.', 'simple-rms-theme' ),
+					implode( ', ', $missing )
+				),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$existing_landings = $this->normalize_state_landings( is_array( $state['landing_pages'] ?? null ) ? $state['landing_pages'] : [] );
+		$parsed            = $this->parse_landings_payload( $payload, $existing_landings );
+
+		if ( \is_wp_error( $parsed ) ) {
+			$this->mark_step_status( 'failed' );
+
+			return $parsed;
+		}
+
+		/** @var array{rows:array<int,array<string,mixed>>,replace_map:array<string,bool>} $parsed */
+		$rows        = $parsed['rows'];
+		$replace_map = $parsed['replace_map'];
+
+		if ( [] === $rows ) {
+			$this->mark_step_status( 'failed' );
+
+			return new \WP_Error(
+				'rms_wizard_landings_required',
+				\__( 'Add at least one landing page or use skip-all to complete without landings.', 'simple-rms-theme' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$required_layouts = $this->collect_required_reusable_layouts( $rows );
+		$bootstrap        = $this->ensure_canonical_reusables( $required_layouts, $state, $client_data, $ai_config );
+
+		if ( \is_wp_error( $bootstrap ) ) {
+			$this->mark_step_status( 'failed' );
+
+			return $bootstrap;
+		}
+
+		$client_context = $this->harness->get_harness_context( $client_data );
+		$landing_pages  = $existing_landings;
+		$built          = [];
+		$prior_payloads = [];
+		$built_ids      = [];
+
+		foreach ( $rows as $row ) {
+			try {
+				$result = $this->build_one_landing( $row, $replace_map, $client_data, $client_context, $ai_config, $landing_pages, $prior_payloads );
+			} catch ( \Throwable $exception ) {
+				// Convert thrown failures so partial persistence still runs before returning.
+				$landing_key = (string) ( $row['landing_key'] ?? '' );
+				$slug        = (string) ( $row['slug'] ?? '' );
+
+				$this->logger->log(
+					'error',
+					'Wizard landing build threw an exception.',
+					[
+						'landing_key'     => $landing_key,
+						'slug'            => $slug,
+						'exception_class' => get_class( $exception ),
+						'message'         => $exception->getMessage(),
+					]
+				);
+
+				$result = new \WP_Error(
+					'rms_wizard_landing_build_exception',
+					sprintf(
+						/* translators: 1: landing slug or key, 2: exception message. */
+						\__( 'Landing "%1$s" failed unexpectedly: %2$s', 'simple-rms-theme' ),
+						'' !== $slug ? $slug : $landing_key,
+						$exception->getMessage()
+					),
+					[
+						'status'          => 500,
+						'landing_key'     => $landing_key,
+						'slug'            => $slug,
+						'exception_class' => get_class( $exception ),
+					]
+				);
+			}
+
+			if ( \is_wp_error( $result ) ) {
+				// Persist successful landings before failing so partial progress is not lost.
+				$this->persist_partial_landing_progress( $state, $landing_pages, $built_ids, $result );
+
+				return $result;
+			}
+
+			$landing_pages[ $result['landing_key'] ] = $result['entry'];
+			$built[]                                 = $result['entry'];
+			$built_ids[]                             = (int) ( $result['entry']['id'] ?? 0 );
+			$prior_payloads                          = array_merge( $prior_payloads, $result['prior_payloads'] );
+		}
+
+		$state['landing_pages']      = array_values( $landing_pages );
+		$state['canonical_sections'] = $this->canonical_store->summary();
+
+		if ( ! $this->persist_wizard_state( $state, 'full success' ) ) {
+			$this->mark_step_status( 'failed' );
+
+			return new \WP_Error(
+				'rms_wizard_landing_state_persist_failed',
+				\__( 'Landing pages were built but wizard state could not be persisted.', 'simple-rms-theme' ),
+				[
+					'status'    => 500,
+					'post_ids'  => array_values( array_filter( $built_ids ) ),
+					'built'     => count( $built ),
+				]
+			);
+		}
+
+		if ( ! $this->mark_step_status( 'complete' ) ) {
+			return new \WP_Error(
+				'rms_wizard_landing_status_persist_failed',
+				\__( 'Landing pages were saved but step status could not be marked complete.', 'simple-rms-theme' ),
+				[ 'status' => 500, 'post_ids' => array_values( array_filter( $built_ids ) ) ]
+			);
+		}
+
+		$this->maybe_mark_completed();
+		$this->logger->log(
+			'info',
+			'Wizard landing pages built.',
+			[
+				'count'    => count( $built ),
+				'post_ids' => array_values( array_filter( $built_ids ) ),
+			]
+		);
+
+		return [
+			'landing_pages'      => array_values( $landing_pages ),
+			'built'              => $built,
+			'canonical_sections' => $state['canonical_sections'],
+		];
+	}
+
+	/**
+	 * @param array<string,mixed>              $payload
+	 * @param array<string,array<string,mixed>> $existing_landings Keyed by landing_key.
+	 *
+	 * @return array{rows:array<int,array<string,mixed>>,replace_map:array<string,bool>}|\WP_Error
+	 */
+	private function parse_landings_payload( array $payload, array $existing_landings ) {
+		$raw_landings = is_array( $payload['landings'] ?? null ) ? $payload['landings'] : [];
+		$replace_raw  = is_array( $payload['replace_canonical'] ?? null ) ? $payload['replace_canonical'] : [];
+		$confirm      = $this->truthy( $payload['confirm_replace_canonical'] ?? false );
+		$replace_map  = [];
+
+		foreach ( $replace_raw as $layout => $flag ) {
+			$layout = $this->normalize_layout( (string) $layout );
+
+			if ( '' !== $layout && $this->truthy( $flag ) ) {
+				if ( ! $confirm ) {
+					return new \WP_Error(
+						'rms_wizard_replace_canonical_unconfirmed',
+						\__( 'Confirm replace canonical before overwriting shared reusable sections.', 'simple-rms-theme' ),
+						[ 'status' => 400 ]
+					);
+				}
+
+				$replace_map[ $layout ] = true;
+			}
+		}
+
+		$rows          = [];
+		$seen_ids      = [];
+		$seen_keys     = [];
+		$seen_slugs    = [];
+		$claimed_ids   = [];
+		$claimed_keys  = [];
+		$claimed_slugs = [];
+
+		foreach ( $existing_landings as $entry ) {
+			$id  = (int) ( $entry['id'] ?? 0 );
+			$key = (string) ( $entry['landing_key'] ?? '' );
+			$slug = \sanitize_title( (string) ( $entry['slug'] ?? '' ) );
+
+			if ( $id > 0 ) {
+				$claimed_ids[ $id ] = $key;
+			}
+
+			if ( '' !== $key ) {
+				$claimed_keys[ $key ] = $entry;
+			}
+
+			if ( '' !== $slug ) {
+				$claimed_slugs[ $slug ] = $key;
+			}
+		}
+
+		foreach ( $raw_landings as $raw ) {
+			if ( ! is_array( $raw ) || $this->truthy( $raw['skipped'] ?? false ) ) {
+				continue;
+			}
+
+			$title = \sanitize_text_field( (string) ( $raw['title'] ?? '' ) );
+			$slug  = \sanitize_title( (string) ( $raw['slug'] ?? $title ) );
+			$type  = \sanitize_key( (string) ( $raw['landing_type'] ?? 'seo' ) );
+			$type  = in_array( $type, [ 'seo', 'ads' ], true ) ? $type : 'seo';
+
+			$keywords = $this->harness->normalize_keywords(
+				[
+					'primary_keyword' => $raw['primary_keyword'] ?? '',
+					'subkeywords'     => $raw['subkeywords'] ?? [],
+				]
+			);
+
+			if ( '' === $keywords['primary_keyword'] ) {
+				return new \WP_Error(
+					'rms_wizard_landing_keyword_required',
+					\__( 'Each landing requires a non-empty primary keyword.', 'simple-rms-theme' ),
+					[ 'status' => 400 ]
+				);
+			}
+
+			if ( '' === $title || '' === $slug ) {
+				return new \WP_Error(
+					'rms_wizard_landing_identity_required',
+					\__( 'Each landing requires a title and slug.', 'simple-rms-theme' ),
+					[ 'status' => 400 ]
+				);
+			}
+
+			$id  = isset( $raw['id'] ) && '' !== (string) $raw['id'] && null !== $raw['id'] ? \absint( $raw['id'] ) : 0;
+			$key = \sanitize_key( (string) ( $raw['landing_key'] ?? '' ) );
+
+			if ( $id > 0 ) {
+				if ( isset( $seen_ids[ $id ] ) ) {
+					return new \WP_Error( 'rms_wizard_landing_duplicate_id', \__( 'Duplicate landing id values are not allowed in one run.', 'simple-rms-theme' ), [ 'status' => 400 ] );
+				}
+
+				$seen_ids[ $id ] = true;
+			}
+
+			if ( '' !== $key ) {
+				if ( isset( $seen_keys[ $key ] ) ) {
+					return new \WP_Error( 'rms_wizard_landing_duplicate_key', \__( 'Duplicate landing_key values are not allowed in one run.', 'simple-rms-theme' ), [ 'status' => 400 ] );
+				}
+
+				$seen_keys[ $key ] = true;
+			}
+
+			if ( isset( $seen_slugs[ $slug ] ) ) {
+				return new \WP_Error( 'rms_wizard_landing_duplicate_slug', \__( 'Duplicate landing slugs are not allowed in one run.', 'simple-rms-theme' ), [ 'status' => 400 ] );
+			}
+
+			$seen_slugs[ $slug ] = true;
+
+			$match = $this->match_existing_landing( $id, $key, $slug, $existing_landings, $claimed_ids, $claimed_keys, $claimed_slugs );
+
+			if ( \is_wp_error( $match ) ) {
+				return $match;
+			}
+
+			$matched_key = (string) ( $match['landing_key'] ?? '' );
+			$matched_id  = (int) ( $match['id'] ?? 0 );
+
+			// Rename collision: slug belongs to a different landing in state.
+			if ( isset( $claimed_slugs[ $slug ] ) && $claimed_slugs[ $slug ] !== $matched_key && '' !== $matched_key ) {
+				return new \WP_Error(
+					'rms_wizard_landing_slug_collision',
+					sprintf(
+						/* translators: %s: page slug. */
+						\__( 'Landing slug "%s" collides with another landing page.', 'simple-rms-theme' ),
+						$slug
+					),
+					[ 'status' => 400 ]
+				);
+			}
+
+			// Page collision when creating or claiming by slug (non-landing or other landing).
+			$slug_page = \get_page_by_path( $slug, \OBJECT, 'page' );
+
+			if ( $slug_page ) {
+				$slug_page_id    = (int) $slug_page->ID;
+				$slug_is_landing = $this->page_has_landing_type( $slug_page_id );
+
+				if ( $matched_id > 0 && $slug_page_id !== $matched_id ) {
+					return new \WP_Error(
+						'rms_wizard_landing_slug_collision',
+						sprintf(
+							/* translators: %s: page slug. */
+							\__( 'Landing slug "%s" collides with an existing page.', 'simple-rms-theme' ),
+							$slug
+						),
+						[ 'status' => 400 ]
+					);
+				}
+
+				if ( $matched_id <= 0 && ! $slug_is_landing ) {
+					return new \WP_Error(
+						'rms_wizard_landing_slug_collision',
+						sprintf(
+							/* translators: %s: page slug. */
+							\__( 'Landing slug "%s" collides with an existing non-landing page.', 'simple-rms-theme' ),
+							$slug
+						),
+						[ 'status' => 400 ]
+					);
+				}
+
+				// Slug fallback may only resolve when the existing page is a landing.
+				if ( $matched_id <= 0 && $slug_is_landing ) {
+					$matched_id = $slug_page_id;
+				}
+			}
+
+			if ( '' === $matched_key ) {
+				$matched_key = '' !== $key ? $key : $this->mint_landing_key();
+			}
+
+			$sections = $this->normalize_section_rows( is_array( $raw['sections'] ?? null ) ? $raw['sections'] : [] );
+
+			$rows[] = [
+				'id'              => $matched_id,
+				'landing_key'     => $matched_key,
+				'title'           => $title,
+				'slug'            => $slug,
+				'landing_type'    => $type,
+				'menu_eligible'   => 'seo' === $type,
+				'primary_keyword' => $keywords['primary_keyword'],
+				'subkeywords'     => $keywords['subkeywords'],
+				'sections'        => $sections,
+			];
+		}
+
+		return [
+			'rows'        => $rows,
+			'replace_map' => $replace_map,
+		];
+	}
+
+	/**
+	 * Deterministic identity match order: id → landing_key → slug.
+	 * When both id and landing_key are non-empty they MUST refer to the same state row.
+	 *
+	 * @param array<string,array<string,mixed>> $existing_landings
+	 * @param array<int,string>                 $claimed_ids
+	 * @param array<string,array<string,mixed>> $claimed_keys
+	 * @param array<string,string>              $claimed_slugs
+	 *
+	 * @return array{id:int,landing_key:string}|\WP_Error
+	 */
+	private function match_existing_landing( int $id, string $key, string $slug, array $existing_landings, array $claimed_ids, array $claimed_keys, array $claimed_slugs ) {
+		unset( $existing_landings ); // Claim maps are the authoritative index.
+
+		// Stale cross-pair: payload pairs id+key that point at different rows.
+		if ( $id > 0 && '' !== $key ) {
+			$id_key     = $claimed_ids[ $id ] ?? null;
+			$key_entry  = $claimed_keys[ $key ] ?? null;
+			$key_id     = is_array( $key_entry ) ? (int) ( $key_entry['id'] ?? 0 ) : 0;
+
+			if ( null !== $id_key && $id_key !== $key ) {
+				return new \WP_Error(
+					'rms_wizard_landing_identity_mismatch',
+					\__( 'Landing id and landing_key refer to different existing landings.', 'simple-rms-theme' ),
+					[ 'status' => 400, 'id' => $id, 'landing_key' => $key, 'id_landing_key' => $id_key ]
+				);
+			}
+
+			if ( $key_id > 0 && $key_id !== $id ) {
+				return new \WP_Error(
+					'rms_wizard_landing_identity_mismatch',
+					\__( 'Landing id and landing_key refer to different existing landings.', 'simple-rms-theme' ),
+					[ 'status' => 400, 'id' => $id, 'landing_key' => $key, 'key_id' => $key_id ]
+				);
+			}
+		}
+
+		// 1) Match by id (strongest).
+		if ( $id > 0 ) {
+			if ( isset( $claimed_ids[ $id ] ) ) {
+				$matched_key = $claimed_ids[ $id ];
+
+				if ( '' !== $key && $key !== $matched_key ) {
+					return new \WP_Error(
+						'rms_wizard_landing_identity_mismatch',
+						\__( 'Landing id and landing_key refer to different existing landings.', 'simple-rms-theme' ),
+						[ 'status' => 400, 'id' => $id, 'landing_key' => $key, 'id_landing_key' => $matched_key ]
+					);
+				}
+
+				return [
+					'id'          => $id,
+					'landing_key' => $matched_key,
+				];
+			}
+
+			// ID supplied but not a known landing in state — only accept if page has landing meta.
+			if ( ! $this->page_has_landing_type( $id ) ) {
+				return new \WP_Error(
+					'rms_wizard_landing_unknown_id',
+					\__( 'Landing id does not match an existing landing page.', 'simple-rms-theme' ),
+					[ 'status' => 400 ]
+				);
+			}
+
+			// Key must not already belong to a different post id.
+			if ( '' !== $key && isset( $claimed_keys[ $key ] ) ) {
+				$other_id = (int) ( $claimed_keys[ $key ]['id'] ?? 0 );
+
+				if ( $other_id > 0 && $other_id !== $id ) {
+					return new \WP_Error(
+						'rms_wizard_landing_identity_mismatch',
+						\__( 'Landing id and landing_key refer to different existing landings.', 'simple-rms-theme' ),
+						[ 'status' => 400, 'id' => $id, 'landing_key' => $key, 'key_id' => $other_id ]
+					);
+				}
+			}
+
+			return [
+				'id'          => $id,
+				'landing_key' => '' !== $key ? $key : $this->mint_landing_key(),
+			];
+		}
+
+		// 2) Match by landing_key.
+		if ( '' !== $key && isset( $claimed_keys[ $key ] ) ) {
+			$entry = $claimed_keys[ $key ];
+
+			return [
+				'id'          => (int) ( $entry['id'] ?? 0 ),
+				'landing_key' => $key,
+			];
+		}
+
+		// 3) Match by slug (landing state only; non-landing collisions handled by caller).
+		if ( '' !== $slug && isset( $claimed_slugs[ $slug ] ) ) {
+			$matched_key = $claimed_slugs[ $slug ];
+			$entry       = $claimed_keys[ $matched_key ] ?? [];
+
+			return [
+				'id'          => (int) ( $entry['id'] ?? 0 ),
+				'landing_key' => $matched_key,
+			];
+		}
+
+		return [
+			'id'          => 0,
+			'landing_key' => $key,
+		];
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $rows
+	 *
+	 * @return string[]
+	 */
+	private function collect_required_reusable_layouts( array $rows ): array {
+		$layouts = [];
+
+		foreach ( $rows as $row ) {
+			foreach ( is_array( $row['sections'] ?? null ) ? $row['sections'] : [] as $section ) {
+				$layout = $this->normalize_layout( (string) ( $section['layout'] ?? '' ) );
+
+				if ( '' === $layout || ! $this->harness->is_reusable_layout( $layout ) ) {
+					continue;
+				}
+
+				// Override rows still need a bootstrap fallback if generation fails.
+				$layouts[ $layout ] = true;
+			}
+		}
+
+		return array_keys( $layouts );
+	}
+
+	/**
+	 * Lazy bootstrap: state.home_sections → Home page_sections → neutral generation.
+	 *
+	 * @param string[]            $required_layouts
+	 * @param array<string,mixed> $state
+	 * @param array<string,mixed> $client_data
+	 * @param array<string,mixed> $ai_config
+	 *
+	 * @return true|\WP_Error
+	 */
+	private function ensure_canonical_reusables( array $required_layouts, array $state, array $client_data, array $ai_config ) {
+		$missing = [];
+
+		foreach ( $required_layouts as $layout ) {
+			if ( ! $this->canonical_store->has( $layout ) ) {
+				$missing[] = $layout;
+			}
+		}
+
+		if ( [] === $missing ) {
+			return true;
+		}
+
+		// (1) state.home_sections prepared reusable rows.
+		$this->seed_from_section_rows( is_array( $state['home_sections'] ?? null ) ? $state['home_sections'] : [], $missing );
+		$missing = $this->still_missing( $missing );
+
+		if ( [] === $missing ) {
+			return true;
+		}
+
+		// (2) Home page ACF page_sections.
+		$home_id = $this->home_page_id( $state );
+
+		if ( $home_id > 0 ) {
+			$home_sections = $this->read_page_sections( $home_id );
+			$this->seed_from_section_rows( $home_sections, $missing );
+			$missing = $this->still_missing( $missing );
+		}
+
+		if ( [] === $missing ) {
+			return true;
+		}
+
+		// (3) Neutral generation (PAGE_HOME, no keywords).
+		$client_context = $this->harness->get_harness_context( $client_data );
+
+		foreach ( $missing as $layout ) {
+			if ( ! $this->layout_repository->has_layout( $layout ) ) {
+				continue;
+			}
+
+			$item_count = $this->item_count( $layout, 0 );
+			$overrides  = $this->generate_section_copy(
+				$layout,
+				$item_count,
+				$client_context,
+				$ai_config,
+				AI_Content_Harness::PAGE_HOME,
+				[],
+				[],
+				false,
+				[ 'layout' => $layout, 'bootstrap' => true ]
+			);
+			$overrides  = \is_wp_error( $overrides ) ? [] : $overrides;
+			$row        = $this->content_builder->prepare_image_fallbacks( $this->section_data( $layout, $client_data, $overrides, $item_count ) );
+
+			if ( [] === $row || empty( $row['acf_fc_layout'] ) ) {
+				continue;
+			}
+
+			if ( ! $this->canonical_store->set_if_empty( $layout, $row ) && ! $this->canonical_store->has( $layout ) ) {
+				$this->logger->log(
+					'error',
+					'Canonical bootstrap first-write persistence failed.',
+					[ 'layout' => $layout ]
+				);
+			}
+		}
+
+		$missing = $this->still_missing( $missing );
+
+		if ( [] !== $missing ) {
+			return new \WP_Error(
+				'rms_wizard_canonical_bootstrap_failed',
+				sprintf(
+					/* translators: %s: comma-separated layout keys. */
+					\__( 'Could not prepare shared reusable sections (%s). Re-run Home Page Builder or fix the Home page sections, then try again.', 'simple-rms-theme' ),
+					implode( ', ', $missing )
+				),
+				[ 'status' => 400, 'missing_layouts' => $missing ]
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $rows
+	 * @param string[]                       $missing
+	 */
+	private function seed_from_section_rows( array $rows, array $missing ): void {
+		$want = array_fill_keys( $missing, true );
+
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+
+			$layout = $this->normalize_layout( (string) ( $row['acf_fc_layout'] ?? $row['layout'] ?? '' ) );
+
+			if ( '' === $layout || ! isset( $want[ $layout ] ) || ! $this->harness->is_reusable_layout( $layout ) ) {
+				continue;
+			}
+
+			if ( empty( $row['acf_fc_layout'] ) ) {
+				$row['acf_fc_layout'] = $layout;
+			}
+
+			if ( ! $this->is_valid_section_row( $row ) ) {
+				continue;
+			}
+
+			$this->canonical_store->set_if_empty( $layout, $row );
+		}
+	}
+
+	/**
+	 * @param string[] $layouts
+	 *
+	 * @return string[]
+	 */
+	private function still_missing( array $layouts ): array {
+		$missing = [];
+
+		foreach ( $layouts as $layout ) {
+			if ( ! $this->canonical_store->has( $layout ) ) {
+				$missing[] = $layout;
+			}
+		}
+
+		return $missing;
+	}
+
+	/**
+	 * @param array<string,mixed>               $row
+	 * @param array<string,bool>                $replace_map
+	 * @param array<string,mixed>               $client_data
+	 * @param array<string,mixed>               $client_context
+	 * @param array<string,mixed>               $ai_config
+	 * @param array<string,array<string,mixed>> $landing_pages
+	 * @param array<int,array<string,mixed>>    $prior_payloads
+	 *
+	 * @return array{entry:array<string,mixed>,landing_key:string,prior_payloads:array<int,array<string,mixed>>}|\WP_Error
+	 */
+	private function build_one_landing( array $row, array $replace_map, array $client_data, array $client_context, array $ai_config, array $landing_pages, array $prior_payloads ) {
+		unset( $landing_pages );
+
+		$keywords = [
+			'primary_keyword' => (string) $row['primary_keyword'],
+			'subkeywords'     => is_array( $row['subkeywords'] ?? null ) ? $row['subkeywords'] : [],
+		];
+
+		$log_context = [
+			'landing_key'  => (string) $row['landing_key'],
+			'slug'         => (string) $row['slug'],
+			'title'        => (string) $row['title'],
+			'landing_type' => (string) $row['landing_type'],
+		];
+
+		$prepared     = [];
+		$local_priors = $prior_payloads;
+		$section_rows = is_array( $row['sections'] ?? null ) ? $row['sections'] : [];
+		$existing_id  = (int) $row['id'];
+
+		foreach ( $section_rows as $section_row ) {
+			$layout   = $this->normalize_layout( (string) ( $section_row['layout'] ?? '' ) );
+			$override = $this->truthy( $section_row['override_canonical'] ?? false );
+			$count    = $this->item_count( $layout, (int) ( $section_row['item_count'] ?? 0 ) );
+
+			if ( '' === $layout || ! $this->layout_repository->has_layout( $layout ) ) {
+				continue;
+			}
+
+			$section_context            = $log_context;
+			$section_context['layout']  = $layout;
+
+			if ( $this->harness->is_keyword_layout( $layout ) ) {
+				$copy = $this->generate_section_copy(
+					$layout,
+					$count,
+					$client_context,
+					$ai_config,
+					AI_Content_Harness::PAGE_LANDING,
+					$keywords,
+					$local_priors,
+					true,
+					$section_context
+				);
+
+				if ( \is_wp_error( $copy ) ) {
+					// Preserve existing landing content instead of publishing keyword placeholders.
+					$preserved = $this->try_preserve_existing_landing( $existing_id, $row, $log_context, $copy );
+
+					if ( \is_wp_error( $preserved ) ) {
+						return $preserved;
+					}
+
+					if ( null !== $preserved ) {
+						return $preserved;
+					}
+
+					return $copy;
+				}
+
+				$section = $this->content_builder->prepare_image_fallbacks( $this->section_data( $layout, $client_data, $copy, $count ) );
+			} else {
+				$section = $this->resolve_reusable_section(
+					$layout,
+					$count,
+					$override,
+					! empty( $replace_map[ $layout ] ),
+					$client_data,
+					$client_context,
+					$ai_config,
+					$local_priors,
+					$section_context
+				);
+			}
+
+			if ( ! $this->is_valid_section_row( $section ) ) {
+				return new \WP_Error(
+					'rms_wizard_landing_section_failed',
+					sprintf(
+						/* translators: %s: layout key. */
+						\__( 'Landing section "%s" could not be prepared.', 'simple-rms-theme' ),
+						$layout
+					),
+					array_merge( [ 'status' => 500 ], $section_context )
+				);
+			}
+
+			$prepared[]     = $section;
+			$local_priors[] = [
+				'layout'     => $layout,
+				'item_count' => $count,
+				'payload'    => $section,
+			];
+		}
+
+		if ( [] === $prepared ) {
+			return new \WP_Error( 'rms_wizard_landing_sections_required', \__( 'Each landing requires at least one valid section.', 'simple-rms-theme' ), [ 'status' => 400 ] );
+		}
+
+		// Local catch: build_page may create/update the post before a later throwable.
+		// Convert to WP_Error so outer partial recovery can still persist prior successes.
+		try {
+			$post_id = $this->content_builder->build_page(
+				[
+					'id'           => $existing_id,
+					'title'        => (string) $row['title'],
+					'slug'         => (string) $row['slug'],
+					'status'       => 'publish',
+					'section_only' => $existing_id > 0,
+					'sections'     => $prepared,
+					'meta_input'   => [
+						'_wp_page_template' => self::TEMPLATE,
+						'rms_landing_type'  => (string) $row['landing_type'],
+					],
+				]
+			);
+		} catch ( \Throwable $exception ) {
+			$recovered_id = $this->recover_build_page_post_id( $existing_id, (string) $row['slug'] );
+
+			$this->logger->log(
+				'error',
+				'Wizard landing build_page threw after possible create/update.',
+				array_merge(
+					$log_context,
+					[
+						'post_id'         => $recovered_id > 0 ? $recovered_id : null,
+						'exception_class' => get_class( $exception ),
+						'message'         => $exception->getMessage(),
+					]
+				)
+			);
+
+			$error_data = array_merge(
+				[
+					'status'          => 500,
+					'exception_class' => get_class( $exception ),
+				],
+				$log_context
+			);
+
+			if ( $recovered_id > 0 ) {
+				$error_data['post_id'] = $recovered_id;
+			}
+
+			return new \WP_Error(
+				'rms_wizard_landing_build_page_exception',
+				sprintf(
+					/* translators: 1: landing title or slug, 2: exception message. */
+					\__( 'Landing "%1$s" could not be saved: %2$s', 'simple-rms-theme' ),
+					'' !== (string) $row['title'] ? (string) $row['title'] : (string) $row['slug'],
+					$exception->getMessage()
+				),
+				$error_data
+			);
+		}
+
+		if ( $post_id <= 0 ) {
+			return new \WP_Error( 'rms_wizard_landing_save_failed', \__( 'Landing page could not be saved.', 'simple-rms-theme' ), array_merge( [ 'status' => 500 ], $log_context ) );
+		}
+
+		$meta_ok = $this->ensure_landing_meta( $post_id, (string) $row['landing_type'], $log_context );
+
+		if ( \is_wp_error( $meta_ok ) ) {
+			return $meta_ok;
+		}
+
+		$entry = [
+			'id'              => $post_id,
+			'landing_key'     => (string) $row['landing_key'],
+			'title'           => (string) $row['title'],
+			'slug'            => (string) $row['slug'],
+			'landing_type'    => (string) $row['landing_type'],
+			'menu_eligible'   => ! empty( $row['menu_eligible'] ),
+			'primary_keyword' => (string) $row['primary_keyword'],
+			'subkeywords'     => is_array( $row['subkeywords'] ?? null ) ? array_values( $row['subkeywords'] ) : [],
+			'keywords'        => [
+				'primary_keyword' => (string) $row['primary_keyword'],
+				'subkeywords'     => is_array( $row['subkeywords'] ?? null ) ? array_values( $row['subkeywords'] ) : [],
+			],
+			'generated_at'    => \current_time( 'mysql', true ),
+		];
+
+		return [
+			'entry'          => $entry,
+			'landing_key'    => (string) $row['landing_key'],
+			'prior_payloads' => $local_priors,
+		];
+	}
+
+	/**
+	 * @param array<string,mixed>            $client_data
+	 * @param array<string,mixed>            $client_context
+	 * @param array<string,mixed>            $ai_config
+	 * @param array<int,array<string,mixed>> $prior_payloads
+	 * @param array<string,mixed>            $log_context
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function resolve_reusable_section(
+		string $layout,
+		int $item_count,
+		bool $override,
+		bool $replace_canonical,
+		array $client_data,
+		array $client_context,
+		array $ai_config,
+		array $prior_payloads,
+		array $log_context = []
+	): array {
+		$canonical = $this->canonical_store->get( $layout );
+		// Keep canonical/reusable generation neutral: never feed keyword-driven priors.
+		$neutral_priors = $this->filter_neutral_priors( $prior_payloads );
+
+		if ( $override ) {
+			// Override stays keyword-neutral (PAGE_HOME, empty keywords).
+			$copy = $this->generate_section_copy(
+				$layout,
+				$item_count,
+				$client_context,
+				$ai_config,
+				AI_Content_Harness::PAGE_HOME,
+				[],
+				$neutral_priors,
+				false,
+				$log_context
+			);
+			$copy = \is_wp_error( $copy ) ? [] : $copy;
+			$row  = $this->content_builder->prepare_image_fallbacks( $this->section_data( $layout, $client_data, $copy, $item_count ) );
+
+			if ( ! $this->is_valid_section_row( $row ) ) {
+				$this->logger->log(
+					'warning',
+					'Landing override generation failed; falling back to canonical.',
+					array_merge( [ 'layout' => $layout ], $log_context )
+				);
+
+				return $canonical;
+			}
+
+			// Overrides must never write the canonical store.
+			return $row;
+		}
+
+		if ( $replace_canonical ) {
+			$copy = $this->generate_section_copy(
+				$layout,
+				$item_count,
+				$client_context,
+				$ai_config,
+				AI_Content_Harness::PAGE_HOME,
+				[],
+				$neutral_priors,
+				false,
+				$log_context
+			);
+			$copy = \is_wp_error( $copy ) ? [] : $copy;
+			$row  = $this->content_builder->prepare_image_fallbacks( $this->section_data( $layout, $client_data, $copy, $item_count ) );
+
+			if ( $this->is_valid_section_row( $row ) ) {
+				if ( ! $this->canonical_store->replace( $layout, $row ) ) {
+					// replace() may return false when DB already holds identical payload.
+					$persisted = $this->canonical_store->get( $layout );
+
+					if ( $persisted !== $row ) {
+						$this->logger->log(
+							'error',
+							'Canonical replace persistence failed; keeping previous canonical when available.',
+							array_merge( [ 'layout' => $layout ], $log_context )
+						);
+
+						if ( $this->is_valid_section_row( $canonical ) ) {
+							return $canonical;
+						}
+					}
+				}
+
+				return $row;
+			}
+
+			$this->logger->log(
+				'warning',
+				'Canonical replace generation failed; keeping existing canonical.',
+				array_merge( [ 'layout' => $layout ], $log_context )
+			);
+		}
+
+		if ( $this->is_valid_section_row( $canonical ) ) {
+			return $canonical;
+		}
+
+		// First-write path when store empty after bootstrap race.
+		$copy = $this->generate_section_copy(
+			$layout,
+			$item_count,
+			$client_context,
+			$ai_config,
+			AI_Content_Harness::PAGE_HOME,
+			[],
+			$neutral_priors,
+			false,
+			$log_context
+		);
+		$copy = \is_wp_error( $copy ) ? [] : $copy;
+		$row  = $this->content_builder->prepare_image_fallbacks( $this->section_data( $layout, $client_data, $copy, $item_count ) );
+
+		if ( $this->is_valid_section_row( $row ) ) {
+			if ( ! $this->canonical_store->set_if_empty( $layout, $row ) && ! $this->canonical_store->has( $layout ) ) {
+				$this->logger->log(
+					'error',
+					'Canonical first-write persistence failed.',
+					array_merge( [ 'layout' => $layout ], $log_context )
+				);
+			}
+		}
+
+		return $row;
+	}
+
+	/**
+	 * @param array<string,mixed>            $client_context
+	 * @param array<string,mixed>            $ai_config
+	 * @param array<string,mixed>            $keywords
+	 * @param array<int,array<string,mixed>> $prior_section_payloads
+	 * @param array<string,mixed>            $log_context
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function generate_section_copy(
+		string $section_key,
+		int $item_count,
+		array $client_context,
+		array $ai_config,
+		string $page_type,
+		array $keywords,
+		array $prior_section_payloads,
+		bool $require_ai = false,
+		array $log_context = []
+	) {
+		$fillable = $this->harness->get_fillable_fields( $section_key );
+
+		if ( [] === $fillable ) {
+			return [];
+		}
+
+		$context = array_merge(
+			[
+				'layout'    => $section_key,
+				'page_type' => $page_type,
+			],
+			$log_context
+		);
+
+		// Reusable/canonical review must not see keyword-driven prior sections.
+		$review_priors = $require_ai
+			? $prior_section_payloads
+			: $this->filter_neutral_priors( $prior_section_payloads );
+
+		$provider = \sanitize_key( (string) $ai_config['provider'] );
+		$model    = \sanitize_text_field( (string) $ai_config['model'] );
+		$system   = $this->harness->get_layer1() . "\n\n" . $this->harness->get_layer2( $page_type );
+		$prompt   = $this->harness->get_layer3( $section_key, $item_count, $client_context, $page_type, $keywords );
+		$result   = AI_Provider_Registry::make_provider( $provider )->generate(
+			$model,
+			$prompt,
+			[
+				'section_key' => $section_key,
+				'client_data' => $client_context,
+				'item_count'  => $item_count,
+				'page_type'   => $page_type,
+			],
+			$system
+		);
+
+		if ( empty( $result['success'] ) || empty( $result['content'] ) ) {
+			$this->logger->log(
+				$require_ai ? 'error' : 'warning',
+				$require_ai
+					? 'Wizard landing keyword section AI generation failed.'
+					: 'Wizard landing section AI generation failed; fallback content used.',
+				array_merge( $context, [ 'error' => $result['error'] ?? '' ] )
+			);
+
+			if ( $require_ai ) {
+				return new \WP_Error(
+					'rms_wizard_landing_keyword_ai_failed',
+					sprintf(
+						/* translators: %s: layout key. */
+						\__( 'Keyword section "%s" could not be generated. Landing was not published with placeholder copy.', 'simple-rms-theme' ),
+						$section_key
+					),
+					array_merge( [ 'status' => 502 ], $context )
+				);
+			}
+
+			return [];
+		}
+
+		$decoded = $this->decode_json_content( (string) $result['content'] );
+
+		if ( [] === $decoded ) {
+			$this->logger->log(
+				$require_ai ? 'error' : 'warning',
+				'Wizard landing AI returned success but content was invalid JSON.',
+				array_merge(
+					$context,
+					[
+						'content_preview' => substr( trim( (string) $result['content'] ), 0, 180 ),
+					]
+				)
+			);
+
+			if ( $require_ai ) {
+				return new \WP_Error(
+					'rms_wizard_landing_keyword_json_failed',
+					sprintf(
+						/* translators: %s: layout key. */
+						\__( 'Keyword section "%s" returned invalid JSON. Landing was not published with placeholder copy.', 'simple-rms-theme' ),
+						$section_key
+					),
+					array_merge( [ 'status' => 502 ], $context )
+				);
+			}
+
+			return [];
+		}
+
+		$reviewed = $this->review_section_content(
+			$section_key,
+			$decoded,
+			$review_priors,
+			$ai_config,
+			$client_context,
+			$item_count,
+			$require_ai,
+			$context
+		);
+
+		if ( \is_wp_error( $reviewed ) ) {
+			return $reviewed;
+		}
+
+		$validated = $this->harness->validate_fields( $section_key, $reviewed );
+
+		if ( $require_ai && [] === $validated ) {
+			$this->logger->log(
+				'error',
+				'Wizard landing keyword section validated to empty payload after AI success.',
+				$context
+			);
+
+			return new \WP_Error(
+				'rms_wizard_landing_keyword_empty',
+				sprintf(
+					/* translators: %s: layout key. */
+					\__( 'Keyword section "%s" produced no usable fields. Landing was not published with placeholder copy.', 'simple-rms-theme' ),
+					$section_key
+				),
+				array_merge( [ 'status' => 502 ], $context )
+			);
+		}
+
+		return $validated;
+	}
+
+	/**
+	 * @param array<string,mixed>            $decoded
+	 * @param array<int,array<string,mixed>> $prior_section_payloads
+	 * @param array<string,mixed>            $ai_config
+	 * @param array<string,mixed>            $client_context
+	 * @param array<string,mixed>            $log_context
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function review_section_content(
+		string $section_key,
+		array $decoded,
+		array $prior_section_payloads,
+		array $ai_config,
+		array $client_context,
+		int $item_count,
+		bool $require_ai = false,
+		array $log_context = []
+	) {
+		if ( ! $this->is_review_enabled() ) {
+			return $decoded;
+		}
+
+		$review_config                   = $ai_config;
+		$review_config['client_context'] = $client_context;
+		$review_config['item_count']     = $item_count;
+
+		try {
+			$result = $this->reviewer()->review( $section_key, $decoded, $prior_section_payloads, $review_config );
+		} catch ( \Throwable $error ) {
+			$this->logger->log(
+				'error',
+				'Wizard landing content reviewer threw an exception.',
+				array_merge(
+					[
+						'layout'  => $section_key,
+						'message' => $error->getMessage(),
+					],
+					$log_context
+				)
+			);
+
+			if ( $require_ai ) {
+				return new \WP_Error(
+					'rms_wizard_landing_keyword_review_failed',
+					sprintf(
+						/* translators: %s: layout key. */
+						\__( 'Keyword section "%s" review failed. Landing was not published with placeholder copy.', 'simple-rms-theme' ),
+						$section_key
+					),
+					array_merge( [ 'status' => 502, 'layout' => $section_key ], $log_context )
+				);
+			}
+
+			return $decoded;
+		}
+
+		$payload = $result['payload'] ?? null;
+
+		return is_array( $payload ) ? $payload : $decoded;
+	}
+
+	/**
+	 * @param array<int,mixed> $raw
+	 *
+	 * @return array<int,array{layout:string,item_count:int,override_canonical:bool}>
+	 */
+	private function normalize_section_rows( array $raw ): array {
+		$rows = [];
+
+		foreach ( $raw as $value ) {
+			if ( is_array( $value ) ) {
+				$layout = $this->normalize_layout( (string) ( $value['layout'] ?? $value['section_key'] ?? $value['key'] ?? '' ) );
+				$count  = \absint( $value['item_count'] ?? 0 );
+				$over   = $this->truthy( $value['override_canonical'] ?? false );
+			} else {
+				$layout = $this->normalize_layout( (string) $value );
+				$count  = 0;
+				$over   = false;
+			}
+
+			if ( '' === $layout || ! $this->layout_repository->has_layout( $layout ) ) {
+				continue;
+			}
+
+			$rows[] = [
+				'layout'             => $layout,
+				'item_count'         => $this->item_count( $layout, $count ),
+				'override_canonical' => $over,
+			];
+		}
+
+		if ( [] === $rows ) {
+			foreach ( self::DEFAULT_SECTIONS as $default ) {
+				$layout = $this->normalize_layout( (string) $default['layout'] );
+
+				if ( ! $this->layout_repository->has_layout( $layout ) ) {
+					continue;
+				}
+
+				$rows[] = [
+					'layout'             => $layout,
+					'item_count'         => $this->item_count( $layout, 0 ),
+					'override_canonical' => false,
+				];
+			}
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * @param array<int,mixed> $landings
+	 *
+	 * @return array<string,array<string,mixed>>
+	 */
+	private function normalize_state_landings( array $landings ): array {
+		$normalized = [];
+
+		foreach ( $landings as $landing ) {
+			if ( ! is_array( $landing ) ) {
+				continue;
+			}
+
+			$key = \sanitize_key( (string) ( $landing['landing_key'] ?? '' ) );
+
+			if ( '' === $key ) {
+				$key = $this->mint_landing_key();
+			}
+
+			$landing['landing_key'] = $key;
+			$landing['id']          = \absint( $landing['id'] ?? 0 );
+			$landing['slug']        = \sanitize_title( (string) ( $landing['slug'] ?? '' ) );
+			$normalized[ $key ]     = $landing;
+		}
+
+		return $normalized;
+	}
+
+	private function section_data( string $section_key, array $client_data, array $copy, int $item_count ): array {
+		$section = array_merge( [ 'acf_fc_layout' => $section_key ], $this->placeholder_copy( $section_key, $client_data, $item_count ) );
+		$allowed = array_flip( $this->harness->get_fillable_fields( $section_key ) );
+
+		foreach ( $copy as $field => $value ) {
+			$field = (string) $field;
+
+			if ( false !== strpos( $field, '_services' ) ) {
+				continue;
+			}
+
+			if ( isset( $allowed[ $field ] ) ) {
+				$section[ $field ] = $this->section_value( $value );
+			}
+		}
+
+		$service_rows = $this->service_rows( $section_key, $client_data, $copy, $item_count );
+
+		if ( [] !== $service_rows ) {
+			$section[ $service_rows['field'] ] = $service_rows['rows'];
+		}
+
+		return $section;
+	}
+
+	private function placeholder_copy( string $section_key, array $client_data, int $item_count ): array {
+		if ( ! $this->harness->has_fillable_fields( $section_key ) ) {
+			return [];
+		}
+
+		$company        = $this->text( $client_data['company_name'] ?? \__( 'Your Company', 'simple-rms-theme' ) );
+		$text_repeaters = $this->harness->get_text_repeater_fields( $section_key );
+		$copy           = [];
+
+		foreach ( $this->harness->get_fillable_fields( $section_key ) as $field ) {
+			if ( false !== strpos( $field, '_services' ) || isset( $text_repeaters[ $field ] ) ) {
+				continue;
+			}
+
+			$copy[ $field ] = $this->placeholder_field_value( $field, $company );
+		}
+
+		foreach ( $text_repeaters as $field => $sub_fields ) {
+			$copy[ $field ] = $this->placeholder_repeater_rows( $sub_fields, $company, $item_count );
+		}
+
+		return $copy;
+	}
+
+	private function placeholder_repeater_rows( array $sub_fields, string $company, int $item_count ): array {
+		$rows  = [];
+		$count = max( 1, min( 12, $item_count ) );
+
+		for ( $index = 0; $index < $count; $index++ ) {
+			$row = [];
+
+			foreach ( $sub_fields as $sub_field ) {
+				$row[ (string) $sub_field ] = $this->placeholder_field_value( (string) $sub_field, $company );
+			}
+
+			if ( [] !== $row ) {
+				$rows[] = $row;
+			}
+		}
+
+		return $rows;
+	}
+
+	private function placeholder_field_value( string $field, string $company ): string {
+		if ( false !== strpos( $field, 'headline' ) || false !== strpos( $field, 'title' ) || false !== strpos( $field, 'question' ) ) {
+			return sprintf( /* translators: %s: company name. */ \__( '%s Services You Can Trust', 'simple-rms-theme' ), $company );
+		}
+
+		if ( false !== strpos( $field, 'subheadline' ) || false !== strpos( $field, 'eyebrow' ) || false !== strpos( $field, 'label' ) ) {
+			return \__( 'Dependable service and clear communication', 'simple-rms-theme' );
+		}
+
+		if ( false !== strpos( $field, 'cta' ) || false !== strpos( $field, 'button' ) ) {
+			return \__( 'Get an Estimate', 'simple-rms-theme' );
+		}
+
+		return sprintf( /* translators: %s: company name. */ \__( '%s provides reliable service with careful attention to each project.', 'simple-rms-theme' ), $company );
+	}
+
+	/**
+	 * @return array{field:string,rows:array<int,array<string,string>>}|array{}
+	 */
+	private function service_rows( string $section_key, array $client_data, array $copy, int $item_count ): array {
+		$contracts = [
+			'services-v1' => [ 'field' => 'services_v1_services', 'name' => 'service_title', 'description' => 'service_text' ],
+			'services-v2' => [ 'field' => 'services_v2_services', 'name' => 'service_title', 'description' => 'service_text' ],
+			'services-v3' => [ 'field' => 'services_v3_services', 'name' => 'service_name', 'description' => 'service_overlay_text' ],
+		];
+
+		if ( ! isset( $contracts[ $section_key ] ) ) {
+			return [];
+		}
+
+		$contract = $contracts[ $section_key ];
+		$ai_rows  = is_array( $copy[ $contract['field'] ] ?? null ) ? array_values( $copy[ $contract['field'] ] ) : [];
+		$rows     = [];
+
+		foreach ( array_slice( is_array( $client_data['company_services'] ?? null ) ? $client_data['company_services'] : [], 0, $item_count ) as $index => $service ) {
+			if ( ! is_array( $service ) || empty( $service['service_name'] ) ) {
+				continue;
+			}
+
+			$ai_row      = is_array( $ai_rows[ $index ] ?? null ) ? $ai_rows[ $index ] : [];
+			$description = $ai_row[ $contract['description'] ] ?? $service['service_short_description'] ?? '';
+
+			$rows[] = [
+				$contract['name']        => $this->text( $service['service_name'] ),
+				$contract['description'] => $this->html( $description ),
+			];
+		}
+
+		return [ 'field' => $contract['field'], 'rows' => $rows ];
+	}
+
+	private function item_count( string $section_key, int $requested ): int {
+		if ( ! $this->harness->has_fillable_fields( $section_key ) ) {
+			return 0;
+		}
+
+		$defaults = [
+			'slider'            => 2,
+			'area-coverage-v1'  => 4,
+			'badges'            => 4,
+			'cta-v3'            => 3,
+			'faq-v1'            => 4,
+			'faq-v2'            => 4,
+			'gallery-grid'      => 6,
+			'portfolio-v1'      => 3,
+			'portfolio-v2'      => 3,
+			'portfolio-v3'      => 6,
+			'services-v1'       => 3,
+			'services-v2'       => 3,
+			'services-v3'       => 3,
+			'testimonials-v1'   => 3,
+			'testimonials-v2'   => 3,
+			'testimonials-v3'   => 3,
+			'video-v2'          => 2,
+			'vision-mission-v1' => 2,
+			'vision-mission-v2' => 3,
+		];
+
+		$count = $requested > 0 ? $requested : ( $defaults[ $section_key ] ?? 1 );
+
+		return max( 1, min( 12, $count ) );
+	}
+
+	private function home_page_id( array $state ): int {
+		$home_slug       = \sanitize_title( (string) ( $state['home_page_slug'] ?? '' ) );
+		$generated_pages = is_array( $state['generated_pages'] ?? null ) ? $state['generated_pages'] : [];
+
+		foreach ( $generated_pages as $page ) {
+			if ( ! is_array( $page ) || $home_slug !== \sanitize_title( (string) ( $page['slug'] ?? '' ) ) ) {
+				continue;
+			}
+
+			$post = \get_post( \absint( $page['id'] ?? 0 ) );
+
+			if ( $post && 'page' === $post->post_type ) {
+				return (int) $post->ID;
+			}
+		}
+
+		if ( '' === $home_slug ) {
+			return 0;
+		}
+
+		$post = \get_page_by_path( $home_slug, \OBJECT, 'page' );
+
+		return $post ? (int) $post->ID : 0;
+	}
+
+	/**
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function read_page_sections( int $post_id ): array {
+		if ( function_exists( 'get_field' ) ) {
+			$sections = \get_field( 'page_sections', $post_id );
+
+			if ( is_array( $sections ) ) {
+				return $sections;
+			}
+		}
+
+		$meta = \get_post_meta( $post_id, 'page_sections', true );
+
+		return is_array( $meta ) ? $meta : [];
+	}
+
+	private function is_valid_section_row( array $row ): bool {
+		$layout = $this->normalize_layout( (string) ( $row['acf_fc_layout'] ?? '' ) );
+
+		return '' !== $layout;
+	}
+
+	private function page_has_landing_type( int $post_id ): bool {
+		if ( $post_id <= 0 ) {
+			return false;
+		}
+
+		$type = \sanitize_key( (string) \get_post_meta( $post_id, 'rms_landing_type', true ) );
+
+		return in_array( $type, [ 'seo', 'ads' ], true );
+	}
+
+	private function mint_landing_key(): string {
+		if ( function_exists( 'wp_generate_uuid4' ) ) {
+			return 'lk_' . str_replace( '-', '', \wp_generate_uuid4() );
+		}
+
+		return 'lk_' . \sanitize_key( uniqid( '', true ) );
+	}
+
+	private function normalize_layout( string $layout ): string {
+		$layout = \sanitize_key( $layout );
+
+		return 'cta-bar' === $layout ? 'cta-v1' : $layout;
+	}
+
+	private function has_ai_config( array $ai_config ): bool {
+		$provider        = \sanitize_key( (string) ( $ai_config['provider'] ?? '' ) );
+		$model           = \sanitize_text_field( (string) ( $ai_config['model'] ?? '' ) );
+		$credential      = is_array( $ai_config['credential'] ?? null ) ? $ai_config['credential'] : [];
+		$has_credentials = ! empty( $ai_config['has_credentials'] ) || ! empty( $credential['has_key'] ) || ( '' !== $provider && AI_Credential_Store::has( $provider ) );
+
+		return '' !== $provider && '' !== $model && $has_credentials && AI_Provider_Registry::provider_exists( $provider );
+	}
+
+	private function decode_json_content( string $content ): array {
+		$content = trim( preg_replace( '/^```(?:json)?|```$/m', '', $content ) ?? $content );
+		$data    = json_decode( $content, true );
+
+		return is_array( $data ) ? $data : [];
+	}
+
+	private function reviewer(): AI_Content_Reviewer {
+		if ( ! $this->reviewer instanceof AI_Content_Reviewer ) {
+			$this->reviewer = new AI_Content_Reviewer( $this->harness );
+		}
+
+		return $this->reviewer;
+	}
+
+	private function is_review_enabled(): bool {
+		if ( ! \defined( 'WIZARD_REVIEW_ENABLED' ) ) {
+			return true;
+		}
+
+		$value = \constant( 'WIZARD_REVIEW_ENABLED' );
+
+		if ( is_bool( $value ) ) {
+			return $value;
+		}
+
+		if ( is_int( $value ) ) {
+			return 0 !== $value;
+		}
+
+		if ( is_string( $value ) ) {
+			$value = strtolower( trim( $value ) );
+
+			if ( in_array( $value, [ '0', 'false', 'off', 'no' ], true ) ) {
+				return false;
+			}
+
+			if ( in_array( $value, [ '1', 'true', 'on', 'yes' ], true ) ) {
+				return true;
+			}
+		}
+
+		return (bool) $value;
+	}
+
+	private function section_value( $value ) {
+		if ( is_array( $value ) ) {
+			return array_map( [ $this, 'section_value' ], $value );
+		}
+
+		return $this->html( $value );
+	}
+
+	private function text( $value ): string {
+		return \sanitize_text_field( (string) $value );
+	}
+
+	private function html( $value ): string {
+		return \wp_kses_post( (string) $value );
+	}
+
+	private function truthy( $value ): bool {
+		return true === $value || 1 === $value || '1' === $value || 'true' === $value || 'yes' === $value || 'on' === $value;
+	}
+
+	private function maybe_mark_completed(): void {
+		$state    = $this->state_manager->get_state();
+		$required = Step_Controller::get_required_steps();
+
+		foreach ( $required as $step ) {
+			if ( 'complete' !== ( $state['step_status'][ $step ] ?? '' ) ) {
+				return;
+			}
+		}
+
+		$this->state_manager->mark_completed();
+	}
+
+	/**
+	 * Persist wizard state and verify landing_pages post-state when critical.
+	 *
+	 * update_option() can return false for identical values, so we re-read.
+	 *
+	 * @param array<string,mixed> $state
+	 */
+	private function persist_wizard_state( array $state, string $reason ): bool {
+		$expected = is_array( $state['landing_pages'] ?? null ) ? array_values( $state['landing_pages'] ) : [];
+		$saved    = $this->state_manager->save_state( $state );
+
+		if ( $saved ) {
+			return true;
+		}
+
+		$reloaded = $this->state_manager->get_state();
+		$actual   = is_array( $reloaded['landing_pages'] ?? null ) ? array_values( $reloaded['landing_pages'] ) : [];
+
+		if ( $this->landing_pages_equivalent( $expected, $actual ) ) {
+			return true;
+		}
+
+		$this->logger->log(
+			'error',
+			'Wizard landing state persistence failed.',
+			[
+				'reason'           => $reason,
+				'expected_count'   => count( $expected ),
+				'actual_count'     => count( $actual ),
+				'expected_post_ids'=> $this->collect_landing_post_ids( $expected ),
+				'actual_post_ids'  => $this->collect_landing_post_ids( $actual ),
+			]
+		);
+
+		return false;
+	}
+
+	/**
+	 * On multi-landing partial failure: save successful landings, then mark failed.
+	 *
+	 * @param array<string,mixed>               $state
+	 * @param array<string,array<string,mixed>> $landing_pages
+	 * @param int[]                             $built_ids
+	 * @param \WP_Error                         $error
+	 */
+	private function persist_partial_landing_progress( array $state, array $landing_pages, array $built_ids, \WP_Error $error ): void {
+		$successful = array_values( array_filter( $built_ids ) );
+		$state['landing_pages']      = array_values( $landing_pages );
+		$state['canonical_sections'] = $this->canonical_store->summary();
+
+		$persisted = $this->persist_wizard_state( $state, 'partial failure recovery' );
+
+		$this->logger->log(
+			$persisted ? 'warning' : 'error',
+			$persisted
+				? 'Wizard landing run failed after partial success; successful landings persisted.'
+				: 'Wizard landing run failed after partial success; could not persist successful landings.',
+			[
+				'successful_count' => count( $successful ),
+				'post_ids'         => $successful,
+				'error_code'       => $error->get_error_code(),
+				'error_message'    => $error->get_error_message(),
+			]
+		);
+
+		// Mark failed only after persistence is attempted.
+		if ( ! $this->mark_step_status( 'failed' ) ) {
+			$this->logger->log(
+				'error',
+				'Wizard landing could not mark step status failed after partial failure.',
+				[
+					'post_ids'   => $successful,
+					'error_code' => $error->get_error_code(),
+				]
+			);
+		}
+	}
+
+	/**
+	 * @param string $status pending|running|complete|failed
+	 */
+	private function mark_step_status( string $status ): bool {
+		$saved = $this->state_manager->set_step_status( self::STEP, $status );
+
+		if ( $saved ) {
+			return true;
+		}
+
+		$state  = $this->state_manager->get_state();
+		$actual = (string) ( $state['step_status'][ self::STEP ] ?? '' );
+
+		if ( $actual === $status ) {
+			return true;
+		}
+
+		$this->logger->log(
+			'error',
+			'Wizard landing step status persistence failed.',
+			[
+				'expected' => $status,
+				'actual'   => $actual,
+			]
+		);
+
+		return false;
+	}
+
+	/**
+	 * Safety-net meta writes with post-state verification.
+	 *
+	 * @param array<string,mixed> $log_context
+	 *
+	 * @return true|\WP_Error
+	 */
+	private function ensure_landing_meta( int $post_id, string $landing_type, array $log_context ) {
+		\update_post_meta( $post_id, '_wp_page_template', self::TEMPLATE );
+		\update_post_meta( $post_id, 'rms_landing_type', $landing_type );
+
+		$template = (string) \get_post_meta( $post_id, '_wp_page_template', true );
+		$type     = \sanitize_key( (string) \get_post_meta( $post_id, 'rms_landing_type', true ) );
+
+		if ( self::TEMPLATE !== $template || $landing_type !== $type ) {
+			$this->logger->log(
+				'error',
+				'Wizard landing meta safety-net verification failed.',
+				array_merge(
+					$log_context,
+					[
+						'post_id'           => $post_id,
+						'expected_template' => self::TEMPLATE,
+						'actual_template'   => $template,
+						'expected_type'     => $landing_type,
+						'actual_type'       => $type,
+					]
+				)
+			);
+
+			return new \WP_Error(
+				'rms_wizard_landing_meta_persist_failed',
+				\__( 'Landing page meta could not be verified after save.', 'simple-rms-theme' ),
+				array_merge( [ 'status' => 500, 'post_id' => $post_id ], $log_context )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * When keyword AI fails on an update, preserve the existing landing page payload.
+	 *
+	 * @param array<string,mixed> $row
+	 * @param array<string,mixed> $log_context
+	 * @param \WP_Error           $error
+	 *
+	 * @return array{entry:array<string,mixed>,landing_key:string,prior_payloads:array<int,array<string,mixed>>}|\WP_Error|null
+	 *         array on preserved success, WP_Error when preserve update fails, null when preserve is not applicable.
+	 */
+	private function try_preserve_existing_landing( int $existing_id, array $row, array $log_context, \WP_Error $error ) {
+		if ( $existing_id <= 0 || ! $this->page_has_landing_type( $existing_id ) ) {
+			return null;
+		}
+
+		$sections = $this->read_page_sections( $existing_id );
+		$valid    = false;
+
+		foreach ( $sections as $section ) {
+			if ( is_array( $section ) && $this->is_valid_section_row( $section ) ) {
+				$valid = true;
+				break;
+			}
+		}
+
+		if ( ! $valid ) {
+			return null;
+		}
+
+		$this->logger->log(
+			'warning',
+			'Keyword AI failed; preserving existing landing page payload instead of placeholders.',
+			array_merge(
+				$log_context,
+				[
+					'post_id'       => $existing_id,
+					'error_code'    => $error->get_error_code(),
+					'error_message' => $error->get_error_message(),
+				]
+			)
+		);
+
+		// Refresh title/slug/type meta without rewriting sections.
+		$updated = \wp_update_post(
+			[
+				'ID'         => $existing_id,
+				'post_title' => (string) $row['title'],
+				'post_name'  => (string) $row['slug'],
+			],
+			true
+		);
+
+		if ( \is_wp_error( $updated ) ) {
+			$this->logger->log(
+				'error',
+				'Failed to preserve existing landing page after keyword AI failure (wp_update_post error).',
+				array_merge(
+					$log_context,
+					[
+						'post_id'       => $existing_id,
+						'error_code'    => $updated->get_error_code(),
+						'error_message' => $updated->get_error_message(),
+					]
+				)
+			);
+
+			return new \WP_Error(
+				'rms_wizard_landing_preserve_failed',
+				\__( 'Keyword generation failed and the existing landing page could not be preserved.', 'simple-rms-theme' ),
+				array_merge(
+					[
+						'status'             => 500,
+						'post_id'            => $existing_id,
+						'update_error_code'  => $updated->get_error_code(),
+						'keyword_error_code' => $error->get_error_code(),
+					],
+					$log_context
+				)
+			);
+		}
+
+		if ( ! is_int( $updated ) || $updated <= 0 ) {
+			$this->logger->log(
+				'error',
+				'Failed to preserve existing landing page after keyword AI failure (invalid wp_update_post result).',
+				array_merge(
+					$log_context,
+					[
+						'post_id'       => $existing_id,
+						'update_result' => $updated,
+					]
+				)
+			);
+
+			return new \WP_Error(
+				'rms_wizard_landing_preserve_failed',
+				\__( 'Keyword generation failed and the existing landing page could not be preserved.', 'simple-rms-theme' ),
+				array_merge(
+					[
+						'status'             => 500,
+						'post_id'            => $existing_id,
+						'keyword_error_code' => $error->get_error_code(),
+					],
+					$log_context
+				)
+			);
+		}
+
+		$meta_ok = $this->ensure_landing_meta( $existing_id, (string) $row['landing_type'], $log_context );
+
+		if ( \is_wp_error( $meta_ok ) ) {
+			$this->logger->log(
+				'error',
+				'Failed to preserve existing landing meta after keyword AI failure.',
+				array_merge(
+					$log_context,
+					[
+						'post_id'       => $existing_id,
+						'error_code'    => $meta_ok->get_error_code(),
+						'error_message' => $meta_ok->get_error_message(),
+					]
+				)
+			);
+
+			return $meta_ok;
+		}
+
+		$entry = [
+			'id'              => $existing_id,
+			'landing_key'     => (string) $row['landing_key'],
+			'title'           => (string) $row['title'],
+			'slug'            => (string) $row['slug'],
+			'landing_type'    => (string) $row['landing_type'],
+			'menu_eligible'   => ! empty( $row['menu_eligible'] ),
+			'primary_keyword' => (string) $row['primary_keyword'],
+			'subkeywords'     => is_array( $row['subkeywords'] ?? null ) ? array_values( $row['subkeywords'] ) : [],
+			'keywords'        => [
+				'primary_keyword' => (string) $row['primary_keyword'],
+				'subkeywords'     => is_array( $row['subkeywords'] ?? null ) ? array_values( $row['subkeywords'] ) : [],
+			],
+			'generated_at'    => \current_time( 'mysql', true ),
+			'preserved'       => true,
+		];
+
+		return [
+			'entry'          => $entry,
+			'landing_key'    => (string) $row['landing_key'],
+			'prior_payloads' => [],
+		];
+	}
+
+	/**
+	 * Strip keyword-governed priors so reusable/canonical generation stays neutral.
+	 *
+	 * @param array<int,array<string,mixed>> $priors
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function filter_neutral_priors( array $priors ): array {
+		$neutral = [];
+
+		foreach ( $priors as $prior ) {
+			if ( ! is_array( $prior ) ) {
+				continue;
+			}
+
+			$layout = $this->normalize_layout( (string) ( $prior['layout'] ?? '' ) );
+
+			if ( '' === $layout || $this->harness->is_keyword_layout( $layout ) ) {
+				continue;
+			}
+
+			$neutral[] = $prior;
+		}
+
+		return $neutral;
+	}
+
+	/**
+	 * Compare meaningful persisted landing state (not only identity fields).
+	 *
+	 * Used when save_state() returns false so identical-but-unordered or
+	 * stale/partial snapshots are not treated as successful persistence.
+	 *
+	 * @param array<int,array<string,mixed>> $left
+	 * @param array<int,array<string,mixed>> $right
+	 */
+	private function landing_pages_equivalent( array $left, array $right ): bool {
+		if ( count( $left ) !== count( $right ) ) {
+			return false;
+		}
+
+		$normalize = function ( array $rows ): array {
+			$map = [];
+
+			foreach ( $rows as $row ) {
+				if ( ! is_array( $row ) ) {
+					continue;
+				}
+
+				$key = \sanitize_key( (string) ( $row['landing_key'] ?? '' ) );
+
+				if ( '' === $key ) {
+					$key = 'id_' . (int) ( $row['id'] ?? 0 );
+				}
+
+				$keywords       = is_array( $row['keywords'] ?? null ) ? $row['keywords'] : [];
+				$primary        = (string) ( $row['primary_keyword'] ?? ( $keywords['primary_keyword'] ?? '' ) );
+				$subkeywords    = is_array( $row['subkeywords'] ?? null )
+					? $row['subkeywords']
+					: ( is_array( $keywords['subkeywords'] ?? null ) ? $keywords['subkeywords'] : [] );
+				$subkeywords    = array_values(
+					array_filter(
+						array_map(
+							static function ( $value ): string {
+								return \sanitize_text_field( (string) $value );
+							},
+							$subkeywords
+						),
+						static function ( string $value ): bool {
+							return '' !== $value;
+						}
+					)
+				);
+				// Order-insensitive keyword bag — payload order is not meaningful state.
+				sort( $subkeywords, SORT_STRING );
+
+				$map[ $key ] = [
+					'id'              => (int) ( $row['id'] ?? 0 ),
+					'landing_key'     => \sanitize_key( (string) ( $row['landing_key'] ?? '' ) ),
+					'title'           => \sanitize_text_field( (string) ( $row['title'] ?? '' ) ),
+					'slug'            => \sanitize_title( (string) ( $row['slug'] ?? '' ) ),
+					'landing_type'    => \sanitize_key( (string) ( $row['landing_type'] ?? '' ) ),
+					'menu_eligible'   => ! empty( $row['menu_eligible'] ),
+					'primary_keyword' => \sanitize_text_field( $primary ),
+					'subkeywords'     => $subkeywords,
+					'generated_at'    => \sanitize_text_field( (string) ( $row['generated_at'] ?? '' ) ),
+					'preserved'       => ! empty( $row['preserved'] ),
+				];
+			}
+
+			ksort( $map );
+
+			return $map;
+		};
+
+		return $normalize( $left ) === $normalize( $right );
+	}
+
+	/**
+	 * Best-effort post ID recovery when build_page throws after create/update.
+	 */
+	private function recover_build_page_post_id( int $existing_id, string $slug ): int {
+		if ( $existing_id > 0 ) {
+			return $existing_id;
+		}
+
+		$slug = \sanitize_title( $slug );
+
+		if ( '' === $slug ) {
+			return 0;
+		}
+
+		$page = \get_page_by_path( $slug, OBJECT, 'page' );
+
+		if ( $page instanceof \WP_Post ) {
+			return (int) $page->ID;
+		}
+
+		return 0;
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $landings
+	 *
+	 * @return int[]
+	 */
+	private function collect_landing_post_ids( array $landings ): array {
+		$ids = [];
+
+		foreach ( $landings as $landing ) {
+			if ( ! is_array( $landing ) ) {
+				continue;
+			}
+
+			$id = (int) ( $landing['id'] ?? 0 );
+
+			if ( $id > 0 ) {
+				$ids[] = $id;
+			}
+		}
+
+		return $ids;
+	}
+}
+

--- a/inc/wizard/class-step-landing-page-builder.php
+++ b/inc/wizard/class-step-landing-page-builder.php
@@ -12,12 +12,8 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Builds N SEO/Ads landing pages from canonical reusable sections + keyword copy.
  *
- * Phase 2 backend scope: identity preflight, lazy canonical bootstrap, page upsert
- * with template/type meta, and state persistence. Menu/Yoast/noindex final-state
- * sync remains Phase 3.
- *
- * PR2 safety: class is implemented but NOT active in REQUIRED_STEPS / DISPATCHABLE_STEPS
- * until Phase 3 wires UI + Ads noindex/menu final-state sync.
+ * Includes identity preflight, lazy canonical bootstrap, page upsert with
+ * template/type meta, Yoast/noindex final-state sync, and menu reconciliation.
  */
 class Step_Landing_Page_Builder {
 	private const STEP     = 'landing-page-builder';
@@ -46,6 +42,8 @@ class Step_Landing_Page_Builder {
 	private $harness;
 	private $reviewer;
 	private $canonical_store;
+	private $menu_builder;
+	private $yoast_meta_writer;
 
 	public function __construct(
 		?Logger $logger = null,
@@ -54,7 +52,9 @@ class Step_Landing_Page_Builder {
 		?Flexible_Content_Layouts $layout_repository = null,
 		?AI_Content_Harness $harness = null,
 		?AI_Content_Reviewer $reviewer = null,
-		?Canonical_Section_Store $canonical_store = null
+		?Canonical_Section_Store $canonical_store = null,
+		?Menu_Builder $menu_builder = null,
+		?Yoast_Meta_Writer $yoast_meta_writer = null
 	) {
 		$this->logger            = $logger ?? new Logger();
 		$this->state_manager     = $state_manager ?? new State_Manager();
@@ -63,6 +63,8 @@ class Step_Landing_Page_Builder {
 		$this->harness           = $harness ?? new AI_Content_Harness();
 		$this->reviewer          = $reviewer;
 		$this->canonical_store   = $canonical_store ?? new Canonical_Section_Store();
+		$this->menu_builder      = $menu_builder ?? new Menu_Builder( $this->logger );
+		$this->yoast_meta_writer = $yoast_meta_writer ?? new Yoast_Meta_Writer( $this->logger );
 	}
 
 	/**
@@ -74,6 +76,69 @@ class Step_Landing_Page_Builder {
 	 */
 	public function run( array $payload ) {
 		if ( $this->truthy( $payload['skip_all'] ?? false ) ) {
+			$state             = $this->state_manager->get_state();
+			$existing_landings = $this->normalize_state_landings(
+				is_array( $state['landing_pages'] ?? null ) ? $state['landing_pages'] : []
+			);
+
+			// Existing landings must still receive final-state robots/menu reconciliation.
+			// No existing landings → skip-all is a pure no-op complete.
+			if ( [] !== $existing_landings ) {
+				foreach ( $existing_landings as $landing_key => $row ) {
+					if ( ! is_array( $row ) ) {
+						continue;
+					}
+
+					$post_id     = (int) ( $row['id'] ?? 0 );
+					$slug        = (string) ( $row['slug'] ?? '' );
+					$log_context = [
+						'landing_key' => (string) ( $row['landing_key'] ?? $landing_key ),
+						'slug'        => $slug,
+						'skip_all'    => true,
+					];
+
+					if ( $post_id <= 0 || 'page' !== \get_post_type( $post_id ) ) {
+						$post_id = $this->recover_build_page_post_id( $post_id, $slug );
+					}
+
+					if ( $post_id <= 0 || 'page' !== \get_post_type( $post_id ) ) {
+						$this->mark_step_status( 'failed' );
+
+						return new \WP_Error(
+							'rms_wizard_landing_skip_all_missing_post',
+							sprintf(
+								/* translators: %s: landing key or slug. */
+								\__( 'Skip-all could not reconcile landing "%s": page not found.', 'simple-rms-theme' ),
+								'' !== (string) ( $row['landing_key'] ?? '' )
+									? (string) $row['landing_key']
+									: ( '' !== $slug ? $slug : (string) $landing_key )
+							),
+							array_merge( [ 'status' => 500 ], $log_context )
+						);
+					}
+
+					$final_state = $this->sync_landing_final_state( $post_id, $row, $log_context );
+
+					if ( \is_wp_error( $final_state ) ) {
+						$this->mark_step_status( 'failed' );
+						$this->logger->log(
+							'error',
+							'Skip-all final-state sync failed; step not marked complete.',
+							array_merge(
+								$log_context,
+								[
+									'post_id'       => $post_id,
+									'error_code'    => $final_state->get_error_code(),
+									'error_message' => $final_state->get_error_message(),
+								]
+							)
+						);
+
+						return $final_state;
+					}
+				}
+			}
+
 			if ( ! $this->mark_step_status( 'complete' ) ) {
 				return new \WP_Error(
 					'rms_wizard_landing_status_persist_failed',
@@ -863,6 +928,11 @@ class Step_Landing_Page_Builder {
 				)
 			);
 
+			// Ads may already be published — best-effort noindex/menu cleanup before failing.
+			if ( $recovered_id > 0 ) {
+				$this->protect_ads_final_state_best_effort( $recovered_id, $row, $log_context );
+			}
+
 			$error_data = array_merge(
 				[
 					'status'          => 500,
@@ -888,13 +958,37 @@ class Step_Landing_Page_Builder {
 		}
 
 		if ( $post_id <= 0 ) {
-			return new \WP_Error( 'rms_wizard_landing_save_failed', \__( 'Landing page could not be saved.', 'simple-rms-theme' ), array_merge( [ 'status' => 500 ], $log_context ) );
+			$recovered_id = $this->recover_build_page_post_id( $existing_id, (string) $row['slug'] );
+
+			if ( $recovered_id > 0 ) {
+				$this->protect_ads_final_state_best_effort( $recovered_id, $row, $log_context );
+			}
+
+			return new \WP_Error(
+				'rms_wizard_landing_save_failed',
+				\__( 'Landing page could not be saved.', 'simple-rms-theme' ),
+				array_merge(
+					[ 'status' => 500 ],
+					$log_context,
+					$recovered_id > 0 ? [ 'post_id' => $recovered_id ] : []
+				)
+			);
 		}
 
 		$meta_ok = $this->ensure_landing_meta( $post_id, (string) $row['landing_type'], $log_context );
 
 		if ( \is_wp_error( $meta_ok ) ) {
+			// Published page without verified meta — protect Ads before surfacing failure.
+			$this->protect_ads_final_state_best_effort( $post_id, $row, $log_context );
+
 			return $meta_ok;
+		}
+
+		// Final-state Yoast + robots + menu reconciliation (every create/update).
+		$final_state = $this->sync_landing_final_state( $post_id, $row, $log_context );
+
+		if ( \is_wp_error( $final_state ) ) {
+			return $final_state;
 		}
 
 		$entry = [
@@ -918,6 +1012,247 @@ class Step_Landing_Page_Builder {
 			'landing_key'    => (string) $row['landing_key'],
 			'prior_payloads' => $local_priors,
 		];
+	}
+
+	/**
+	 * Apply final-state menu + robots + Yoast title/metadesc for one landing.
+	 *
+	 * SEO: clear noindex; append to configured menus idempotently when eligible.
+	 * Ads: write noindex + read-back (fail closed); remove from configured menus.
+	 *
+	 * @param array<string,mixed> $row
+	 * @param array<string,mixed> $log_context
+	 *
+	 * @return true|\WP_Error
+	 */
+	private function sync_landing_final_state( int $post_id, array $row, array $log_context ) {
+		$landing_type    = \sanitize_key( (string) ( $row['landing_type'] ?? 'seo' ) );
+		$landing_type    = in_array( $landing_type, [ 'seo', 'ads' ], true ) ? $landing_type : 'seo';
+		$primary_keyword = (string) ( $row['primary_keyword'] ?? '' );
+		$title           = (string) ( $row['title'] ?? '' );
+		$menu_eligible   = array_key_exists( 'menu_eligible', $row )
+			? (bool) $row['menu_eligible']
+			: ( 'seo' === $landing_type );
+
+		// Optional Yoast title/metadesc (skip+log when Yoast absent — never fails the step).
+		$this->yoast_meta_writer->write_landing_seo( $post_id, $primary_keyword, $landing_type, $title );
+
+		// Robots final state.
+		if ( 'ads' === $landing_type ) {
+			$noindex = $this->yoast_meta_writer->set_noindex( $post_id, true );
+
+			if ( \is_wp_error( $noindex ) ) {
+				return $noindex;
+			}
+		} else {
+			$clear = $this->yoast_meta_writer->set_noindex( $post_id, false );
+
+			if ( \is_wp_error( $clear ) ) {
+				return $clear;
+			}
+		}
+
+		// Menu final state against currently configured theme menus.
+		$menu_ids = $this->configured_menu_ids();
+
+		if ( [] === $menu_ids ) {
+			$this->logger->log(
+				'info',
+				'Landing final-state menu sync skipped; no configured menus yet.',
+				array_merge( [ 'post_id' => $post_id, 'landing_type' => $landing_type ], $log_context )
+			);
+
+			return true;
+		}
+
+		$seo_append_failed = [];
+
+		if ( 'seo' === $landing_type && $menu_eligible ) {
+			// SEO menu append is best-effort: log failures with detail, do not fail-close.
+			// Ads menu removal below remains fail-closed.
+			foreach ( $menu_ids as $menu_id ) {
+				$append = $this->menu_builder->append_page_items( $menu_id, [ $post_id ] );
+
+				if ( empty( $append['verified'] ) ) {
+					$failed = is_array( $append['failed_page_ids'] ?? null )
+						? array_values( $append['failed_page_ids'] )
+						: [ $post_id ];
+					$seo_append_failed[] = [
+						'menu_id'         => $menu_id,
+						'failed_page_ids' => $failed,
+						'created'         => is_array( $append['created'] ?? null ) ? $append['created'] : [],
+						'already_present' => is_array( $append['already_present'] ?? null ) ? $append['already_present'] : [],
+					];
+
+					$this->logger->log(
+						'warning',
+						'Landing final-state SEO menu append failed (best-effort; step continues). Ads removal remains fail-closed.',
+						array_merge(
+							[
+								'post_id'          => $post_id,
+								'menu_id'          => $menu_id,
+								'landing_type'     => $landing_type,
+								'failed_page_ids'  => $failed,
+								'created'          => $append['created'] ?? [],
+								'already_present'  => $append['already_present'] ?? [],
+							],
+							$log_context
+						)
+					);
+				}
+			}
+		} else {
+			// Ads / ineligible: fail-closed if menu removal cannot be verified.
+			foreach ( $menu_ids as $menu_id ) {
+				$removal = $this->menu_builder->remove_page_items( $menu_id, [ $post_id ] );
+
+				if ( empty( $removal['verified'] ) ) {
+					$failed = is_array( $removal['failed_page_ids'] ?? null )
+						? array_values( $removal['failed_page_ids'] )
+						: [ $post_id ];
+
+					$this->logger->log(
+						'error',
+						'Landing final-state menu removal failed verification.',
+						array_merge(
+							[
+								'post_id'          => $post_id,
+								'menu_id'          => $menu_id,
+								'landing_type'     => $landing_type,
+								'failed_page_ids'  => $failed,
+							],
+							$log_context
+						)
+					);
+
+					return new \WP_Error(
+						'rms_wizard_landing_menu_remove_failed',
+						sprintf(
+							/* translators: %s: landing title or slug. */
+							\__( 'Landing "%s" could not be removed from menus. Final state was not applied.', 'simple-rms-theme' ),
+							'' !== $title ? $title : (string) ( $row['slug'] ?? $post_id )
+						),
+						array_merge(
+							[
+								'status'          => 500,
+								'post_id'         => $post_id,
+								'menu_id'         => $menu_id,
+								'failed_page_ids' => $failed,
+							],
+							$log_context
+						)
+					);
+				}
+			}
+		}
+
+		$this->logger->log(
+			'info',
+			'Landing final-state menu/robots sync applied.',
+			array_merge(
+				[
+					'post_id'            => $post_id,
+					'landing_type'       => $landing_type,
+					'menu_eligible'      => $menu_eligible,
+					'menu_ids'           => $menu_ids,
+					'seo_append_best_effort' => 'seo' === $landing_type && $menu_eligible,
+					'seo_append_failed'  => $seo_append_failed,
+				],
+				$log_context
+			)
+		);
+
+		return true;
+	}
+
+	/**
+	 * Best-effort Ads final-state protection after a post-publish failure.
+	 *
+	 * Does not change the caller's failure outcome — only attempts noindex + menu
+	 * removal when landing_type is ads and a post ID is known. Logs success/failure.
+	 *
+	 * @param array<string,mixed> $row
+	 * @param array<string,mixed> $log_context
+	 */
+	private function protect_ads_final_state_best_effort( int $post_id, array $row, array $log_context ): void {
+		$post_id      = \absint( $post_id );
+		$landing_type = \sanitize_key( (string) ( $row['landing_type'] ?? 'seo' ) );
+		$landing_type = in_array( $landing_type, [ 'seo', 'ads' ], true ) ? $landing_type : 'seo';
+		$landing_key  = (string) ( $row['landing_key'] ?? ( $log_context['landing_key'] ?? '' ) );
+		$slug         = (string) ( $row['slug'] ?? ( $log_context['slug'] ?? '' ) );
+
+		if ( $post_id <= 0 || 'ads' !== $landing_type ) {
+			return;
+		}
+
+		// Ensure Ads path in sync (menu_eligible false).
+		$protection_row                   = $row;
+		$protection_row['landing_type']   = 'ads';
+		$protection_row['menu_eligible']  = false;
+
+		$protection = $this->sync_landing_final_state( $post_id, $protection_row, $log_context );
+		$ok         = ! \is_wp_error( $protection );
+
+		$this->logger->log(
+			$ok ? 'info' : 'error',
+			$ok
+				? 'Ads best-effort final-state protection succeeded after build failure.'
+				: 'Ads best-effort final-state protection failed after build failure.',
+			array_merge(
+				[
+					'post_id'           => $post_id,
+					'landing_key'       => $landing_key,
+					'slug'              => $slug,
+					'protection_ok'     => $ok,
+					'protection_error'  => $ok ? null : $protection->get_error_code(),
+					'protection_message'=> $ok ? null : $protection->get_error_message(),
+				],
+				$log_context
+			)
+		);
+	}
+
+	/**
+	 * Menu term IDs currently assigned to theme locations / stored menu_config.
+	 *
+	 * @return array<int,int>
+	 */
+	private function configured_menu_ids(): array {
+		$ids   = [];
+		$state = $this->state_manager->get_state();
+		$config = is_array( $state['menu_config'] ?? null ) ? $state['menu_config'] : [];
+
+		foreach ( [ 'primary_menu_id', 'mobile_menu_id' ] as $key ) {
+			$id = \absint( $config[ $key ] ?? 0 );
+
+			if ( $id > 0 ) {
+				$ids[] = $id;
+			}
+		}
+
+		if ( is_array( $config['locations'] ?? null ) ) {
+			foreach ( $config['locations'] as $menu_id ) {
+				$id = \absint( $menu_id );
+
+				if ( $id > 0 ) {
+					$ids[] = $id;
+				}
+			}
+		}
+
+		$locations = \get_theme_mod( 'nav_menu_locations', [] );
+
+		if ( is_array( $locations ) ) {
+			foreach ( $locations as $menu_id ) {
+				$id = \absint( $menu_id );
+
+				if ( $id > 0 ) {
+					$ids[] = $id;
+				}
+			}
+		}
+
+		return array_values( array_unique( array_filter( $ids ) ) );
 	}
 
 	/**
@@ -1857,6 +2192,9 @@ class Step_Landing_Page_Builder {
 				)
 			);
 
+			// Best-effort Ads protection before returning the original preserve failure.
+			$this->protect_ads_final_state_best_effort( $existing_id, $row, $log_context );
+
 			return new \WP_Error(
 				'rms_wizard_landing_preserve_failed',
 				\__( 'Keyword generation failed and the existing landing page could not be preserved.', 'simple-rms-theme' ),
@@ -1884,6 +2222,9 @@ class Step_Landing_Page_Builder {
 					]
 				)
 			);
+
+			// Best-effort Ads protection before returning the original preserve failure.
+			$this->protect_ads_final_state_best_effort( $existing_id, $row, $log_context );
 
 			return new \WP_Error(
 				'rms_wizard_landing_preserve_failed',
@@ -1915,7 +2256,17 @@ class Step_Landing_Page_Builder {
 				)
 			);
 
+			// Best-effort Ads protection before returning the original meta failure.
+			$this->protect_ads_final_state_best_effort( $existing_id, $row, $log_context );
+
 			return $meta_ok;
+		}
+
+		// Type flips / robots / menu still reconcile even when sections are preserved.
+		$final_state = $this->sync_landing_final_state( $existing_id, $row, $log_context );
+
+		if ( \is_wp_error( $final_state ) ) {
+			return $final_state;
 		}
 
 		$entry = [

--- a/inc/wizard/class-step-menu-setup.php
+++ b/inc/wizard/class-step-menu-setup.php
@@ -35,8 +35,14 @@ class Step_Menu_Setup {
 	public function run( array $payload ) {
 		$state           = $this->state_manager->get_state();
 		$generated_pages = is_array( $state['generated_pages'] ?? null ) ? $state['generated_pages'] : [];
+		$landing_pages   = is_array( $state['landing_pages'] ?? null ) ? $state['landing_pages'] : [];
 
-		if ( [] === $generated_pages ) {
+		// Pool may come from generated_pages and/or menu-eligible SEO landings.
+		// Do not fail solely because generated_pages is empty when landings exist.
+		// Ads remain excluded from the pool.
+		$page_pool = $this->build_page_pool( $generated_pages, $landing_pages );
+
+		if ( [] === $page_pool ) {
 			$this->state_manager->set_step_status( self::STEP, 'failed' );
 
 			return new \WP_Error( 'rms_wizard_no_generated_pages', \__( 'No pages found. Please complete the Generate Pages step first', 'simple-rms-theme' ), [ 'status' => 400 ] );
@@ -44,8 +50,8 @@ class Step_Menu_Setup {
 
 		$primary_input    = is_array( $payload['primary'] ?? null ) ? $payload['primary'] : ( is_array( $payload['primary_page_ids'] ?? null ) ? $payload['primary_page_ids'] : [] );
 		$mobile_input     = is_array( $payload['mobile'] ?? null ) ? $payload['mobile'] : ( is_array( $payload['mobile_page_ids'] ?? null ) ? $payload['mobile_page_ids'] : [] );
-		$primary_page_ids = $this->resolve_page_ids( $primary_input, $generated_pages );
-		$mobile_page_ids  = $this->resolve_page_ids( $mobile_input, $generated_pages );
+		$primary_page_ids = $this->resolve_page_ids( $primary_input, $page_pool );
+		$mobile_page_ids  = $this->resolve_page_ids( $mobile_input, $page_pool );
 
 		if ( [] === $primary_page_ids ) {
 			$this->state_manager->set_step_status( self::STEP, 'failed' );
@@ -89,11 +95,70 @@ class Step_Menu_Setup {
 
 		$this->menu_builder->assign_location( 'mobile', $mobile_menu_id );
 
+		// Mandatory safety net after destructive replace: eligible SEO present, Ads removed.
+		$configured_menu_ids = array_values(
+			array_unique(
+				array_filter(
+					[
+						$primary_menu_id,
+						$mobile_menu_id,
+					]
+				)
+			)
+		);
+		$landing_reconcile = $this->menu_builder->reconcile_landing_menu_items( $configured_menu_ids, $landing_pages );
+
+		// Fail-closed when Ads / ineligible landings could not be verified removed.
+		if ( empty( $landing_reconcile['verified'] ) ) {
+			$failed = is_array( $landing_reconcile['removal_failed_page_ids'] ?? null )
+				? array_values( $landing_reconcile['removal_failed_page_ids'] )
+				: [];
+
+			$this->state_manager->set_step_status( self::STEP, 'failed' );
+			$this->logger->log(
+				'error',
+				'Menu setup landing reconciliation failed Ads/ineligible removal verification.',
+				[
+					'menu_ids'                 => $configured_menu_ids,
+					'removal_failed_page_ids'  => $failed,
+					'landing_reconcile'        => $landing_reconcile,
+				]
+			);
+
+			return new \WP_Error(
+				'rms_wizard_menu_ads_removal_failed',
+				\__( 'Menu setup could not verify removal of Ads or ineligible landing pages from menus.', 'simple-rms-theme' ),
+				[
+					'status'                  => 500,
+					'removal_failed_page_ids' => $failed,
+					'landing_reconcile'       => $landing_reconcile,
+				]
+			);
+		}
+
+		// SEO append is best-effort: surface incomplete appends without failing the step.
+		$append_failed = is_array( $landing_reconcile['append_failed_page_ids'] ?? null )
+			? array_values( $landing_reconcile['append_failed_page_ids'] )
+			: [];
+
+		if ( [] !== $append_failed ) {
+			$this->logger->log(
+				'warning',
+				'Menu setup SEO landing menu append incomplete (best-effort; Ads removal verified).',
+				[
+					'menu_ids'               => $configured_menu_ids,
+					'append_failed_page_ids' => $append_failed,
+					'landing_reconcile'      => $landing_reconcile,
+				]
+			);
+		}
+
 		$menu_config = [
-			'primary_menu_id'  => $primary_menu_id,
-			'mobile_menu_id'   => $mobile_menu_id,
-			'locations'        => [ 'primary' => $primary_menu_id, 'mobile' => $mobile_menu_id ],
-			'deleted_menu_ids' => $deleted_menu_ids,
+			'primary_menu_id'    => $primary_menu_id,
+			'mobile_menu_id'     => $mobile_menu_id,
+			'locations'          => [ 'primary' => $primary_menu_id, 'mobile' => $mobile_menu_id ],
+			'deleted_menu_ids'   => $deleted_menu_ids,
+			'landing_reconcile'  => $landing_reconcile,
 		];
 
 		$state['menu_config'] = $menu_config;
@@ -104,8 +169,18 @@ class Step_Menu_Setup {
 		return $menu_config;
 	}
 
-	private function resolve_page_ids( array $selected, array $generated_pages ): array {
-		$generated = [];
+	/**
+	 * Build id/slug lookup from generated pages + menu-eligible SEO landings.
+	 *
+	 * Ads / menu_eligible=false landings are never added to the pool.
+	 *
+	 * @param array<int,array<string,mixed>> $generated_pages
+	 * @param array<int,array<string,mixed>> $landing_pages
+	 *
+	 * @return array<string,int>
+	 */
+	private function build_page_pool( array $generated_pages, array $landing_pages ): array {
+		$pool = [];
 
 		foreach ( $generated_pages as $page ) {
 			if ( ! is_array( $page ) || empty( $page['id'] ) ) {
@@ -118,20 +193,57 @@ class Step_Menu_Setup {
 				continue;
 			}
 
-			$generated[ (string) $id ] = $id;
+			$pool[ (string) $id ] = $id;
 
 			if ( ! empty( $page['slug'] ) ) {
-				$generated[ \sanitize_title( (string) $page['slug'] ) ] = $id;
+				$pool[ \sanitize_title( (string) $page['slug'] ) ] = $id;
 			}
 		}
 
+		foreach ( $landing_pages as $landing ) {
+			if ( ! is_array( $landing ) || empty( $landing['id'] ) ) {
+				continue;
+			}
+
+			$id   = \absint( $landing['id'] );
+			$type = \sanitize_key( (string) ( $landing['landing_type'] ?? '' ) );
+			$eligible = array_key_exists( 'menu_eligible', $landing )
+				? (bool) $landing['menu_eligible']
+				: ( 'seo' === $type );
+
+			// Ads and ineligible landings must never join the menu pool.
+			if ( $id <= 0 || 'seo' !== $type || ! $eligible ) {
+				continue;
+			}
+
+			if ( 'page' !== \get_post_type( $id ) ) {
+				continue;
+			}
+
+			$pool[ (string) $id ] = $id;
+
+			if ( ! empty( $landing['slug'] ) ) {
+				$pool[ \sanitize_title( (string) $landing['slug'] ) ] = $id;
+			}
+		}
+
+		return $pool;
+	}
+
+	/**
+	 * @param array<int|string,mixed> $selected
+	 * @param array<string,int>       $pool
+	 *
+	 * @return array<int,int>
+	 */
+	private function resolve_page_ids( array $selected, array $pool ): array {
 		$page_ids = [];
 
 		foreach ( $selected as $item ) {
 			$key = is_numeric( $item ) ? (string) \absint( $item ) : \sanitize_title( (string) $item );
 
-			if ( isset( $generated[ $key ] ) && ! in_array( $generated[ $key ], $page_ids, true ) ) {
-				$page_ids[] = $generated[ $key ];
+			if ( isset( $pool[ $key ] ) && ! in_array( $pool[ $key ], $page_ids, true ) ) {
+				$page_ids[] = $pool[ $key ];
 			}
 		}
 

--- a/inc/wizard/class-wizard-unlock-controller.php
+++ b/inc/wizard/class-wizard-unlock-controller.php
@@ -1,0 +1,266 @@
+<?php
+/**
+ * Controlled unlock controller for completed wizard sites.
+ *
+ * @package Simple_RMS_Theme
+ */
+
+namespace Inc\Wizard;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Reversibly re-opens a completed wizard without destroying completion state.
+ */
+class Wizard_Unlock_Controller {
+	public const UNLOCKED_AT_OPTION = 'rms_wizard_unlocked_at';
+	public const UNLOCKED_BY_OPTION = 'rms_wizard_unlocked_by';
+	public const NONCE_ACTION       = 'rms_wizard_controlled_unlock';
+	public const UNLOCK_ACTION      = 'rms_wizard_unlock';
+	public const RELOCK_ACTION      = 'rms_wizard_relock';
+
+	/**
+	 * Whether user-facing controlled unlock is enabled.
+	 *
+	 * TODO(Phase 2 task 2.6): set true when the generate-pages landing deletion guard ships.
+	 */
+	public const CONTROLLED_UNLOCK_ENABLED = false;
+
+	private $state_manager;
+	private $logger;
+
+	public function __construct( ?State_Manager $state_manager = null, ?Logger $logger = null ) {
+		$this->state_manager = $state_manager ?? new State_Manager();
+		$this->logger        = $logger ?? new Logger();
+	}
+
+	/**
+	 * Whether user-facing controlled unlock UI/actions are available.
+	 */
+	public static function is_controlled_unlock_enabled(): bool {
+		return true === self::CONTROLLED_UNLOCK_ENABLED;
+	}
+
+	/**
+	 * Whether RMS_WIZARD_FORCE bypasses the completed lock.
+	 */
+	public static function is_force_unlocked(): bool {
+		return \defined( 'RMS_WIZARD_FORCE' ) && true === \RMS_WIZARD_FORCE;
+	}
+
+	/**
+	 * Whether a stored unlock marker exists (raw option presence).
+	 *
+	 * Used for relock cleanup of stale markers. Does not imply an effective unlock.
+	 */
+	public static function has_unlock_marker(): bool {
+		$unlocked_at = \get_option( self::UNLOCKED_AT_OPTION, '' );
+
+		return is_string( $unlocked_at ) && '' !== $unlocked_at;
+	}
+
+	/**
+	 * Whether unlock effectively bypasses the completed lock.
+	 *
+	 * Ignores stale/manual `rms_wizard_unlocked_at` while controlled unlock is disabled.
+	 * `RMS_WIZARD_FORCE` is handled separately via `is_force_unlocked()` / callers.
+	 */
+	public static function is_unlocked(): bool {
+		if ( ! self::is_controlled_unlock_enabled() ) {
+			return false;
+		}
+
+		return self::has_unlock_marker();
+	}
+
+	/**
+	 * Unlock a completed wizard for editing.
+	 *
+	 * Does not modify `rms_wizard_completed` or other wizard state.
+	 * Inactive while CONTROLLED_UNLOCK_ENABLED is false (REST/admin both hit this gate).
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function unlock() {
+		if ( ! \current_user_can( 'manage_options' ) ) {
+			return new \WP_Error(
+				'rms_wizard_forbidden',
+				\__( 'You do not have permission to unlock the setup wizard.', 'simple-rms-theme' ),
+				[ 'status' => 403 ]
+			);
+		}
+
+		if ( ! self::is_controlled_unlock_enabled() ) {
+			return new \WP_Error(
+				'rms_wizard_unlock_unavailable',
+				\__( 'Controlled unlock is not available until landing page protection is enabled.', 'simple-rms-theme' ),
+				[ 'status' => 503 ]
+			);
+		}
+
+		// State_Manager is the single source of truth for the completion flag.
+		if ( ! $this->state_manager->has_completion_flag() ) {
+			return new \WP_Error(
+				'rms_wizard_not_completed',
+				\__( 'The setup wizard is not completed, so unlock is not required.', 'simple-rms-theme' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		if ( self::has_unlock_marker() ) {
+			return [
+				'success'     => true,
+				'action'      => 'unlock',
+				'already'     => true,
+				'unlocked_at' => (string) \get_option( self::UNLOCKED_AT_OPTION, '' ),
+				'unlocked_by' => (int) \get_option( self::UNLOCKED_BY_OPTION, 0 ),
+				'completed'   => true,
+			];
+		}
+
+		$unlocked_at = \current_time( 'mysql', true );
+		$user_id     = (int) \get_current_user_id();
+
+		\update_option( self::UNLOCKED_AT_OPTION, $unlocked_at, false );
+		\update_option( self::UNLOCKED_BY_OPTION, $user_id, false );
+
+		// Post-state is authoritative: update_option() can return false for identical values.
+		$persisted_at = (string) \get_option( self::UNLOCKED_AT_OPTION, '' );
+		$persisted_by = (int) \get_option( self::UNLOCKED_BY_OPTION, 0 );
+		$at_ok        = $persisted_at === $unlocked_at;
+		$by_ok        = $persisted_by === $user_id;
+
+		if ( ! $at_ok || ! $by_ok || ! self::has_unlock_marker() ) {
+			$this->logger->log(
+				'error',
+				'Unlock persistence failed; rolling back partial unlock markers.',
+				[
+					'expected_at'  => $unlocked_at,
+					'expected_by'  => $user_id,
+					'persisted_at' => $persisted_at,
+					'persisted_by' => $persisted_by,
+					'at_ok'        => $at_ok,
+					'by_ok'        => $by_ok,
+				]
+			);
+
+			// Best-effort rollback so a partial write does not look unlocked.
+			\delete_option( self::UNLOCKED_AT_OPTION );
+			\delete_option( self::UNLOCKED_BY_OPTION );
+
+			if ( self::has_unlock_marker() ) {
+				$this->logger->log(
+					'error',
+					'Unlock rollback left a residual unlock marker.',
+					[
+						'unlocked_at' => (string) \get_option( self::UNLOCKED_AT_OPTION, '' ),
+						'unlocked_by' => (int) \get_option( self::UNLOCKED_BY_OPTION, 0 ),
+					]
+				);
+			}
+
+			return new \WP_Error(
+				'rms_wizard_unlock_persist_failed',
+				\__( 'The setup wizard could not be unlocked because the unlock state failed to persist.', 'simple-rms-theme' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		$this->logger->log(
+			'info',
+			'Setup wizard unlocked for editing.',
+			[
+				'unlocked_at' => $persisted_at,
+				'unlocked_by' => $persisted_by,
+			]
+		);
+
+		return [
+			'success'     => true,
+			'action'      => 'unlock',
+			'already'     => false,
+			'unlocked_at' => $persisted_at,
+			'unlocked_by' => $persisted_by,
+			'completed'   => true,
+		];
+	}
+
+	/**
+	 * Restore read-only state without destroying completion.
+	 *
+	 * Allowed while controlled unlock is disabled so stale markers can be cleared.
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function relock() {
+		if ( ! \current_user_can( 'manage_options' ) ) {
+			return new \WP_Error(
+				'rms_wizard_forbidden',
+				\__( 'You do not have permission to re-lock the setup wizard.', 'simple-rms-theme' ),
+				[ 'status' => 403 ]
+			);
+		}
+
+		// State_Manager is the single source of truth for the completion flag.
+		if ( ! $this->state_manager->has_completion_flag() ) {
+			return new \WP_Error(
+				'rms_wizard_not_completed',
+				\__( 'The setup wizard is not completed, so re-lock is not applicable.', 'simple-rms-theme' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		// Clear stale markers even when controlled unlock is disabled.
+		$had_marker = self::has_unlock_marker();
+
+		if ( $had_marker ) {
+			\delete_option( self::UNLOCKED_AT_OPTION );
+			\delete_option( self::UNLOCKED_BY_OPTION );
+		}
+
+		// Confirm next request would no longer see a stored unlock marker.
+		if ( self::has_unlock_marker() ) {
+			$this->logger->log(
+				'error',
+				'Relock persistence failed; unlock marker still present after delete_option.',
+				[
+					'unlocked_at' => (string) \get_option( self::UNLOCKED_AT_OPTION, '' ),
+					'unlocked_by' => (int) \get_option( self::UNLOCKED_BY_OPTION, 0 ),
+					'user_id'     => (int) \get_current_user_id(),
+				]
+			);
+
+			return new \WP_Error(
+				'rms_wizard_relock_persist_failed',
+				\__( 'The setup wizard could not be re-locked because the unlock state failed to clear.', 'simple-rms-theme' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		if ( $had_marker ) {
+			$this->logger->log(
+				'info',
+				'Setup wizard re-locked.',
+				[
+					'was_unlocked' => true,
+					'user_id'      => (int) \get_current_user_id(),
+				]
+			);
+		}
+
+		return [
+			'success'   => true,
+			'action'    => 'relock',
+			'already'   => ! $had_marker,
+			'completed' => true,
+			'locked'    => true,
+		];
+	}
+
+	/**
+	 * Verify a nonce for admin unlock/relock form posts.
+	 */
+	public static function verify_admin_nonce( string $nonce ): bool {
+		return (bool) \wp_verify_nonce( $nonce, self::NONCE_ACTION );
+	}
+}

--- a/inc/wizard/class-wizard-unlock-controller.php
+++ b/inc/wizard/class-wizard-unlock-controller.php
@@ -22,9 +22,9 @@ class Wizard_Unlock_Controller {
 	/**
 	 * Whether user-facing controlled unlock is enabled.
 	 *
-	 * TODO(Phase 2 task 2.6): set true when the generate-pages landing deletion guard ships.
+	 * Enabled together with the generate-pages landing deletion guard (Phase 2 task 2.6).
 	 */
-	public const CONTROLLED_UNLOCK_ENABLED = false;
+	public const CONTROLLED_UNLOCK_ENABLED = true;
 
 	private $state_manager;
 	private $logger;

--- a/inc/wizard/class-yoast-meta-writer.php
+++ b/inc/wizard/class-yoast-meta-writer.php
@@ -10,16 +10,46 @@ namespace Inc\Wizard;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Writes Yoast SEO title and description meta to generated pages.
+ * Writes Yoast SEO title, description, and robots meta for wizard pages.
  */
 class Yoast_Meta_Writer {
 	public const TITLE_KEY       = '_yoast_wpseo_title';
 	public const DESCRIPTION_KEY = '_yoast_wpseo_metadesc';
+	public const NOINDEX_KEY     = '_yoast_wpseo_meta-robots-noindex';
+
+	/** Common SERP-friendly max length for SEO titles. */
+	public const TITLE_MAX_LENGTH = 60;
+
+	/** Common SERP-friendly max length for meta descriptions. */
+	public const DESCRIPTION_MAX_LENGTH = 155;
 
 	private $logger;
 
+	/** @var bool Whether missing-Yoast was already logged this request. */
+	private static $missing_yoast_logged = false;
+
 	public function __construct( ?Logger $logger = null ) {
 		$this->logger = $logger ?? new Logger();
+	}
+
+	/**
+	 * Whether Yoast SEO appears active for optional title/metadesc writes.
+	 */
+	public static function is_yoast_active(): bool {
+		if ( defined( 'WPSEO_VERSION' ) ) {
+			return true;
+		}
+
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			$plugin_php = \ABSPATH . 'wp-admin/includes/plugin.php';
+
+			if ( is_readable( $plugin_php ) ) {
+				require_once $plugin_php;
+			}
+		}
+
+		// Yoast package slug is wordpress-seo/wp-seo.php.
+		return function_exists( 'is_plugin_active' ) && \is_plugin_active( 'wordpress-seo/wp-seo.php' );
 	}
 
 	/**
@@ -48,5 +78,174 @@ class Yoast_Meta_Writer {
 		$this->logger->log( $written ? 'info' : 'warning', $written ? 'Yoast metadata written.' : 'No Yoast metadata values supplied.', [ 'post_id' => $post_id ] );
 
 		return $written;
+	}
+
+	/**
+	 * Write per-landing Yoast title/metadesc from keyword + type when Yoast is active.
+	 *
+	 * When Yoast is absent, skips title/metadesc writes and logs once per request.
+	 *
+	 * @param int    $post_id         Landing page ID.
+	 * @param string $primary_keyword Primary keyword.
+	 * @param string $landing_type    seo|ads.
+	 * @param string $title           Optional page title for fallback copy.
+	 *
+	 * @return bool True when title/metadesc were written.
+	 */
+	public function write_landing_seo( int $post_id, string $primary_keyword, string $landing_type, string $title = '' ): bool {
+		$post_id         = \absint( $post_id );
+		$primary_keyword = \sanitize_text_field( $primary_keyword );
+		$landing_type    = in_array( $landing_type, [ 'seo', 'ads' ], true ) ? $landing_type : 'seo';
+		$title           = \sanitize_text_field( $title );
+
+		if ( $post_id <= 0 || '' === $primary_keyword ) {
+			return false;
+		}
+
+		if ( ! self::is_yoast_active() ) {
+			if ( ! self::$missing_yoast_logged ) {
+				$this->logger->log(
+					'info',
+					'Yoast SEO is not active; skipping landing title/metadesc writes.',
+					[ 'post_id' => $post_id ]
+				);
+				self::$missing_yoast_logged = true;
+			}
+
+			return false;
+		}
+
+		$company = '';
+
+		if ( function_exists( 'get_field' ) ) {
+			$company = \sanitize_text_field( (string) \get_field( 'company_name', 'option' ) );
+		}
+
+		if ( '' === $company ) {
+			$company = \sanitize_text_field( (string) \get_bloginfo( 'name' ) );
+		}
+
+		$suffix = 'ads' === $landing_type
+			? \__( 'Get a free estimate', 'simple-rms-theme' )
+			: \__( 'Trusted local experts', 'simple-rms-theme' );
+
+		$meta_title = trim(
+			sprintf(
+				/* translators: 1: primary keyword, 2: company or site name. */
+				\__( '%1$s | %2$s', 'simple-rms-theme' ),
+				$primary_keyword,
+				'' !== $company ? $company : ( '' !== $title ? $title : \get_bloginfo( 'name' ) )
+			)
+		);
+
+		$meta_desc = trim(
+			sprintf(
+				/* translators: 1: primary keyword, 2: short CTA/trust phrase, 3: company name. */
+				\__( 'Learn about %1$s. %2$s%3$s', 'simple-rms-theme' ),
+				$primary_keyword,
+				$suffix,
+				'' !== $company ? ' — ' . $company : ''
+			)
+		);
+
+		// Keep within common SERP-friendly bounds.
+		if ( function_exists( 'mb_substr' ) ) {
+			$meta_title = \mb_substr( $meta_title, 0, self::TITLE_MAX_LENGTH );
+			$meta_desc  = \mb_substr( $meta_desc, 0, self::DESCRIPTION_MAX_LENGTH );
+		} else {
+			$meta_title = substr( $meta_title, 0, self::TITLE_MAX_LENGTH );
+			$meta_desc  = substr( $meta_desc, 0, self::DESCRIPTION_MAX_LENGTH );
+		}
+
+		return $this->write(
+			$post_id,
+			[
+				'title'       => $meta_title,
+				'description' => $meta_desc,
+			]
+		);
+	}
+
+	/**
+	 * Set or clear Ads noindex meta and verify read-back.
+	 *
+	 * Always writes the Yoast noindex post meta key (storage), independent of Yoast being active.
+	 * wp_robots in wizard-init.php provides the second protection layer for Ads landings.
+	 *
+	 * @param int  $post_id  Landing page ID.
+	 * @param bool $noindex  True to force noindex=1, false to clear.
+	 *
+	 * @return true|\WP_Error
+	 */
+	public function set_noindex( int $post_id, bool $noindex ) {
+		$post_id = \absint( $post_id );
+
+		if ( $post_id <= 0 ) {
+			return new \WP_Error(
+				'rms_wizard_noindex_invalid_post',
+				\__( 'Invalid landing page for noindex sync.', 'simple-rms-theme' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		if ( $noindex ) {
+			\update_post_meta( $post_id, self::NOINDEX_KEY, '1' );
+			$read_back = (string) \get_post_meta( $post_id, self::NOINDEX_KEY, true );
+
+			if ( '1' !== $read_back ) {
+				$this->logger->log(
+					'error',
+					'Ads landing noindex meta failed read-back.',
+					[
+						'post_id'   => $post_id,
+						'read_back' => $read_back,
+					]
+				);
+
+				return new \WP_Error(
+					'rms_wizard_ads_noindex_failed',
+					\__( 'Ads landing noindex meta could not be verified. The landing was not marked complete.', 'simple-rms-theme' ),
+					[
+						'status'  => 500,
+						'post_id' => $post_id,
+					]
+				);
+			}
+
+			$this->logger->log( 'info', 'Ads landing noindex meta written and verified.', [ 'post_id' => $post_id ] );
+
+			return true;
+		}
+
+		\delete_post_meta( $post_id, self::NOINDEX_KEY );
+		$read_back = (string) \get_post_meta( $post_id, self::NOINDEX_KEY, true );
+
+		if ( '1' === $read_back ) {
+			$this->logger->log(
+				'error',
+				'SEO landing noindex meta could not be cleared.',
+				[ 'post_id' => $post_id ]
+			);
+
+			return new \WP_Error(
+				'rms_wizard_seo_noindex_clear_failed',
+				\__( 'SEO landing noindex meta could not be cleared.', 'simple-rms-theme' ),
+				[
+					'status'  => 500,
+					'post_id' => $post_id,
+				]
+			);
+		}
+
+		$this->logger->log( 'info', 'SEO landing noindex meta cleared.', [ 'post_id' => $post_id ] );
+
+		return true;
+	}
+
+	/**
+	 * Read whether noindex meta is currently set to 1.
+	 */
+	public function has_noindex( int $post_id ): bool {
+		return '1' === (string) \get_post_meta( \absint( $post_id ), self::NOINDEX_KEY, true );
 	}
 }

--- a/inc/wizard/wizard-init.php
+++ b/inc/wizard/wizard-init.php
@@ -94,6 +94,89 @@ add_action(
 	}
 );
 
+// Unlock admin-post is inactive until CONTROLLED_UNLOCK_ENABLED flips (Phase 2 task 2.6).
+// Relock stays registered so stale unlock markers can still be cleared.
+if ( Inc\Wizard\Wizard_Unlock_Controller::is_controlled_unlock_enabled() ) {
+	add_action( 'admin_post_' . Inc\Wizard\Wizard_Unlock_Controller::UNLOCK_ACTION, 'rms_wizard_handle_unlock_action' );
+}
+add_action( 'admin_post_' . Inc\Wizard\Wizard_Unlock_Controller::RELOCK_ACTION, 'rms_wizard_handle_relock_action' );
+
+/**
+ * Handle controlled unlock form posts from the Setup Wizard admin notice.
+ *
+ * Registered only while controlled unlock is enabled. REST still routes unlock
+ * through Step_Controller → Wizard_Unlock_Controller::unlock(), which returns
+ * 503 while the feature is disabled.
+ *
+ * @return void
+ */
+function rms_wizard_handle_unlock_action(): void {
+	if ( ! Inc\Wizard\Wizard_Unlock_Controller::is_controlled_unlock_enabled() ) {
+		wp_die( esc_html__( 'Controlled unlock is not available until landing page protection is enabled.', 'simple-rms-theme' ) );
+	}
+
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_die( esc_html__( 'You do not have permission to unlock the setup wizard.', 'simple-rms-theme' ) );
+	}
+
+	$nonce = isset( $_POST['_wpnonce'] ) ? sanitize_text_field( wp_unslash( (string) $_POST['_wpnonce'] ) ) : '';
+
+	if ( ! Inc\Wizard\Wizard_Unlock_Controller::verify_admin_nonce( $nonce ) ) {
+		wp_die( esc_html__( 'Invalid unlock request. Please try again.', 'simple-rms-theme' ) );
+	}
+
+	$result = ( new Inc\Wizard\Wizard_Unlock_Controller() )->unlock();
+
+	if ( is_wp_error( $result ) ) {
+		wp_die( esc_html( $result->get_error_message() ) );
+	}
+
+	wp_safe_redirect(
+		add_query_arg(
+			[
+				'page'                => 'rms-setup-wizard',
+				'rms_wizard_unlocked' => '1',
+			],
+			admin_url( 'themes.php' )
+		)
+	);
+	exit;
+}
+
+/**
+ * Handle controlled re-lock form posts from the Setup Wizard admin notice.
+ *
+ * @return void
+ */
+function rms_wizard_handle_relock_action(): void {
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_die( esc_html__( 'You do not have permission to re-lock the setup wizard.', 'simple-rms-theme' ) );
+	}
+
+	$nonce = isset( $_POST['_wpnonce'] ) ? sanitize_text_field( wp_unslash( (string) $_POST['_wpnonce'] ) ) : '';
+
+	if ( ! Inc\Wizard\Wizard_Unlock_Controller::verify_admin_nonce( $nonce ) ) {
+		wp_die( esc_html__( 'Invalid re-lock request. Please try again.', 'simple-rms-theme' ) );
+	}
+
+	$result = ( new Inc\Wizard\Wizard_Unlock_Controller() )->relock();
+
+	if ( is_wp_error( $result ) ) {
+		wp_die( esc_html( $result->get_error_message() ) );
+	}
+
+	wp_safe_redirect(
+		add_query_arg(
+			[
+				'page'              => 'rms-setup-wizard',
+				'rms_wizard_relocked' => '1',
+			],
+			admin_url( 'themes.php' )
+		)
+	);
+	exit;
+}
+
 /**
  * Render the setup wizard admin UI.
  *
@@ -104,10 +187,16 @@ function rms_wizard_render_admin_page(): void {
 		wp_die( esc_html__( 'You do not have permission to access the setup wizard.', 'simple-rms-theme' ) );
 	}
 
-	$controller = new Inc\Wizard\Step_Controller();
-	$state      = $controller->get_resume_state();
-	$locked     = ! empty( $state['locked'] );
-	$steps      = [
+	$controller         = new Inc\Wizard\Step_Controller();
+	$state              = $controller->get_resume_state();
+	// Trust resume-state flags from Step_Controller (single source of truth).
+	$locked             = ! empty( $state['locked'] );
+	$completed_flag     = ! empty( $state['completed_flag'] );
+	$is_unlocked        = ! empty( $state['unlocked'] );
+	$has_unlock_marker  = ! empty( $state['has_unlock_marker'] );
+	$force_unlocked     = ! empty( $state['force_unlocked'] );
+	$unlock_ui_enabled  = ! empty( $state['controlled_unlock_ui'] );
+	$steps              = [
 		'dependencies'      => __( 'Dependencies', 'simple-rms-theme' ),
 		'acf-import'        => __( 'ACF Import', 'simple-rms-theme' ),
 		'client-data'       => __( 'Client Data', 'simple-rms-theme' ),
@@ -135,9 +224,64 @@ function rms_wizard_render_admin_page(): void {
 		data-rms-wizard-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>"
 	>
 		<h1><?php esc_html_e( 'Setup Wizard', 'simple-rms-theme' ); ?></h1>
-		<?php if ( $locked ) : ?>
-			<div class="notice notice-success inline">
-				<p><?php esc_html_e( 'The setup wizard has already been completed. Define RMS_WIZARD_FORCE as true to run it again in development.', 'simple-rms-theme' ); ?></p>
+		<?php if ( $unlock_ui_enabled && ! empty( $_GET['rms_wizard_unlocked'] ) ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended ?>
+			<div class="notice notice-success is-dismissible">
+				<p><?php esc_html_e( 'Setup wizard unlocked for editing. Completion state was preserved.', 'simple-rms-theme' ); ?></p>
+			</div>
+		<?php endif; ?>
+		<?php /* Relock success can happen for stale-marker cleanup while unlock UI is still disabled. */ ?>
+		<?php if ( ! empty( $_GET['rms_wizard_relocked'] ) ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended ?>
+			<div class="notice notice-success is-dismissible">
+				<p><?php esc_html_e( 'Setup wizard re-locked. The site is read-only again.', 'simple-rms-theme' ); ?></p>
+			</div>
+		<?php endif; ?>
+		<?php if ( $force_unlocked ) : ?>
+			<div class="notice notice-info inline rms-wizard-controlled-unlock" data-wizard-controlled-unlock="force">
+				<p>
+					<?php esc_html_e( 'The setup wizard is force-unlocked via RMS_WIZARD_FORCE. Completion state is ignored for editing in this environment.', 'simple-rms-theme' ); ?>
+				</p>
+			</div>
+		<?php elseif ( $completed_flag && $has_unlock_marker ) : ?>
+			<?php /* Relock clears markers even when controlled unlock is disabled (stale cleanup). */ ?>
+			<div class="notice notice-warning inline rms-wizard-controlled-unlock" data-wizard-controlled-unlock="relock">
+				<p>
+					<?php
+					echo esc_html(
+						$is_unlocked
+							? __( 'The setup wizard is unlocked for editing. Completion state is preserved. Re-lock when you are finished to restore read-only mode.', 'simple-rms-theme' )
+							: __( 'A leftover unlock marker was found while controlled unlock is disabled. Re-lock to clear it and keep the wizard read-only.', 'simple-rms-theme' )
+					);
+					?>
+				</p>
+				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="rms-wizard-controlled-unlock__form">
+					<input type="hidden" name="action" value="<?php echo esc_attr( Inc\Wizard\Wizard_Unlock_Controller::RELOCK_ACTION ); ?>">
+					<?php wp_nonce_field( Inc\Wizard\Wizard_Unlock_Controller::NONCE_ACTION ); ?>
+					<?php submit_button( __( 'Re-lock wizard', 'simple-rms-theme' ), 'secondary', 'submit', false ); ?>
+				</form>
+			</div>
+		<?php elseif ( $unlock_ui_enabled && ( $locked || ( $completed_flag && ! $is_unlocked ) ) ) : ?>
+			<?php /* Unlock form is gated; admin-post handler is registered only when enabled. */ ?>
+			<div class="notice notice-success inline rms-wizard-controlled-unlock" data-wizard-controlled-unlock="unlock">
+				<p>
+					<?php esc_html_e( 'The setup wizard has already been completed and is read-only. Unlock it to make non-destructive edits without resetting completion state.', 'simple-rms-theme' ); ?>
+				</p>
+				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="rms-wizard-controlled-unlock__form">
+					<input type="hidden" name="action" value="<?php echo esc_attr( Inc\Wizard\Wizard_Unlock_Controller::UNLOCK_ACTION ); ?>">
+					<?php wp_nonce_field( Inc\Wizard\Wizard_Unlock_Controller::NONCE_ACTION ); ?>
+					<?php submit_button( __( 'Unlock wizard for editing', 'simple-rms-theme' ), 'primary', 'submit', false ); ?>
+				</form>
+				<p class="description">
+					<?php esc_html_e( 'Developers may also define RMS_WIZARD_FORCE as true to bypass the lock in local environments.', 'simple-rms-theme' ); ?>
+				</p>
+			</div>
+		<?php elseif ( $locked || ( $completed_flag && ! $is_unlocked ) ) : ?>
+			<div class="notice notice-success inline rms-wizard-controlled-unlock" data-wizard-controlled-unlock="readonly">
+				<p>
+					<?php esc_html_e( 'The setup wizard has already been completed and is read-only.', 'simple-rms-theme' ); ?>
+				</p>
+				<p class="description">
+					<?php esc_html_e( 'Controlled unlock will be available after landing page protection ships. Developers may define RMS_WIZARD_FORCE as true to bypass the lock in local environments.', 'simple-rms-theme' ); ?>
+				</p>
 			</div>
 		<?php endif; ?>
 

--- a/inc/wizard/wizard-init.php
+++ b/inc/wizard/wizard-init.php
@@ -101,6 +101,161 @@ if ( Inc\Wizard\Wizard_Unlock_Controller::is_controlled_unlock_enabled() ) {
 }
 add_action( 'admin_post_' . Inc\Wizard\Wizard_Unlock_Controller::RELOCK_ACTION, 'rms_wizard_handle_relock_action' );
 
+// Always-loaded Ads landing robots + sitemap protections (front-end + sitemaps).
+add_filter( 'wp_robots', 'rms_wizard_ads_landing_wp_robots' );
+add_filter( 'wp_sitemaps_posts_query_args', 'rms_wizard_exclude_ads_landings_from_wp_sitemap', 10, 2 );
+add_filter( 'wpseo_exclude_from_sitemap_by_post_ids', 'rms_wizard_exclude_ads_landings_from_yoast_sitemap' );
+add_filter( 'wpseo_sitemap_entry', 'rms_wizard_filter_yoast_sitemap_entry', 10, 3 );
+
+/**
+ * Force noindex for Ads landings on the landing template (second protection layer).
+ *
+ * Requires ALL of: is_page(), valid queried ID, template pages/landing-page.php,
+ * and rms_landing_type === ads. SEO landings on the same template are untouched.
+ *
+ * @param array<string,bool|string> $robots Robots directives.
+ *
+ * @return array<string,bool|string>
+ */
+function rms_wizard_ads_landing_wp_robots( array $robots ): array {
+	if ( ! is_page() ) {
+		return $robots;
+	}
+
+	$post_id = (int) get_queried_object_id();
+
+	if ( $post_id <= 0 ) {
+		return $robots;
+	}
+
+	$template = (string) get_page_template_slug( $post_id );
+
+	if ( 'pages/landing-page.php' !== $template ) {
+		return $robots;
+	}
+
+	$landing_type = sanitize_key( (string) get_post_meta( $post_id, 'rms_landing_type', true ) );
+
+	if ( 'ads' !== $landing_type ) {
+		return $robots;
+	}
+
+	$robots['noindex']  = true;
+	$robots['nofollow'] = true;
+
+	return $robots;
+}
+
+/**
+ * Exclude Ads landings from the core WordPress XML sitemap query.
+ *
+ * @param array<string,mixed> $args      Query args.
+ * @param string              $post_type Post type.
+ *
+ * @return array<string,mixed>
+ */
+function rms_wizard_exclude_ads_landings_from_wp_sitemap( array $args, string $post_type ): array {
+	if ( 'page' !== $post_type ) {
+		return $args;
+	}
+
+	$meta_query = isset( $args['meta_query'] ) && is_array( $args['meta_query'] ) ? $args['meta_query'] : [];
+
+	$meta_query[] = [
+		'relation' => 'OR',
+		[
+			'key'     => 'rms_landing_type',
+			'compare' => 'NOT EXISTS',
+		],
+		[
+			'key'     => 'rms_landing_type',
+			'value'   => 'ads',
+			'compare' => '!=',
+		],
+	];
+
+	$args['meta_query'] = $meta_query;
+
+	return $args;
+}
+
+/**
+ * Collect Ads landing page IDs for Yoast sitemap exclusion.
+ *
+ * @return array<int,int>
+ */
+function rms_wizard_ads_landing_page_ids(): array {
+	static $ids = null;
+
+	if ( null !== $ids ) {
+		return $ids;
+	}
+
+	$query = new WP_Query(
+		[
+			'post_type'              => 'page',
+			'post_status'            => 'publish',
+			'posts_per_page'         => -1,
+			'fields'                 => 'ids',
+			'no_found_rows'          => true,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+			'meta_key'               => 'rms_landing_type',
+			'meta_value'             => 'ads',
+		]
+	);
+
+	$ids = array_map( 'absint', is_array( $query->posts ) ? $query->posts : [] );
+
+	return $ids;
+}
+
+/**
+ * Exclude Ads landings from Yoast sitemaps when the API is available.
+ *
+ * @param array<int,int> $excluded_ids Existing excluded post IDs.
+ *
+ * @return array<int,int>
+ */
+function rms_wizard_exclude_ads_landings_from_yoast_sitemap( $excluded_ids ): array {
+	$excluded_ids = is_array( $excluded_ids ) ? $excluded_ids : [];
+	$ads_ids      = rms_wizard_ads_landing_page_ids();
+
+	if ( [] === $ads_ids ) {
+		return $excluded_ids;
+	}
+
+	return array_values( array_unique( array_merge( array_map( 'absint', $excluded_ids ), $ads_ids ) ) );
+}
+
+/**
+ * Defense-in-depth: drop Ads landings from Yoast sitemap entries.
+ *
+ * @param array<string,mixed>|false $url    Sitemap entry.
+ * @param string                    $type   Object type.
+ * @param object|null               $object Post-like object.
+ *
+ * @return array<string,mixed>|false
+ */
+function rms_wizard_filter_yoast_sitemap_entry( $url, $type, $object ) {
+	if ( false === $url || ! is_object( $object ) || empty( $object->ID ) ) {
+		return $url;
+	}
+
+	if ( 'post' !== $type && 'page' !== $type ) {
+		// Yoast uses 'post' for pages in some versions; also check post_type.
+		if ( empty( $object->post_type ) || 'page' !== $object->post_type ) {
+			return $url;
+		}
+	}
+
+	if ( 'ads' === sanitize_key( (string) get_post_meta( (int) $object->ID, 'rms_landing_type', true ) ) ) {
+		return false;
+	}
+
+	return $url;
+}
+
 /**
  * Handle controlled unlock form posts from the Setup Wizard admin notice.
  *
@@ -197,23 +352,25 @@ function rms_wizard_render_admin_page(): void {
 	$force_unlocked     = ! empty( $state['force_unlocked'] );
 	$unlock_ui_enabled  = ! empty( $state['controlled_unlock_ui'] );
 	$steps              = [
-		'dependencies'      => __( 'Dependencies', 'simple-rms-theme' ),
-		'acf-import'        => __( 'ACF Import', 'simple-rms-theme' ),
-		'client-data'       => __( 'Client Data', 'simple-rms-theme' ),
-		'generate-pages'    => __( 'Generate Pages', 'simple-rms-theme' ),
-		'menu-setup'        => __( 'Menu Setup', 'simple-rms-theme' ),
-		'ia-generation'     => __( 'IA Generation', 'simple-rms-theme' ),
-		'home-page-builder' => __( 'Home Page Builder', 'simple-rms-theme' ),
+		'dependencies'         => __( 'Dependencies', 'simple-rms-theme' ),
+		'acf-import'           => __( 'ACF Import', 'simple-rms-theme' ),
+		'client-data'          => __( 'Client Data', 'simple-rms-theme' ),
+		'generate-pages'       => __( 'Generate Pages', 'simple-rms-theme' ),
+		'menu-setup'           => __( 'Menu Setup', 'simple-rms-theme' ),
+		'ia-generation'        => __( 'IA Generation', 'simple-rms-theme' ),
+		'home-page-builder'    => __( 'Home Page Builder', 'simple-rms-theme' ),
+		'landing-page-builder' => __( 'Landing Page Builder', 'simple-rms-theme' ),
 	];
 	$step_slugs = array_keys( $steps );
 	$descriptions = [
-		'dependencies'      => __( 'Check and install the required WordPress plugins before continuing.', 'simple-rms-theme' ),
-		'acf-import'        => __( 'Import ACF JSON field groups from the theme acf-json directory.', 'simple-rms-theme' ),
-		'client-data'       => __( 'Save contractor business information into the theme options.', 'simple-rms-theme' ),
-		'generate-pages'    => __( 'Add the site pages to create, then assign the Home and optional Blog roles.', 'simple-rms-theme' ),
-		'menu-setup'        => __( 'Choose generated pages for the primary and mobile menus.', 'simple-rms-theme' ),
-		'ia-generation'     => __( 'Configure the AI provider, model, and encrypted credentials for later content generation.', 'simple-rms-theme' ),
-		'home-page-builder' => __( 'Choose Home page sections and build them from the saved client data.', 'simple-rms-theme' ),
+		'dependencies'         => __( 'Check and install the required WordPress plugins before continuing.', 'simple-rms-theme' ),
+		'acf-import'           => __( 'Import ACF JSON field groups from the theme acf-json directory.', 'simple-rms-theme' ),
+		'client-data'          => __( 'Save contractor business information into the theme options.', 'simple-rms-theme' ),
+		'generate-pages'       => __( 'Add the site pages to create, then assign the Home and optional Blog roles.', 'simple-rms-theme' ),
+		'menu-setup'           => __( 'Choose generated pages for the primary and mobile menus.', 'simple-rms-theme' ),
+		'ia-generation'        => __( 'Configure the AI provider, model, and encrypted credentials for later content generation.', 'simple-rms-theme' ),
+		'home-page-builder'    => __( 'Choose Home page sections and build them from the saved client data.', 'simple-rms-theme' ),
+		'landing-page-builder' => __( 'Create SEO and Ads landing pages with keywords, reusable sections, and noindex controls.', 'simple-rms-theme' ),
 	];
 	?>
 	<div
@@ -280,7 +437,7 @@ function rms_wizard_render_admin_page(): void {
 					<?php esc_html_e( 'The setup wizard has already been completed and is read-only.', 'simple-rms-theme' ); ?>
 				</p>
 				<p class="description">
-					<?php esc_html_e( 'Controlled unlock will be available after landing page protection ships. Developers may define RMS_WIZARD_FORCE as true to bypass the lock in local environments.', 'simple-rms-theme' ); ?>
+					<?php esc_html_e( 'Developers may define RMS_WIZARD_FORCE as true to bypass the lock in local environments.', 'simple-rms-theme' ); ?>
 				</p>
 			</div>
 		<?php endif; ?>
@@ -361,6 +518,8 @@ function rms_wizard_render_admin_page(): void {
 							<?php rms_wizard_render_ia_generation_form(); ?>
 						<?php elseif ( 'home-page-builder' === $slug ) : ?>
 							<?php rms_wizard_render_home_page_builder_form(); ?>
+						<?php elseif ( 'landing-page-builder' === $slug ) : ?>
+							<?php rms_wizard_render_landing_page_builder_form(); ?>
 						<?php endif; ?>
 
 						<div class="rms-wizard-actions rms-wizard-step-actions">
@@ -489,7 +648,7 @@ function rms_wizard_render_menu_setup_form(): void {
 	<form class="rms-wizard-fields rms-wizard-guided-form" data-wizard-menu-form>
 		<div class="rms-wizard-guided-panel">
 			<p class="rms-wizard-fields__intro">
-				<?php esc_html_e( 'Menus are built only from pages created by the Generate Pages step. Refresh the state after generating pages if this list is empty.', 'simple-rms-theme' ); ?>
+				<?php esc_html_e( 'Menus are built from Generate Pages results plus menu-eligible SEO landings. Ads landings are excluded automatically. Refresh the state after generating pages or landings if this list is empty.', 'simple-rms-theme' ); ?>
 			</p>
 
 			<div class="notice notice-warning inline rms-wizard-menu-empty" data-wizard-menu-empty hidden>
@@ -675,6 +834,133 @@ function rms_wizard_render_home_page_builder_form(): void {
 					</div>
 					<button type="button" class="button-link-delete rms-wizard-home-section-row__remove" data-wizard-remove-home-section><?php esc_html_e( 'Remove', 'simple-rms-theme' ); ?></button>
 				</article>
+			</template>
+		</div>
+	</form>
+	<?php
+}
+
+/**
+ * Render the guided Landing Page Builder form.
+ *
+ * @return void
+ */
+function rms_wizard_render_landing_page_builder_form(): void {
+	$sections        = rms_wizard_home_section_choices();
+	$default_layouts = [
+		'hero',
+		'seo-content',
+		'vision-mission-v1',
+		'badges',
+		'portfolio-v1',
+		'seo-content',
+		'testimonials-v1',
+		'seo-content',
+	];
+	$section_options = array_values(
+		array_map(
+			static function ( array $section ) use ( $default_layouts ): array {
+				$layout = (string) $section['name'];
+
+				return [
+					'layout'              => $layout,
+					'label'               => $section['label'],
+					'description'         => $section['description'],
+					'is_keyword_layout'   => in_array( $layout, [ 'hero', 'seo-content' ], true ),
+					'is_default'          => in_array( $layout, $default_layouts, true ),
+					'default_item_count'  => rms_wizard_home_section_default_item_count( $layout ),
+					'has_fillable_fields' => rms_wizard_home_section_has_fillable_fields( $layout ),
+				];
+			},
+			$sections
+		)
+	);
+	?>
+	<form class="rms-wizard-fields rms-wizard-guided-form" data-wizard-landing-page-builder-form>
+		<div class="rms-wizard-guided-panel">
+			<p class="rms-wizard-fields__intro">
+				<?php esc_html_e( 'Create one or more SEO or Ads landing pages. Only Hero and SEO Content receive keywords; reusable sections stay neutral and pull from the canonical store. Ads landings are noindex and never auto-added to menus.', 'simple-rms-theme' ); ?>
+			</p>
+
+			<label class="rms-wizard-landing-skip-all">
+				<input type="checkbox" name="skip_all" value="1" data-wizard-landing-skip-all>
+				<span><?php esc_html_e( 'Skip landing pages for now (complete this step with zero landings)', 'simple-rms-theme' ); ?></span>
+			</label>
+
+			<script type="application/json" data-wizard-landing-sections><?php echo wp_json_encode( $section_options, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT ); ?></script>
+			<script type="application/json" data-wizard-landing-default-layouts><?php echo wp_json_encode( $default_layouts, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT ); ?></script>
+
+			<div class="rms-wizard-landing-toolbar">
+				<button type="button" class="button button-secondary" data-wizard-add-landing><?php esc_html_e( 'Add landing', 'simple-rms-theme' ); ?></button>
+				<p class="rms-wizard-field__instructions"><?php esc_html_e( 'Duplicate a row to start a new landing with a fresh identity. Existing landings hydrate from wizard state on load.', 'simple-rms-theme' ); ?></p>
+			</div>
+
+			<div class="rms-wizard-landing-builder" data-wizard-landing-builder>
+				<div class="rms-wizard-landing-rows" role="list" data-wizard-landing-rows></div>
+				<p class="rms-wizard-landing-builder__empty" data-wizard-landing-empty><?php esc_html_e( 'No landings added yet. Add a landing or skip this step.', 'simple-rms-theme' ); ?></p>
+			</div>
+
+			<div class="rms-wizard-landing-replace-panel" data-wizard-landing-replace-panel>
+				<strong><?php esc_html_e( 'Replace canonical reusable sections', 'simple-rms-theme' ); ?></strong>
+				<p class="rms-wizard-field__instructions"><?php esc_html_e( 'Optional. Mark reusable layouts to regenerate and overwrite the shared canonical store. Requires confirmation when running the step.', 'simple-rms-theme' ); ?></p>
+				<div class="rms-wizard-landing-replace-list" data-wizard-landing-replace-list></div>
+			</div>
+
+			<template data-wizard-landing-row-template>
+				<article class="rms-wizard-landing-row" role="listitem" data-wizard-landing-row>
+					<input type="hidden" name="landings[__INDEX__][id]" value="" data-wizard-landing-id>
+					<input type="hidden" name="landings[__INDEX__][landing_key]" value="" data-wizard-landing-key>
+					<header class="rms-wizard-landing-row__header">
+						<strong data-wizard-landing-heading><?php esc_html_e( 'Landing', 'simple-rms-theme' ); ?></strong>
+						<div class="rms-wizard-landing-row__actions">
+							<button type="button" class="button-link" data-wizard-duplicate-landing><?php esc_html_e( 'Duplicate', 'simple-rms-theme' ); ?></button>
+							<button type="button" class="button-link-delete" data-wizard-remove-landing><?php esc_html_e( 'Remove', 'simple-rms-theme' ); ?></button>
+						</div>
+					</header>
+					<div class="rms-wizard-landing-row__grid">
+						<div class="rms-wizard-field">
+							<label for="rms-wizard-landing-title-__INDEX__"><?php esc_html_e( 'Title', 'simple-rms-theme' ); ?></label>
+							<input id="rms-wizard-landing-title-__INDEX__" type="text" name="landings[__INDEX__][title]" data-wizard-landing-title placeholder="<?php esc_attr_e( 'Kitchen Remodel Landing', 'simple-rms-theme' ); ?>">
+						</div>
+						<div class="rms-wizard-field">
+							<label for="rms-wizard-landing-slug-__INDEX__"><?php esc_html_e( 'Slug', 'simple-rms-theme' ); ?></label>
+							<input id="rms-wizard-landing-slug-__INDEX__" type="text" name="landings[__INDEX__][slug]" data-wizard-landing-slug data-wizard-slug-auto="1" placeholder="<?php esc_attr_e( 'kitchen-remodel', 'simple-rms-theme' ); ?>">
+						</div>
+						<div class="rms-wizard-field">
+							<label for="rms-wizard-landing-type-__INDEX__"><?php esc_html_e( 'Landing type', 'simple-rms-theme' ); ?></label>
+							<select id="rms-wizard-landing-type-__INDEX__" name="landings[__INDEX__][landing_type]" data-wizard-landing-type>
+								<option value="seo"><?php esc_html_e( 'SEO (indexable, menu-eligible)', 'simple-rms-theme' ); ?></option>
+								<option value="ads"><?php esc_html_e( 'Ads (noindex, orphan)', 'simple-rms-theme' ); ?></option>
+							</select>
+						</div>
+						<div class="rms-wizard-field">
+							<label for="rms-wizard-landing-keyword-__INDEX__"><?php esc_html_e( 'Primary keyword', 'simple-rms-theme' ); ?></label>
+							<input id="rms-wizard-landing-keyword-__INDEX__" type="text" name="landings[__INDEX__][primary_keyword]" data-wizard-landing-primary-keyword placeholder="<?php esc_attr_e( 'kitchen remodel near me', 'simple-rms-theme' ); ?>">
+						</div>
+						<div class="rms-wizard-field rms-wizard-landing-row__subkeywords">
+							<label for="rms-wizard-landing-subkeywords-__INDEX__"><?php esc_html_e( 'Subkeywords (comma-separated, max 10)', 'simple-rms-theme' ); ?></label>
+							<input id="rms-wizard-landing-subkeywords-__INDEX__" type="text" name="landings[__INDEX__][subkeywords]" data-wizard-landing-subkeywords placeholder="<?php esc_attr_e( 'cabinet refinishing, countertop install', 'simple-rms-theme' ); ?>">
+						</div>
+					</div>
+					<div class="rms-wizard-landing-sections" data-wizard-landing-sections-list>
+						<div class="rms-wizard-landing-sections__header">
+							<strong><?php esc_html_e( 'Sections', 'simple-rms-theme' ); ?></strong>
+							<button type="button" class="button-link" data-wizard-add-landing-section><?php esc_html_e( 'Add section', 'simple-rms-theme' ); ?></button>
+						</div>
+						<div class="rms-wizard-landing-section-rows" data-wizard-landing-section-rows></div>
+					</div>
+				</article>
+			</template>
+
+			<template data-wizard-landing-section-row-template>
+				<div class="rms-wizard-landing-section-row" data-wizard-landing-section-row>
+					<select name="landings[__LINDEX__][sections][__SINDEX__][layout]" data-wizard-landing-section-layout></select>
+					<label class="rms-wizard-landing-section-override">
+						<input type="checkbox" name="landings[__LINDEX__][sections][__SINDEX__][override_canonical]" value="1" data-wizard-landing-section-override>
+						<span><?php esc_html_e( 'Override canonical (neutral regen, does not write store)', 'simple-rms-theme' ); ?></span>
+					</label>
+					<button type="button" class="button-link-delete" data-wizard-remove-landing-section><?php esc_html_e( 'Remove', 'simple-rms-theme' ); ?></button>
+				</div>
 			</template>
 		</div>
 	</form>

--- a/openspec/changes/wizard-landing-page-builder/apply-progress.md
+++ b/openspec/changes/wizard-landing-page-builder/apply-progress.md
@@ -1,9 +1,9 @@
 # Apply Progress: wizard-landing-page-builder
 
 **Mode**: Standard  
-**Batch**: Phase 2 Backend Landing Slice (PR2) + PR2 review-blocker fixes + remaining PR2 reliability follow-up + equivalence/`build_page` reliability  
-**Date**: 2026-07-21  
-**Branch**: `feat/wizard-landing-backend` (feature-branch-chain, base = PR1 foundation)
+**Batch**: PR3 remaining risk blockers + SEO append feedback  
+**Date**: 2026-07-22  
+**Branch**: `feat/wizard-landing-ui` (feature-branch-chain, base = PR2 `feat/wizard-landing-backend`)
 
 ## Completed Tasks (cumulative)
 
@@ -21,118 +21,85 @@
 - [x] 2.5 `Content_Builder` whitelist `meta_input` (`_wp_page_template`, `rms_landing_type`)
 - [x] 2.6 `delete_unselected_pages()` landing guard + controlled unlock enabled
 
-### Phase 2 PR2 review-blocker follow-up
-- [x] Deactivate live required/dispatch for `landing-page-builder` until Phase 3 UI+noindex
+### Phase 2 PR2 review-blocker / reliability follow-up
+- [x] Deactivate live required/dispatch until Phase 3 (then re-activated in 3.7)
 - [x] Identity cross-pair validation + stricter slug collisions
-- [x] Keyword AI failure → `WP_Error` (or preserve existing landing); no placeholder publish
-- [x] Multi-landing partial-failure state persistence before failed status
-- [x] Critical persistence post-state checks (state, status, meta, canonical write)
-- [x] Reviewer/JSON observability + neutral priors for reusable/canonical paths
+- [x] Keyword AI failure → `WP_Error` (or preserve existing landing)
+- [x] Multi-landing partial-failure state persistence
+- [x] Critical persistence post-state checks
+- [x] Reviewer/JSON observability + neutral priors
+- [x] generate-pages residual landing exclusion (fail-closed)
+- [x] build_one_landing exception → WP_Error + partial path
+- [x] try_preserve checks update/meta results
+- [x] landing_pages_equivalent expanded
+- [x] Local try/catch around `build_page()`
 
-### Phase 2 PR2 remaining reliability follow-up
-- [x] `generate-pages` excludes residual SEO/Ads landings from select/update/Home-Blog assignment (fail-closed `WP_Error`); deletion guard retained
-- [x] `build_one_landing()` thrown exceptions converted to `WP_Error` + partial persistence path
-- [x] `try_preserve_existing_landing()` checks `wp_update_post()` / meta results (no false preserve success)
-- [x] Document duplicated Home/Landing helper families + extraction plan after PR3/before archive
-- [x] `landing_pages_equivalent()` expanded beyond id/key/slug/type (title, keywords, menu_eligible, generated_at, preserved)
-- [x] Local try/catch around `Content_Builder::build_page()` with post-ID recovery + contextual `WP_Error` (outer partial recovery unchanged)
+### Phase 3
+- [x] 3.1 `Menu_Builder`: idempotent `append_page_items()`, `remove_page_items()`, `reconcile_landing_menu_items()`
+- [x] 3.2 `Step_Menu_Setup`: merge eligible SEO landings, exclude Ads, post-replace reconciliation
+- [x] 3.3 Yoast title/metadesc + noindex write/read-back; `wp_robots`; WP/Yoast sitemap Ads exclusion
+- [x] 3.4 Admin TS: landing collector, keyword validation, skip-all, identity hydration, duplicate reset, unlock-aware lock UI, replace-canonical modal
+- [x] 3.5 Admin SCSS: landing + unlock states
+- [x] 3.6 `pages/landing-page.php`: flexible `page_sections` + breadcrumb once after first Hero
+- [x] 3.7 Atomic activation: `landing-page-builder` in `REQUIRED_STEPS` + `DISPATCHABLE_STEPS` with visible UI + final-state sync
 
-Phase 3/4 tasks remain incomplete (including 3.7 activation).
+### PR3 review-blocker / high-value warning fixes (prior batch)
+- [x] BLOCKER: `skip_all` reconciles final-state (noindex/menu) for existing landings before complete; fails closed on sync error; no-op when none exist
+- [x] BLOCKER: post-publish failure path best-effort Ads final-state protection (recover post_id → noindex + menu remove); logs success/fail; still returns original error
+- [x] WARNING: `remove_page_items` read-back verification; Ads/ineligible removal fail-closed in landing final-state + Menu Setup reconcile
+- [x] WARNING: Menu Setup builds pool from eligible landings even when `generated_pages` empty; Ads still excluded
+- [x] WARNING: `landing-page.php` guards ACF helpers with `function_exists` before flexible loop
+- [x] Docs: JSDoc on `getGeneratedPages()`; breadcrumb behavior documented; blank lines cleaned; no-runner limitation kept
 
-## Phase 1 Review Follow-up Fixes (preserved)
+### PR3 remaining risk blockers (this batch)
+- [x] BLOCKER: `landing-page.php` ACF-missing path no longer loads template parts that call `get_sub_field()`; minimal title/content fallback when ACF absent; hardcoded section order preserved when ACF present but `page_sections` empty; flexible path unchanged when rows exist
+- [x] BLOCKER: `try_preserve_existing_landing()` early failures (`wp_update_post` error, invalid update result, `ensure_landing_meta` failure) call `protect_ads_final_state_best_effort()` before returning original error (logs post_id/landing_key/slug via protection helper)
+- [x] WARNING: SEO menu append returns structured result + read-back; failures logged as warning (best-effort). Ads menu removal remains fail-closed. Reconcile exposes `append_failed_page_ids` without flipping removal `verified`
+- [x] Minor: JSDoc on `getMenuEligibleLandings()`; Yoast title/description max lengths as named constants
 
-| Finding | Severity | Fix |
-|---------|----------|-----|
-| `landing-page-builder` required before runtime | BLOCKER | Removed from active `REQUIRED_STEPS` in Phase 1 |
-| Canonical store nondeterministic persistence | WARNING | Cache mutates only after successful `update_option()` or verified equal full post-state entry |
-| Unlock/relock nondeterministic persistence | WARNING | Post-state option equality checks |
-| Premature `landing_page_builder` alias pollutes state | WARNING | Unknown-step reject before status writes |
-| Stale unlock marker bypasses lock | BLOCKER | `has_unlock_marker()` vs effective `is_unlocked()` |
-| Completion flag SoT | WARNING | `State_Manager::has_completion_flag()` only |
+Phase 4 verification tasks remain incomplete (manual WP Admin scenarios).
 
-## Phase 2 PR2 Review Blocker Fixes
-
-| Finding | Severity | Fix |
-|---------|----------|-----|
-| Live backend can publish Ads indexable before Phase 3 noindex | BLOCKER | Safer smaller fix: keep `Step_Landing_Page_Builder` implemented but remove `landing-page-builder` from `REQUIRED_STEPS` + `DISPATCHABLE_STEPS`. Dispatch case + alias retained for Phase 3 atomic activation (task 3.7). Existing 7-step UI completion unchanged. |
-| UI/required mismatch (7-step UI vs 8th required) | BLOCKER | Same deactivation; completion stays 7 required steps until UI can send payload/`skip_all`. |
-| Identity mismatch id+key | BLOCKER | `match_existing_landing()` rejects stale cross-pair when both non-empty id and landing_key disagree; order id → key → slug; slug collisions reject other pages (landing or not) when id already matched. |
-| Keyword AI failure publishes placeholders | BLOCKER | `generate_section_copy(..., require_ai=true)` returns `WP_Error` on AI/decode/review/empty-validation failure for hero/seo-content. Updates may preserve existing valid page_sections instead of placeholders. Logs include landing_key/slug/layout. |
-| Multi-landing partial failure diverges state | HIGH | On failure after N-1 successes, `persist_partial_landing_progress()` saves `landing_pages` + canonical summary first, logs counts/post IDs, then marks step failed (logs if status write fails). No delete of updated existing landings. |
-| Persistence checks | HIGH | `persist_wizard_state` / `mark_step_status` re-read post-state; meta safety-net verifies template+type; canonical `replace`/`set_if_empty` failures logged and fall back when possible. Critical full-run state/status failures return `WP_Error`. |
-| Reviewer/JSON observability + keyword priors | HIGH | Reviewer throwables and invalid JSON-on-success logged with context. Reusable/canonical paths use `filter_neutral_priors()` so keyword sections do not pollute neutral generation/review. |
-| `generate-pages` can publish/assign residual landings | BLOCKER | Fail-closed: selected slugs resolving to `rms_landing_type` `seo`/`ads` return `WP_Error` (`rms_wizard_page_slug_is_landing`) before cleanup/update; loop + `assign_reading_pages()` refuse landing Home/Blog assignment; deletion guard kept. |
-| Partial recovery misses thrown exceptions | WARNING | Each `build_one_landing()` call wrapped in try/catch; `\Throwable` → contextual `WP_Error` then existing `persist_partial_landing_progress()`. |
-| `try_preserve_existing_landing()` ignores update result | WARNING | Capture `wp_update_post(..., true)`; on `WP_Error`/invalid result or meta failure log and return `WP_Error` (no false preserved success). |
-| `landing_pages_equivalent()` too narrow | WARNING | Normalize/compare id, landing_key, title, slug, landing_type, menu_eligible, primary_keyword, order-insensitive subkeywords, generated_at, preserved — reject stale/partial state as “saved”. |
-| `build_page()` throwable after create/update bypasses recovery | WARNING | Local try/catch around `build_page()` → contextual `WP_Error` (`landing_key`/`slug`/`title`, recovered `post_id` when known); outer loop still runs `persist_partial_landing_progress()` for prior successes. |
-| Readability/size (shared helper extraction) | WARNING | **Deliberate duplication retained** with Home Builder. See Known limitations for named helper families + extraction plan after PR3/before archive. |
-
-## Files Changed (Phase 2 batch + review fixes)
+## Files Changed (this batch)
 
 | File | Action | What Was Done |
 |------|--------|---------------|
-| `inc/wizard/class-ai-content-harness.php` | Modified | Distinct `PAGE_LANDING` Layer 2; keyword inject only hero/seo-content |
-| `inc/wizard/class-step-home-page-builder.php` | Modified | After success, `set_if_empty` reusable prepared rows |
-| `inc/wizard/class-step-landing-page-builder.php` | Created + hardened | Full backend + PR2 safety: identity, keyword fail-closed, partial persist, persistence checks, observability, neutral priors, richer state equivalence, local `build_page()` exception boundary |
-| `inc/wizard/class-content-builder.php` | Modified | Whitelist-only `meta_input` |
-| `inc/wizard/class-step-generate-pages.php` | Modified | Landing deletion guard + select/update/reading-assignment exclusion (fail-closed) |
-| `inc/wizard/class-wizard-unlock-controller.php` | Modified | `CONTROLLED_UNLOCK_ENABLED = true` |
-| `inc/wizard/class-step-controller.php` | Modified | PR2: required/dispatch remain 7 steps; dispatch case + alias kept dormant with Phase 3 activation comments |
-| `openspec/changes/wizard-landing-page-builder/tasks.md` | Modified | Phase 2 complete + compatibility notes + task 3.7 activation |
-| `openspec/changes/wizard-landing-page-builder/apply-progress.md` | Modified | This cumulative progress note + helper-duplication known limitations |
+| `pages/landing-page.php` | Modified | Split ACF-missing vs ACF-empty fallbacks; safe markup without `get_sub_field` |
+| `inc/wizard/class-step-landing-page-builder.php` | Modified | Ads protect on preserve early fails; SEO append feedback logs |
+| `inc/wizard/class-menu-builder.php` | Modified | Structured `append_page_items` + verify; reconcile reports append failures |
+| `inc/wizard/class-step-menu-setup.php` | Modified | Warning log when SEO append incomplete after Ads removal OK |
+| `inc/wizard/class-yoast-meta-writer.php` | Modified | `TITLE_MAX_LENGTH` / `DESCRIPTION_MAX_LENGTH` constants |
+| `src/ts/admin/wizard.ts` | Modified | JSDoc for `getMenuEligibleLandings` |
+| `openspec/changes/wizard-landing-page-builder/apply-progress.md` | Modified | This cumulative progress note |
 
-## Intentionally not changed (Phase 3+)
+## Design notes
 
-- Menu append/remove / Menu Setup landing merge
-- Yoast title/metadesc/noindex + `wp_robots` + ads sitemap
-- Admin TS/SCSS landing UI
-- `pages/landing-page.php` flexible loop / breadcrumb
-- Shared Home/Landing section-assembly extraction (documented follow-up)
-- Local docs: `Wizard ai harness prompt guide.md`, `wizard-prd.html`
-- No commit/push
-
-## Design notes (Phase 2 + PR2 safety)
-
-- Landing **runtime code** is present; **activation** is Phase 3 (required + dispatchable + UI + noindex/menu).
-- Controlled unlock enabled only because 2.6 deletion guard shipped in the same backend slice.
-- Ads noindex/menu final-state sync deferred to Phase 3 (by design; PR2 cannot go live without it).
-- Keyword scope strict: only `hero` / `seo-content` receive keywords; overrides stay neutral (`PAGE_HOME`).
-- Canonical first-write only; overrides never write store; replace requires `replace_canonical` + confirm flag.
-- Bootstrap failure returns actionable `WP_Error` (`rms_wizard_canonical_bootstrap_failed`).
-
-## Known limitations
-
-1. Step is not callable via REST until Phase 3 activation — intentional PR2 safety.
-2. **Deliberate Home Builder / Landing Builder helper duplication** (readability debt, not a runtime bug). Duplicated helper families today:
-   - Section assembly / section row preparation (`section_data`, service row contracts, image fallbacks orchestration)
-   - Placeholder copy builders (`placeholder_copy`, `placeholder_repeater_rows`, `placeholder_field_value`)
-   - Item-count defaults / clamp (`item_count` and the shared max section item limit **`12`**)
-   - Reviewer/config helpers (`reviewer()`, `is_review_enabled()`, review wiring around AI decode)
-   - Text/HTML/JSON helpers (`text`, `html`, `section_value`, `decode_json_content`, `truthy`)
-   - Completion helper (`maybe_mark_completed` against `Step_Controller::get_required_steps()`)
-   - **Follow-up plan**: extract a shared section-assembly / content-helper collaborator **after PR3 lands or before archive** — not in this PR2 reliability patch. Also extract the repeated max item limit `12` to a named constant during that cleanup.
-3. No automated behavioral tests / no test runner (`strict_tdd: false`). Reliability is verified via `php -l` + code review only — do not claim automated behavior coverage.
-4. Preserve-on-keyword-failure path updates title/slug/meta only; does not rewrite sections.
-5. Partial-failure recovery does not roll back newly created posts (prefers state persistence over destructive delete). Thrown exceptions (including local `build_page()` catch) convert to `WP_Error` and use the same partial persistence path as returned errors. Recovered orphan post IDs are logged/error-data only — not auto-added to successful `landing_pages`.
+- **Breadcrumb (flexible path)**: injected **once after the first Hero row only**. If flexible `page_sections` has no Hero layout, **no breadcrumb** is rendered in that path.
+- **Breadcrumb (fallback path, ACF present)**: hardcoded order still includes Hero then `breadcrumb-slim`.
+- **ACF missing**: minimal `the_title` / `the_content` fallback only — never load section template parts.
+- **Menu policy asymmetry**: SEO append = **best-effort** (warn + continue). Ads removal / noindex = **fail-closed**.
+- **No automated behavioral tests**: Mode Standard (`strict_tdd: false`, no test runner). Verification is `php -l`, `tsc --noEmit`, and `npm run build` only.
 
 ## Verification
 
 ```
+php -l pages/landing-page.php
 php -l inc/wizard/class-step-landing-page-builder.php
+php -l inc/wizard/class-menu-builder.php
+php -l inc/wizard/class-step-menu-setup.php
+php -l inc/wizard/class-yoast-meta-writer.php
+npx tsc --noEmit
+npm run build
 ```
 
-(Plus prior Phase 2 `php -l` on generate-pages/controller/harness/content-builder/unlock/home-builder.)
-
-Mode: **Standard** (`openspec/config.yaml` → `strict_tdd: false`, no test runner). No automated behavior tests exist for these reliability paths.
+Mode: **Standard** (`strict_tdd: false`, no test runner). Manual WP Admin scenarios remain for Phase 4.
 
 ## Workload / PR Boundary
 
 - Mode: chained PR slice (feature-branch-chain)
-- Current work unit: PR2 Backend Landing + remaining reliability follow-up (equivalence + build_page boundary)
-- Boundary: Phase 2 tasks 2.1–2.6 hardened for standalone PR safety; no Phase 3 UI/menu/template
-- Estimated review budget impact: small incremental reliability patch on PR2 surface
+- Current work unit: PR3 remaining risk blockers only
+- Boundary: no archive, no commit/push
+- Estimated review budget impact: small focused delta
 
 ## Status
 
-Phase 1 + Phase 2 complete with PR2 remaining reliability warnings addressed (10/19 tasks incl. new 3.7). Ready for PR2 re-review / next batch Phase 3 UI/menu/SEO/template + activation.
+17/19 tasks complete (Phase 1–3) + PR3 remaining risk blockers addressed. Ready for re-review / Phase 4 verification. No commit performed.

--- a/openspec/changes/wizard-landing-page-builder/apply-progress.md
+++ b/openspec/changes/wizard-landing-page-builder/apply-progress.md
@@ -1,0 +1,69 @@
+# Apply Progress: wizard-landing-page-builder
+
+**Mode**: Standard  
+**Batch**: Phase 1 final cleanup before PR prep  
+**Date**: 2026-07-20
+
+## Completed Tasks (cumulative)
+
+- [x] 1.1 Canonical section store
+- [x] 1.2 State manager + step controller foundation
+- [x] 1.3 Unlock controller + admin wiring
+- [x] 1.4 Completed-gate allowlist for unlock/relock only
+
+Phase 2+ tasks remain incomplete and were not started in this batch.
+
+## Review Follow-up Fixes (cumulative)
+
+| Finding | Severity | Fix |
+|---------|----------|-----|
+| `landing-page-builder` required before runtime | BLOCKER | Removed from active `REQUIRED_STEPS`; 7-step completion remains valid via shared `get_required_steps()` |
+| Canonical store nondeterministic persistence | WARNING | Cache mutates only after successful `update_option()` or verified equal full post-state entry |
+| Unlock/relock nondeterministic persistence | WARNING | Post-state option equality checks; fail + rollback on unlock; fail if still unlocked after relock |
+| Phase 1 unlock exposes destructive reruns | WARNING | `CONTROLLED_UNLOCK_ENABLED = false`; no unlock admin-post registration until Phase 2 deletion guard; REST unlock returns 503; relock kept for stale cleanup |
+| `RMS_WIZARD_FORCE` UI ambiguity | WARNING | Explicit force-unlocked notice; suppress unlock messaging under force mode |
+| Premature `landing_page_builder` alias pollutes state | WARNING | Removed Phase 1 alias; `is_dispatchable_step()` rejects unknown/unimplemented steps **before** status writes |
+| Stale unlock marker bypasses lock | BLOCKER | `has_unlock_marker()` vs effective `is_unlocked()`; lock ignores markers while controlled unlock disabled |
+| View duplicates unlock source of truth | WARNING | `wizard-init.php` trusts only `$state` from `get_resume_state()` |
+| Untracked local docs risk commit | WARNING | `.gitignore` entries for local docs |
+| Step status stuck `running` on throw | WARNING | catch marks progress steps `failed`; logs if failed-status write itself fails |
+| Dead `assert_required_steps_parity()` | WARNING | Removed; shared `get_required_steps()` is the single list |
+| Duplicate completion-flag helper | WARNING | Removed `Wizard_Unlock_Controller::has_completion_flag()`; use `State_Manager::has_completion_flag()` |
+| Tautological unlock `$at_ok`/`$by_ok` | WARNING | Simplified to post-state equality only |
+| Canonical success ignored `generated_at` | WARNING | Full entry compare (payload + generated_at) after reload |
+| Unlock/relock failures silent | WARNING | Logger records persist failures + residual rollback markers |
+| Duplicate execute_step success shape | INFO | Single success return path after dispatch |
+
+## Files Changed (this batch)
+
+| File | Action | What Was Done |
+|------|--------|---------------|
+| `inc/wizard/class-wizard-unlock-controller.php` | Modified | SoT completion flag; simplified post-state checks; failure/rollback logging |
+| `inc/wizard/class-canonical-section-store.php` | Modified | Full-entry post-state verification including `generated_at` |
+| `inc/wizard/class-step-controller.php` | Modified | Deduped success return; log failed-status write failure on throw |
+| `inc/wizard/wizard-init.php` | Modified | Register unlock admin-post only when enabled; relock notice always; keep gated unlock UI for Phase 2 |
+| `openspec/changes/wizard-landing-page-builder/apply-progress.md` | Modified | This progress note |
+
+## Intentionally not changed
+
+- **Unlock UI branch behind `$unlock_ui_enabled`**: left in place (dead in Phase 1) so Phase 2 task 2.6 can flip `CONTROLLED_UNLOCK_ENABLED` without reintroducing the form. Risk of removing it outweighs PR-size gain.
+- **REST `/steps/unlock/run` route**: still dispatchable, but `unlock()` hard-gates with 503 while disabled — keeps a clear unavailable contract instead of pretending the step is unknown.
+- **Phase 2/3/4 landing runtime / TS / template**: out of Phase 1 scope.
+- **No commit/push**: per apply instructions.
+
+## Verification
+
+Automated behavioral tests are **unavailable** by project config (`openspec/config.yaml`: `strict_tdd: false`, testing section unavailable).  
+Phase 1 relies on **PHP syntax (`php -l`) + 4R fresh review + later manual runtime verification (Phase 4)**. Do not pretend unit/integration tests exist.
+
+```
+php -l inc/wizard/class-wizard-unlock-controller.php
+php -l inc/wizard/class-canonical-section-store.php
+php -l inc/wizard/class-step-controller.php
+php -l inc/wizard/wizard-init.php
+```
+
+## Status
+
+Phase 1 final cleanup complete. Ready for PR prep / re-verify of Phase 1 slice.  
+Do **not** mark Phase 2 tasks complete. Do not start Phase 2 in this batch.

--- a/openspec/changes/wizard-landing-page-builder/apply-progress.md
+++ b/openspec/changes/wizard-landing-page-builder/apply-progress.md
@@ -1,69 +1,138 @@
 # Apply Progress: wizard-landing-page-builder
 
 **Mode**: Standard  
-**Batch**: Phase 1 final cleanup before PR prep  
-**Date**: 2026-07-20
+**Batch**: Phase 2 Backend Landing Slice (PR2) + PR2 review-blocker fixes + remaining PR2 reliability follow-up + equivalence/`build_page` reliability  
+**Date**: 2026-07-21  
+**Branch**: `feat/wizard-landing-backend` (feature-branch-chain, base = PR1 foundation)
 
 ## Completed Tasks (cumulative)
 
+### Phase 1
 - [x] 1.1 Canonical section store
 - [x] 1.2 State manager + step controller foundation
 - [x] 1.3 Unlock controller + admin wiring
 - [x] 1.4 Completed-gate allowlist for unlock/relock only
 
-Phase 2+ tasks remain incomplete and were not started in this batch.
+### Phase 2
+- [x] 2.1 AI harness `PAGE_LANDING` Layer 2 + Layer 3 keywords (`hero` / `seo-content` only)
+- [x] 2.2 Home Builder first-write reusable rows to `Canonical_Section_Store`
+- [x] 2.3 `Step_Landing_Page_Builder` payload validation, identity preflight, renames, skip-all
+- [x] 2.4 Lazy canonical bootstrap (`state.home_sections` → Home `page_sections` → neutral gen)
+- [x] 2.5 `Content_Builder` whitelist `meta_input` (`_wp_page_template`, `rms_landing_type`)
+- [x] 2.6 `delete_unselected_pages()` landing guard + controlled unlock enabled
 
-## Review Follow-up Fixes (cumulative)
+### Phase 2 PR2 review-blocker follow-up
+- [x] Deactivate live required/dispatch for `landing-page-builder` until Phase 3 UI+noindex
+- [x] Identity cross-pair validation + stricter slug collisions
+- [x] Keyword AI failure → `WP_Error` (or preserve existing landing); no placeholder publish
+- [x] Multi-landing partial-failure state persistence before failed status
+- [x] Critical persistence post-state checks (state, status, meta, canonical write)
+- [x] Reviewer/JSON observability + neutral priors for reusable/canonical paths
+
+### Phase 2 PR2 remaining reliability follow-up
+- [x] `generate-pages` excludes residual SEO/Ads landings from select/update/Home-Blog assignment (fail-closed `WP_Error`); deletion guard retained
+- [x] `build_one_landing()` thrown exceptions converted to `WP_Error` + partial persistence path
+- [x] `try_preserve_existing_landing()` checks `wp_update_post()` / meta results (no false preserve success)
+- [x] Document duplicated Home/Landing helper families + extraction plan after PR3/before archive
+- [x] `landing_pages_equivalent()` expanded beyond id/key/slug/type (title, keywords, menu_eligible, generated_at, preserved)
+- [x] Local try/catch around `Content_Builder::build_page()` with post-ID recovery + contextual `WP_Error` (outer partial recovery unchanged)
+
+Phase 3/4 tasks remain incomplete (including 3.7 activation).
+
+## Phase 1 Review Follow-up Fixes (preserved)
 
 | Finding | Severity | Fix |
 |---------|----------|-----|
-| `landing-page-builder` required before runtime | BLOCKER | Removed from active `REQUIRED_STEPS`; 7-step completion remains valid via shared `get_required_steps()` |
+| `landing-page-builder` required before runtime | BLOCKER | Removed from active `REQUIRED_STEPS` in Phase 1 |
 | Canonical store nondeterministic persistence | WARNING | Cache mutates only after successful `update_option()` or verified equal full post-state entry |
-| Unlock/relock nondeterministic persistence | WARNING | Post-state option equality checks; fail + rollback on unlock; fail if still unlocked after relock |
-| Phase 1 unlock exposes destructive reruns | WARNING | `CONTROLLED_UNLOCK_ENABLED = false`; no unlock admin-post registration until Phase 2 deletion guard; REST unlock returns 503; relock kept for stale cleanup |
-| `RMS_WIZARD_FORCE` UI ambiguity | WARNING | Explicit force-unlocked notice; suppress unlock messaging under force mode |
-| Premature `landing_page_builder` alias pollutes state | WARNING | Removed Phase 1 alias; `is_dispatchable_step()` rejects unknown/unimplemented steps **before** status writes |
-| Stale unlock marker bypasses lock | BLOCKER | `has_unlock_marker()` vs effective `is_unlocked()`; lock ignores markers while controlled unlock disabled |
-| View duplicates unlock source of truth | WARNING | `wizard-init.php` trusts only `$state` from `get_resume_state()` |
-| Untracked local docs risk commit | WARNING | `.gitignore` entries for local docs |
-| Step status stuck `running` on throw | WARNING | catch marks progress steps `failed`; logs if failed-status write itself fails |
-| Dead `assert_required_steps_parity()` | WARNING | Removed; shared `get_required_steps()` is the single list |
-| Duplicate completion-flag helper | WARNING | Removed `Wizard_Unlock_Controller::has_completion_flag()`; use `State_Manager::has_completion_flag()` |
-| Tautological unlock `$at_ok`/`$by_ok` | WARNING | Simplified to post-state equality only |
-| Canonical success ignored `generated_at` | WARNING | Full entry compare (payload + generated_at) after reload |
-| Unlock/relock failures silent | WARNING | Logger records persist failures + residual rollback markers |
-| Duplicate execute_step success shape | INFO | Single success return path after dispatch |
+| Unlock/relock nondeterministic persistence | WARNING | Post-state option equality checks |
+| Premature `landing_page_builder` alias pollutes state | WARNING | Unknown-step reject before status writes |
+| Stale unlock marker bypasses lock | BLOCKER | `has_unlock_marker()` vs effective `is_unlocked()` |
+| Completion flag SoT | WARNING | `State_Manager::has_completion_flag()` only |
 
-## Files Changed (this batch)
+## Phase 2 PR2 Review Blocker Fixes
+
+| Finding | Severity | Fix |
+|---------|----------|-----|
+| Live backend can publish Ads indexable before Phase 3 noindex | BLOCKER | Safer smaller fix: keep `Step_Landing_Page_Builder` implemented but remove `landing-page-builder` from `REQUIRED_STEPS` + `DISPATCHABLE_STEPS`. Dispatch case + alias retained for Phase 3 atomic activation (task 3.7). Existing 7-step UI completion unchanged. |
+| UI/required mismatch (7-step UI vs 8th required) | BLOCKER | Same deactivation; completion stays 7 required steps until UI can send payload/`skip_all`. |
+| Identity mismatch id+key | BLOCKER | `match_existing_landing()` rejects stale cross-pair when both non-empty id and landing_key disagree; order id → key → slug; slug collisions reject other pages (landing or not) when id already matched. |
+| Keyword AI failure publishes placeholders | BLOCKER | `generate_section_copy(..., require_ai=true)` returns `WP_Error` on AI/decode/review/empty-validation failure for hero/seo-content. Updates may preserve existing valid page_sections instead of placeholders. Logs include landing_key/slug/layout. |
+| Multi-landing partial failure diverges state | HIGH | On failure after N-1 successes, `persist_partial_landing_progress()` saves `landing_pages` + canonical summary first, logs counts/post IDs, then marks step failed (logs if status write fails). No delete of updated existing landings. |
+| Persistence checks | HIGH | `persist_wizard_state` / `mark_step_status` re-read post-state; meta safety-net verifies template+type; canonical `replace`/`set_if_empty` failures logged and fall back when possible. Critical full-run state/status failures return `WP_Error`. |
+| Reviewer/JSON observability + keyword priors | HIGH | Reviewer throwables and invalid JSON-on-success logged with context. Reusable/canonical paths use `filter_neutral_priors()` so keyword sections do not pollute neutral generation/review. |
+| `generate-pages` can publish/assign residual landings | BLOCKER | Fail-closed: selected slugs resolving to `rms_landing_type` `seo`/`ads` return `WP_Error` (`rms_wizard_page_slug_is_landing`) before cleanup/update; loop + `assign_reading_pages()` refuse landing Home/Blog assignment; deletion guard kept. |
+| Partial recovery misses thrown exceptions | WARNING | Each `build_one_landing()` call wrapped in try/catch; `\Throwable` → contextual `WP_Error` then existing `persist_partial_landing_progress()`. |
+| `try_preserve_existing_landing()` ignores update result | WARNING | Capture `wp_update_post(..., true)`; on `WP_Error`/invalid result or meta failure log and return `WP_Error` (no false preserved success). |
+| `landing_pages_equivalent()` too narrow | WARNING | Normalize/compare id, landing_key, title, slug, landing_type, menu_eligible, primary_keyword, order-insensitive subkeywords, generated_at, preserved — reject stale/partial state as “saved”. |
+| `build_page()` throwable after create/update bypasses recovery | WARNING | Local try/catch around `build_page()` → contextual `WP_Error` (`landing_key`/`slug`/`title`, recovered `post_id` when known); outer loop still runs `persist_partial_landing_progress()` for prior successes. |
+| Readability/size (shared helper extraction) | WARNING | **Deliberate duplication retained** with Home Builder. See Known limitations for named helper families + extraction plan after PR3/before archive. |
+
+## Files Changed (Phase 2 batch + review fixes)
 
 | File | Action | What Was Done |
 |------|--------|---------------|
-| `inc/wizard/class-wizard-unlock-controller.php` | Modified | SoT completion flag; simplified post-state checks; failure/rollback logging |
-| `inc/wizard/class-canonical-section-store.php` | Modified | Full-entry post-state verification including `generated_at` |
-| `inc/wizard/class-step-controller.php` | Modified | Deduped success return; log failed-status write failure on throw |
-| `inc/wizard/wizard-init.php` | Modified | Register unlock admin-post only when enabled; relock notice always; keep gated unlock UI for Phase 2 |
-| `openspec/changes/wizard-landing-page-builder/apply-progress.md` | Modified | This progress note |
+| `inc/wizard/class-ai-content-harness.php` | Modified | Distinct `PAGE_LANDING` Layer 2; keyword inject only hero/seo-content |
+| `inc/wizard/class-step-home-page-builder.php` | Modified | After success, `set_if_empty` reusable prepared rows |
+| `inc/wizard/class-step-landing-page-builder.php` | Created + hardened | Full backend + PR2 safety: identity, keyword fail-closed, partial persist, persistence checks, observability, neutral priors, richer state equivalence, local `build_page()` exception boundary |
+| `inc/wizard/class-content-builder.php` | Modified | Whitelist-only `meta_input` |
+| `inc/wizard/class-step-generate-pages.php` | Modified | Landing deletion guard + select/update/reading-assignment exclusion (fail-closed) |
+| `inc/wizard/class-wizard-unlock-controller.php` | Modified | `CONTROLLED_UNLOCK_ENABLED = true` |
+| `inc/wizard/class-step-controller.php` | Modified | PR2: required/dispatch remain 7 steps; dispatch case + alias kept dormant with Phase 3 activation comments |
+| `openspec/changes/wizard-landing-page-builder/tasks.md` | Modified | Phase 2 complete + compatibility notes + task 3.7 activation |
+| `openspec/changes/wizard-landing-page-builder/apply-progress.md` | Modified | This cumulative progress note + helper-duplication known limitations |
 
-## Intentionally not changed
+## Intentionally not changed (Phase 3+)
 
-- **Unlock UI branch behind `$unlock_ui_enabled`**: left in place (dead in Phase 1) so Phase 2 task 2.6 can flip `CONTROLLED_UNLOCK_ENABLED` without reintroducing the form. Risk of removing it outweighs PR-size gain.
-- **REST `/steps/unlock/run` route**: still dispatchable, but `unlock()` hard-gates with 503 while disabled — keeps a clear unavailable contract instead of pretending the step is unknown.
-- **Phase 2/3/4 landing runtime / TS / template**: out of Phase 1 scope.
-- **No commit/push**: per apply instructions.
+- Menu append/remove / Menu Setup landing merge
+- Yoast title/metadesc/noindex + `wp_robots` + ads sitemap
+- Admin TS/SCSS landing UI
+- `pages/landing-page.php` flexible loop / breadcrumb
+- Shared Home/Landing section-assembly extraction (documented follow-up)
+- Local docs: `Wizard ai harness prompt guide.md`, `wizard-prd.html`
+- No commit/push
+
+## Design notes (Phase 2 + PR2 safety)
+
+- Landing **runtime code** is present; **activation** is Phase 3 (required + dispatchable + UI + noindex/menu).
+- Controlled unlock enabled only because 2.6 deletion guard shipped in the same backend slice.
+- Ads noindex/menu final-state sync deferred to Phase 3 (by design; PR2 cannot go live without it).
+- Keyword scope strict: only `hero` / `seo-content` receive keywords; overrides stay neutral (`PAGE_HOME`).
+- Canonical first-write only; overrides never write store; replace requires `replace_canonical` + confirm flag.
+- Bootstrap failure returns actionable `WP_Error` (`rms_wizard_canonical_bootstrap_failed`).
+
+## Known limitations
+
+1. Step is not callable via REST until Phase 3 activation — intentional PR2 safety.
+2. **Deliberate Home Builder / Landing Builder helper duplication** (readability debt, not a runtime bug). Duplicated helper families today:
+   - Section assembly / section row preparation (`section_data`, service row contracts, image fallbacks orchestration)
+   - Placeholder copy builders (`placeholder_copy`, `placeholder_repeater_rows`, `placeholder_field_value`)
+   - Item-count defaults / clamp (`item_count` and the shared max section item limit **`12`**)
+   - Reviewer/config helpers (`reviewer()`, `is_review_enabled()`, review wiring around AI decode)
+   - Text/HTML/JSON helpers (`text`, `html`, `section_value`, `decode_json_content`, `truthy`)
+   - Completion helper (`maybe_mark_completed` against `Step_Controller::get_required_steps()`)
+   - **Follow-up plan**: extract a shared section-assembly / content-helper collaborator **after PR3 lands or before archive** — not in this PR2 reliability patch. Also extract the repeated max item limit `12` to a named constant during that cleanup.
+3. No automated behavioral tests / no test runner (`strict_tdd: false`). Reliability is verified via `php -l` + code review only — do not claim automated behavior coverage.
+4. Preserve-on-keyword-failure path updates title/slug/meta only; does not rewrite sections.
+5. Partial-failure recovery does not roll back newly created posts (prefers state persistence over destructive delete). Thrown exceptions (including local `build_page()` catch) convert to `WP_Error` and use the same partial persistence path as returned errors. Recovered orphan post IDs are logged/error-data only — not auto-added to successful `landing_pages`.
 
 ## Verification
 
-Automated behavioral tests are **unavailable** by project config (`openspec/config.yaml`: `strict_tdd: false`, testing section unavailable).  
-Phase 1 relies on **PHP syntax (`php -l`) + 4R fresh review + later manual runtime verification (Phase 4)**. Do not pretend unit/integration tests exist.
+```
+php -l inc/wizard/class-step-landing-page-builder.php
+```
 
-```
-php -l inc/wizard/class-wizard-unlock-controller.php
-php -l inc/wizard/class-canonical-section-store.php
-php -l inc/wizard/class-step-controller.php
-php -l inc/wizard/wizard-init.php
-```
+(Plus prior Phase 2 `php -l` on generate-pages/controller/harness/content-builder/unlock/home-builder.)
+
+Mode: **Standard** (`openspec/config.yaml` → `strict_tdd: false`, no test runner). No automated behavior tests exist for these reliability paths.
+
+## Workload / PR Boundary
+
+- Mode: chained PR slice (feature-branch-chain)
+- Current work unit: PR2 Backend Landing + remaining reliability follow-up (equivalence + build_page boundary)
+- Boundary: Phase 2 tasks 2.1–2.6 hardened for standalone PR safety; no Phase 3 UI/menu/template
+- Estimated review budget impact: small incremental reliability patch on PR2 surface
 
 ## Status
 
-Phase 1 final cleanup complete. Ready for PR prep / re-verify of Phase 1 slice.  
-Do **not** mark Phase 2 tasks complete. Do not start Phase 2 in this batch.
+Phase 1 + Phase 2 complete with PR2 remaining reliability warnings addressed (10/19 tasks incl. new 3.7). Ready for PR2 re-review / next batch Phase 3 UI/menu/SEO/template + activation.

--- a/openspec/changes/wizard-landing-page-builder/design.md
+++ b/openspec/changes/wizard-landing-page-builder/design.md
@@ -1,0 +1,216 @@
+# Design: Wizard Landing Page Builder
+
+## Technical Approach
+
+Add `landing-page-builder` as the **8th step** (after menu setup) mirroring `Step_Home_Page_Builder`, dispatched via existing `POST /rms-wizard/v1/steps/{step}/run` (no new routes). Reusable copy lives in first-write `Canonical_Section_Store`, with **lazy canonical bootstrap** before landing generation when the store is empty (existing completed/unlocked sites). Keyword copy (`hero`, `seo-content`) comes from `AI_Content_Harness` with distinct `PAGE_LANDING` Layer 2 and keyword-injected Layer 3. Pages are created only in this step via `Content_Builder::build_page()` with whitelist `meta_input`. Unlock is reversible via `Wizard_Unlock_Controller` (`unlock`/`relock` POST pseudo-steps only; state remains existing GET `/state`). After each upsert, **final-state** menu + robots sync: SEO landings get idempotent `Menu_Builder::append_page_items()`; Ads get `remove_page_items` + noindex (type flips reconcile both sides). **Menu Setup re-runs MUST** merge eligible landings and run the same final-state menu reconciliation after destructive menu replacement. Per-landing Yoast title/metadesc are written when Yoast is active. **Data-loss guard:** `Step_Generate_Pages::delete_unselected_pages()` must never delete landing pages (see Architecture Decisions).
+
+## Architecture Decisions
+
+| Decision | Alternative rejected | Chosen + Rationale |
+|---|---|---|
+| Landing render path | Keep hardcoded `get_template_part()` — `get_sub_field()` null outside loop; inject breadcrumb on every hero. | Mirror `front-page.php`: flexible ACF loop + hardcoded fallback. **Inject `breadcrumb-slim` once after the first Hero row only** when loop-rendering (not an ACF layout; not repeated for later hero rows; preserves current landing template semantics). |
+| Template meta at insert | Post-insert `update_post_meta` — first render wrong. | **Rescope** `Content_Builder::build_page()`: optional whitelist-only `meta_input` pass-through for `_wp_page_template` and `rms_landing_type` only (sanitized; no arbitrary keys). |
+| Canonical payload shape | Raw AI JSON. | Full prepared ACF row (`acf_fc_layout`, fallbacks); landings copy 1:1 into `page_sections`. |
+| Keyword injection | New harness method. | Extend signature: `get_layer3( string $layout, int $item_count, array $client_context, string $page_type = self::PAGE_HOME, array $keywords = [] )`. Existing Home Builder calls remain valid. Placeholders only when `PAGE_LANDING` AND layout ∈ {`hero`,`seo-content`}; server drops empties, clamps to 10. |
+| Layer 2 landing | Fall through unsupported-type warning. | `get_layer2(PAGE_LANDING)` returns a **distinct landing context block**; unsupported-type warning must **not** fire for `PAGE_LANDING`. |
+| Unlock transport | New REST route — forbidden. | **POST pseudo-steps only:** `unlock` and `relock` on the existing run route. **Do not** treat `state` as a run-route pseudo-step — state is already served by existing **GET** `/rms-wizard/v1/state`. `execute_step()` **completed-gate allowlist: `unlock`, `relock` only** → dispatch to `Wizard_Unlock_Controller`. Unlock/relock **must bypass** `set_current_step()` and `set_step_status()` (short-circuit before normal status writes) to prevent pseudo-step pollution. Options: `rms_wizard_unlocked_at`, `rms_wizard_unlocked_by` (separate; not one combined option). `is_completed()` false while unlocked; never touch `rms_wizard_completed`. |
+| Menu eligibility | Pollute `generated_pages`; call `wp_update_nav_menu_item()` ad hoc from the landing step; append-only (duplicates on re-run; stale items after type flip); optional Menu Setup merge (landings dropped on destructive re-run). | Keep landing step **8th after menu setup**. After each successful landing upsert, run **final-state menu + robots reconciliation** (not append-only): (1) **SEO → eligible:** `Menu_Builder::append_page_items()` adds the page **idempotently** (skip if already present); (2) **Ads / ineligible:** `Menu_Builder::remove_page_items()` removes that page from configured menus; (3) **type flip SEO→Ads:** remove from menus + write noindex meta + ensure `wp_robots` applies; (4) **type flip Ads→SEO:** clear noindex meta + append if menu exists and page is menu-eligible. Re-running SEO landings **must not** duplicate menu items. Ads never menu-eligible. `state.landing_pages` rows carry stable `id`/`landing_key`, `slug`, `landing_type`, `menu_eligible` (seo `true`, ads `false`). **Menu Setup re-run (mandatory):** existing Menu Setup **destructively replaces** menus. If SEO landings already exist, a re-run would drop landing menu items unless reconciled. Therefore `Step_Menu_Setup` **MUST** (not optional): (a) **merge** all `state.landing_pages` with `menu_eligible === true` into its slug/id pool before build; (b) **exclude** Ads / `menu_eligible === false`; (c) immediately after menu replacement, run the **same final-state menu reconciliation** used by the landing step — eligible SEO landings present **idempotently**, Ads **removed**. Primary per-upsert sync remains in the landing step; Menu Setup reconciliation is the **required safety net** for unlock/re-run of step 7 after landings exist. |
+| Lazy canonical bootstrap | Assume canonical exists only after future Home Builder success; landing generation fails or invents empty reusables on older completed sites. | Before any landing section assembly, Landing Builder **MUST ensure** required reusable layouts exist in `Canonical_Section_Store`. **Bootstrap source order (first success wins, first-write only via `set_if_empty`):** (1) existing `state.home_sections` prepared reusable rows if available and valid; (2) else current Home page ACF `page_sections` reusable rows if present and valid; (3) else generate **neutral** reusable sections (same path as Home Builder reusable generation without keyword injection) and first-write them. Seed `state.canonical_sections` summary when writes succeed. If bootstrap **cannot** produce the required reusable content after all sources, **block** landing generation for rows that need those layouts and surface an **actionable UI error** (e.g. re-run Home Builder or fix Home page sections) — do not create landings with empty/invalid reusable payloads. Keyword layouts (`hero`, `seo-content`) are never bootstrapped from canonical; they always come from the harness. |
+| Per-landing Yoast SEO | Title/metadesc omitted or only noindex. | When Yoast is **active**, for **each** created/updated landing write `_yoast_wpseo_title` and `_yoast_wpseo_metadesc` derived from `primary_keyword` + `landing_type` (via `Yoast_Meta_Writer` or step helper). When Yoast is **absent**, **skip** title/metadesc writes and **log** once per run (do not fail the step for missing Yoast). Ads still require noindex path below. |
+| Ads noindex | Yoast alone lost if disabled. | Extend `Yoast_Meta_Writer` (or small step helper) to write `_yoast_wpseo_meta-robots-noindex` = `1`; **read-back must equal `1`** or block completion. Plus `wp_robots` filter in always-loaded `wizard-init.php`. |
+| Ads sitemap | No exclusion. | Scoped exclusion of `rms_landing_type=ads` from WP/Yoast sitemaps when those APIs are available. |
+| Completion / 0 landings | Ambiguous empty complete; required-step list drift. | Empty `landings[]` is a **valid no-op completion** only when the UI explicitly allows skip (skip/empty confirmed). If the user submits rows, every non-skipped row requires non-empty sanitized `primary_keyword` (server + UI reject otherwise). Add `landing-page-builder` to the **single source of truth** for required steps (prefer one shared constant/list consumed by both `REQUIRED_STEPS` and `maybe_mark_completed()`). If two lists must remain temporarily, **both** must be updated in the same change and asserted equal in a smoke check — never edit one without the other. |
+| Primary keyword | Optional. | Server and UI reject a landing row with empty sanitized `primary_keyword` unless the row is skipped/disabled. |
+| Rerun / stable identity | Blind re-create; payload rows without stable identity; slug fallback collides with standard pages. | Each payload row may carry optional stable **`id`** (WP post ID) and/or **`landing_key`** hydrated from `state.landing_pages` on UI load. **Match order:** (1) `id` if present and still a landing in state, (2) else `landing_key` if present, (3) else slug. **Preflight (reject before any write):** (a) **slug fallback** may only resolve to an existing page that has post meta `rms_landing_type` (seo\|ads) — never claim a non-landing page; (b) **reject** slug collisions with unmatched/non-landing pages (e.g. standard generated slugs like `services`); (c) **reject** duplicate non-empty `id` values within the payload; (d) **reject** duplicate non-empty `landing_key` values within the payload; (e) reject duplicate slugs within payload and against other landing-state entries (including rename collisions). **UI duplicate-row:** when the user duplicates a landing row, clear `id` and assign a **new** `landing_key` (never copy identity). On valid slug rename for a matched landing: update `post_name` and the corresponding `state.landing_pages` entry. |
+| Replace canonical | Unspecified confirm. | Reuse `rms_wizard_render_confirmation_modal`. Server accepts replace only when `replace_canonical[layout] === true` **and** explicit confirmation flag/token from the modal is present. |
+| Step_Generate_Pages reverse-overlap | Assume landings are safe because they bypass generate-pages creation. | **DATA-LOSS RISK (explicit):** after unlock/rerun, `Step_Generate_Pages::delete_unselected_pages()` deletes every page whose slug is **not** in the selected standard-page slug set. Landing pages are **not** standard slugs → they would be **hard-deleted** without a guard. **Mitigation (required):** modify `delete_unselected_pages()` to **exclude any page that has post meta `rms_landing_type`** (seo\|ads) from the deletion candidate set. Prefer meta exclusion over slug-pool merge: landings remain identifiable even if `state.landing_pages` is stale or empty. Optionally also merge slugs from `state.landing_pages` into the protected pool as defense-in-depth, but meta exclusion is the primary contract. Landings are still **created only** in `Step_Landing_Page_Builder`; reading settings untouched. |
+
+## Data Flow
+
+```
+wizard.ts (collectLandingPageBuilderPayload)
+    │ POST /rms-wizard/v1/steps/landing-page-builder/run
+    ▼
+Rest_Controller → Step_Controller (lock; completed allowlist unlock|relock only)
+    → Step_Landing_Page_Builder | Wizard_Unlock_Controller
+    ├─ preflight: reject dup non-empty id/landing_key; reject slug vs non-landing pages;
+    │    slug fallback only if target has rms_landing_type; match id → landing_key → slug
+    ├─ lazy canonical bootstrap (if store missing required reusables):
+    │    state.home_sections → else Home page_sections → else neutral generate
+    │    → set_if_empty + state.canonical_sections; fail with actionable UI error if still missing
+    ├─ hero/seo-content → Harness PAGE_LANDING + keywords → Provider → Reviewer → validate_fields()
+    ├─ reusable rows → Canonical_Section_Store (copy; override → neutral regen; fallback on empty/invalid)
+    ├─ Content_Builder::build_page( whitelist meta_input )
+    ├─ Yoast (if active): per-landing _yoast_wpseo_title + _yoast_wpseo_metadesc from primary_keyword + landing_type; else skip+log
+    ├─ final-state type sync (every update, not append-only):
+    │    SEO: clear noindex; Menu_Builder::append_page_items idempotent (no dupes)
+    │    Ads: write noindex + read-back; Menu_Builder::remove_page_items from configured menus
+    │    SEO→Ads / Ads→SEO flips apply both menu + robots sides
+    ├─ ads sitemap exclusion hooks as applicable
+    └─ state.landing_pages (id, landing_key, slug, …) → response → UI
+
+Menu Setup re-run (mandatory when landings exist):
+    Step_Menu_Setup
+      → MUST merge state.landing_pages where menu_eligible === true into slug/id pool
+      → MUST exclude Ads / menu_eligible === false
+      → destructive menu replace (existing behavior)
+      → MUST run final-state menu reconciliation immediately after replace:
+           eligible SEO landings → append_page_items idempotent
+           Ads → remove_page_items
+
+Separate (existing): GET /rms-wizard/v1/state — not a run-route pseudo-step.
+
+Generate-pages guard (unlock/rerun path):
+    Step_Generate_Pages::delete_unselected_pages()
+      → skip candidates with rms_landing_type meta (required)
+      → optional: also protect slugs in state.landing_pages
+```
+
+Home step delta: on success, prepared reusable rows → `set_if_empty()` + state summary (forward path for new runs). Existing completed sites without `rms_wizard_canonical_sections` rely on **lazy bootstrap** in Landing Builder (above).
+
+### `wp_robots` guard sequence
+
+Early return unless **all** of: `is_page()`, valid queried object ID, page template is `pages/landing-page.php`, and `rms_landing_type === ads`. Then force noindex.
+
+## File Changes
+
+| File | Action | Description |
+|---|---|---|
+| `inc/wizard/class-step-landing-page-builder.php` | Create | 8th step: identity preflight; **lazy canonical bootstrap** (`home_sections` → Home `page_sections` → neutral generate; actionable error if still missing); rows, keywords, sections, meta, final-state menu+robots sync, slug upsert |
+| `inc/wizard/class-canonical-section-store.php` | Create | `get/has/set_if_empty/replace/summary`; lazy load; used by Home first-write and Landing bootstrap |
+| `inc/wizard/class-wizard-unlock-controller.php` | Create | `unlock()`/`relock()`; writes `rms_wizard_unlocked_at` / `rms_wizard_unlocked_by` |
+| `inc/wizard/class-step-controller.php` | Modify | Shared required-steps source (or dual-list keep-in-sync); dispatch; completed-gate allowlist **`unlock`/`relock` only** (not `state`); unlock/relock bypass status writes |
+| `inc/wizard/class-state-manager.php` | Modify | New state defaults (`landing_pages` with id/landing_key); unlock-aware `is_completed()` |
+| `inc/wizard/class-ai-content-harness.php` | Modify | PAGE_LANDING Layer 2 distinct block; Layer 3 signature + keywords |
+| `inc/wizard/class-step-home-page-builder.php` | Modify | Canonical first-write; required list |
+| `inc/wizard/class-step-menu-setup.php` | Modify | **Mandatory** merge of `menu_eligible === true` landings into slug/id pool; exclude Ads; after destructive menu replace, run final-state menu reconciliation (idempotent SEO append + Ads remove) |
+| `inc/wizard/class-menu-builder.php` | Modify | `append_page_items` (idempotent); `remove_page_items`; shared landing menu reconciliation helper used by landing step + Menu Setup |
+| `inc/wizard/class-step-generate-pages.php` | Modify | **`delete_unselected_pages()`:** exclude pages with `rms_landing_type` meta (data-loss guard); optional protect `state.landing_pages` slugs |
+| `inc/wizard/class-content-builder.php` | Modify | Whitelist `meta_input` only: `_wp_page_template`, `rms_landing_type` |
+| `inc/wizard/class-yoast-meta-writer.php` | Modify | Per-landing title + metadesc from keyword/type when Yoast active; ads noindex write path (or equivalent small helper); skip+log when Yoast absent |
+| `inc/wizard/wizard-init.php` | Modify | Registry, form, unlock notice, `wp_robots`, ads sitemap exclusion |
+| `src/ts/admin/wizard.ts` | Modify | Collector (optional `id`/`landing_key`); duplicate-row clears `id` + new `landing_key`; skip/empty; keyword validation; unlock; replace modal |
+| `src/scss/admin/wizard.scss` | Modify | Landing/unlock admin styles only |
+| `pages/landing-page.php` | Modify | Flexible loop + inject `breadcrumb-slim` once after first Hero row only |
+
+No new ACF fields/layouts. Untracked docs untouched. State remains GET `/state` only — not a POST run pseudo-step.
+
+## Interfaces / Contracts
+
+```php
+// Payload (wizard.ts → step)
+[
+  'landings' => [ [
+    'id' => int|null,                // optional; WP post ID hydrated from state.landing_pages
+    'landing_key' => string|null,    // optional stable key hydrated from state (survives slug rename)
+    'title', 'slug', 'landing_type', // seo|ads
+    'primary_keyword',               // required unless row skipped
+    'subkeywords' => string[],
+    'sections' => [ [ 'layout', 'override_canonical' => bool ] ],
+    'skipped' => bool,               // optional; skipped rows ignored
+  ] ],
+  'replace_canonical' => [ '{layout}' => bool ],
+  'confirm_replace_canonical' => bool|string, // modal flag/token required with any replace true
+  'skip_all' => bool,                // explicit UI skip → 0-landing no-op complete
+]
+
+// Harness
+get_layer3( string $layout, int $item_count, array $client_context,
+            string $page_type = self::PAGE_HOME, array $keywords = [] ): ...
+get_layer2( /* PAGE_LANDING */ ): // distinct landing context; no unsupported warning
+
+// Canonical_Section_Store
+set_if_empty( string $layout, array $row ): bool;
+replace( string $layout, array $row ): bool; // only if replace_canonical[layout] && confirm
+get( string $layout ): array;  has( string $layout ): bool;
+
+// Menu_Builder — final-state reconciliation helpers (not append-only)
+append_page_items( int $menu_id, array $page_ids ): array;
+// Idempotent: skip page_ids already present as menu items; never duplicate.
+remove_page_items( int $menu_id, array $page_ids ): array;
+// Remove nav items pointing at those page IDs (when landing becomes Ads/ineligible).
+// Shared helper (preferred): reconcile_landing_menu_items( menus, state.landing_pages )
+//   — eligible SEO present idempotently; Ads removed. Called from:
+//   (1) Step_Landing_Page_Builder after each upsert
+//   (2) Step_Menu_Setup immediately after destructive menu replacement (MANDATORY)
+
+// Step_Menu_Setup re-run contract (MANDATORY — not optional)
+// 1. Merge state.landing_pages where menu_eligible === true into slug/id pool before build.
+// 2. Exclude Ads / menu_eligible === false from pool.
+// 3. After menu replacement: run final-state menu reconciliation (same as landing step).
+
+// Canonical_Section_Store — lazy bootstrap (Landing Builder, before generation)
+// ensure_canonical_reusables(): if required layouts missing:
+//   (1) seed from state.home_sections if valid
+//   (2) else seed from Home page ACF page_sections if valid
+//   (3) else generate neutral reusable rows and set_if_empty
+//   On total failure: return error → step surfaces actionable UI message; do not build landings
+//   needing missing layouts. Keyword layouts (hero, seo-content) never come from bootstrap.
+
+// Content_Builder meta_input whitelist (sanitized values only)
+// _wp_page_template, rms_landing_type
+
+// Step_Generate_Pages::delete_unselected_pages()
+// MUST skip any page with post meta rms_landing_type (seo|ads).
+// Optional defense-in-depth: also protect slugs listed in state.landing_pages.
+
+// Unlock options (separate) — POST run pseudo-steps: unlock, relock only
+// rms_wizard_unlocked_at, rms_wizard_unlocked_by
+// State: existing GET /rms-wizard/v1/state (not a run pseudo-step)
+
+// Completion gate — single source of truth for required steps
+// Prefer one shared list/constant used by REQUIRED_STEPS and maybe_mark_completed().
+// If dual lists remain, both updated together + asserted equal (prevent drift).
+
+// Yoast per landing (when Yoast active)
+// _yoast_wpseo_title, _yoast_wpseo_metadesc ← from primary_keyword + landing_type
+// When Yoast absent: skip title/metadesc writes + log; do not fail step for missing Yoast
+// Ads: _yoast_wpseo_meta-robots-noindex = 1 (write+read-back); SEO: clear noindex meta
+// wp_robots filter always applies for ads landings (wizard-init.php)
+
+state.landing_pages[]    = [ 'id', 'landing_key', 'slug', 'landing_type', 'menu_eligible', 'keywords' ];
+state.canonical_sections = [ '{layout}' => [ 'has_payload', 'generated_at' ] ];
+```
+
+Post meta: `rms_landing_type` (`seo|ads`), `_wp_page_template`, `_yoast_wpseo_title`, `_yoast_wpseo_metadesc` (when Yoast active), `_yoast_wpseo_meta-robots-noindex` (ads; read-back `1`; cleared when type becomes SEO).
+
+**Rerun / identity preflight + match:**
+1. **Reject** payload with duplicate non-empty `id` values or duplicate non-empty `landing_key` values.
+2. **Match** existing `state.landing_pages` by **`id` first**, then **`landing_key`**, then **slug**.
+3. **Slug fallback** may only match an existing WP page that has `rms_landing_type` post meta; otherwise treat as no match for update.
+4. **Reject** slug collision with an unmatched/non-landing page (e.g. standard page `services`) — do not overwrite or “claim” non-landings.
+5. Reject intra-payload duplicate slugs and collisions with other landing-state slugs (including rename collisions).
+6. On match + valid slug rename: update `post_name` + state row.
+7. **UI duplicate row:** clear `id`; mint a new `landing_key`.
+
+**Landing-type final-state sync (every successful create/update AND after Menu Setup replace):**
+| Transition / state | Menu | Robots / meta |
+|---|---|---|
+| SEO (create, re-run, or Ads→SEO) | `append_page_items` idempotent if menu exists + menu-eligible | Clear `_yoast_wpseo_meta-robots-noindex` |
+| Ads (create, re-run, or SEO→Ads) | `remove_page_items` from configured menus | Write noindex `1` + read-back; `wp_robots` applies |
+| Re-run same type | Reconcile to final state (no duplicate menu items; no leftover noindex on SEO) | Same |
+| Menu Setup re-run (after destructive replace) | **MUST** re-apply same menu final state for all `state.landing_pages` (eligible SEO present idempotently; Ads removed) | Robots unchanged by Menu Setup (landing step owns meta) |
+
+## Testing Strategy
+
+No automated runner (`openspec/config.yaml`).
+
+| Layer | What | Approach |
+|---|---|---|
+| Syntax/type | Modified PHP / TS | `php -l` per file; `tsc --noEmit` |
+| Scenario | Spec scenarios | Manual: seo+ads, skip-all no-op, keyword reject, identity preflight (dup id/key reject, slug vs non-landing reject, slug fallback only with `rms_landing_type`), UI duplicate clears id+new key, rerun upsert by id/key/slug + rename, SEO↔Ads type flip (menu remove/append + noindex clear/set, no menu dupes on re-run), **Menu Setup re-run after SEO+Ads landings exist** (eligible SEO items restored idempotently; Ads absent from menus), **lazy canonical bootstrap** on completed site with empty `rms_wizard_canonical_sections` (seeds from home_sections → page_sections → neutral; actionable error if all sources fail), unlock/relock status (GET state separate), Yoast title/metadesc when active / skip+log when absent, sitemap ads exclusion, generate-pages does **not** delete landings after unlock, replace modal, required-steps list parity |
+| Manual audit | Landing frontend | Template first-load, breadcrumb once after first hero only, `wp_robots`, DOM < 1500, lazy images |
+
+## Migration / Rollout
+
+No bulk data migration; additive options/state. Completed sites re-open via unlock.
+
+**Existing completed / unlocked sites (pre-landing-builder):** may lack `rms_wizard_canonical_sections` because canonical first-write only ran after Home Builder success on *future* runs. **No backfill job required.** On first Landing Builder run, **lazy canonical bootstrap** (Architecture Decisions) seeds the store from `state.home_sections` → Home `page_sections` → neutral generate, then first-writes. If bootstrap fails, the step errors with an actionable UI message rather than creating broken landings.
+
+**Menu Setup after landings:** sites that re-run Menu Setup post-landing must pick up the mandatory merge + final-state reconciliation (no separate migration).
+
+Rollback: revert chained PRs; delete unlock options, `state.landing_pages`, and `rms_wizard_canonical_sections` if written. Delivery: chained PRs under 400 lines (`force-chained`).
+
+## Open Questions
+
+None — all prior open questions resolved above.

--- a/openspec/changes/wizard-landing-page-builder/exploration.md
+++ b/openspec/changes/wizard-landing-page-builder/exploration.md
@@ -1,0 +1,244 @@
+# Exploration: Wizard Landing Page Builder
+
+## Current State
+
+The wizard (`inc/wizard/wizard-init.php`, `inc/wizard/class-step-controller.php`, `inc/wizard/class-rest-controller.php`) ships a 7-step flow that ends with a Home Page Builder step:
+
+1. `dependencies` — TGMPA plugin check/install
+2. `acf-import` — Import ACF JSON
+3. `client-data` — Save Theme Settings via `Client_Data_Fields`
+4. `generate-pages` — Create the wizard-selected pages and assign Home/Blog reading options
+5. `menu-setup` — Build primary/mobile menus from generated pages
+6. `ia-generation` — Configure AI provider, model, and encrypted credentials
+7. `home-page-builder` — Build selected ACF flexible-content sections on the Home page
+
+The Home Page Builder (`inc/wizard/class-step-home-page-builder.php`) is the architectural reference for this change. It already:
+- Pulls `state.client_data` and validates required harness context via `AI_Content_Harness::validate_required_context()`.
+- Composes 3-layer prompts per section: `Layer 1` (global editorial system prompt) + `Layer 2(PAGE_HOME)` → `system`; `Layer 3(layout, item_count, client_context)` → `user`. See `class-step-home-page-builder.php:230-253`.
+- Calls the configured AI provider through `AI_Provider_Registry::make_provider( $provider )->generate( $model, $prompt, $context, $system )`.
+- Passes decoded payloads through `AI_Content_Reviewer::review()` with `prior_section_payloads` for cross-section repetition detection (`class-step-home-page-builder.php:267-302`).
+- Re-uses `Content_Builder::build_page( [ 'id' => $home_page_id, 'section_only' => true, 'sections' => $prepared_sections ] )` to persist the Home page's `page_sections` ACF field (`class-content-builder.php:59-107`).
+- Stores `selected_home_sections`, `home_section_rows`, and `home_sections` on the state option (`class-step-home-page-builder.php:115-119`).
+
+The harness is already prepared for landing pages:
+- `AI_Content_Harness::PAGE_LANDING` constant is defined (`class-ai-content-harness.php:19`).
+- `get_layer2()` only validates `PAGE_HOME !== $page_type` and falls back to a warning; `PAGE_LANDING` would fall back today (`class-ai-content-harness.php:328-348`). A real `PAGE_LANDING` block (purpose, tone, section-ordering guidance) is a TODO and must be added.
+- The harness guide (`Wizard ai harness prompt guide.md`, untracked) already lists `hero` and `seo-content` as the keyword-driven landing sections and enumerates the per-field editorial contracts that are now enforced in PHP constants (`AI_Content_Harness::EDITORIAL_RULES`).
+
+A page template already exists: `pages/landing-page.php` (Template Name: "SEO Landing Page") hardcodes the section order hero → breadcrumb-slim → seo-content → vision-mission-v1 → badges → portfolio-v1 → seo-content → testimonials-v1 → seo-content. `header.php` already defers its assets when this template is in use. This template is the rendering surface the new builder must drive for v1; it is not used by the wizard today.
+
+The PRD (`wizard-prd.html`, untracked) already states the user-facing requirement: "tantas landing pages como desee, sin límite" with the same section dynamics as the Home (R-11). The keyword governance model requested by the user (keyword only on Hero + SEO Content, canonical reusable for everything else, per-landing override allowed) is a new product layer that does not exist yet.
+
+State shape today (`class-state-manager.php:25-43`) has `client_data`, `generated_pages`, `home_page_slug`, `blog_page_slug`, `ai_config`, `menu_config`, `selected_home_sections`, `home_sections`. There is no concept of canonical reusable section content, no landing pages registry, no keyword context, and no `landing_type` (seo vs ads).
+
+The wizard TypeScript client (`src/ts/admin/wizard.ts`) is generic over the step list: it reads `state.step_status`, renders step panels from `data-wizard-step-panel`, builds payloads via `collectPayload(step)` (with per-step collectors for `generate-pages`, `menu-setup`, `ia-generation`, `home-page-builder`), and dispatches `POST /rms-wizard/v1/steps/{step}/run` with a JSON body. The only Home Builder–specific branch in TS is `collectHomePageBuilderPayload()` (referenced at `wizard.ts:500-502`); everything else is data-driven from server-rendered JSON inside `<script type="application/json">` blocks.
+
+REST surface (`class-rest-controller.php`) already exposes generic `POST /steps/{step}/run` and `GET /state`, so new step slugs do not need new routes. The completion gate (`Step_Controller::REQUIRED_STEPS`) and `Step_Home_Page_Builder::maybe_mark_completed()` both hardcode the same 7-step list, so a new step requires updating both call sites in lockstep. Adding an 8th step on a site that already shows `rms_wizard_completed = true` must be handled via a controlled unlock path (admin notice + explicit "unlock wizard" action) rather than a destructive reset.
+
+## Product Decisions (confirmed by user)
+
+These decisions are now part of the contract for this change. They are not open questions.
+
+1. **Canonical store location** — Canonical reusable section content lives in a dedicated option, `rms_wizard_canonical_sections`, NOT inside the wizard state. `State_Manager` does not load it on every read; `Canonical_Section_Store` lazy-loads it on demand. The wizard state only tracks a small `canonical_sections_summary` (which layouts have a canonical payload and the `generated_at` timestamp) so the Landing step can surface staleness without reading the full payloads.
+2. **First-write canonical semantics** — Canonical reusable content is **first-write by default**. The Home Page Builder (and Landing Page Builder) can populate the canonical store when it is empty for a given layout. Re-runs **MUST NOT** overwrite canonical content automatically. Overwriting requires an explicit user action (a "publish as canonical" / "replace canonical" affordance — see Open Questions). This applies in both directions: a Home re-run does not silently rewrite canonical About copy, and a Landing run that produces a reusable payload only writes to canonical if the store is empty for that layout.
+3. **Testimonials are canonical/reusable** — `testimonials-v1/v2/v3` are part of the reusable set and participate in the canonical store like every other non-hero/non-seo-content layout. They are NOT landing-keyword-specific.
+4. **V1 override UX** — A per-section checkbox labeled `Regenerate only for this landing` (internal name `override_canonical`) is the only override mechanism in v1. When checked, the harness is called for that row on that landing and the result is written to the landing's `page_sections` only. The canonical store is never touched on the override path. There is no "regenerate all overridable sections" button in v1.
+5. **Subkeywords range** — 0 to 10 subkeywords per landing. The UI accepts a free-text, comma- or newline-separated list; the server clamps the count to 10 and silently drops empties. Hero and SEO Content are the only sections that consume them. Default is 0 (none) when the field is empty.
+6. **Yoast meta per landing** — The Landing Page Builder generates a per-landing meta title and description (sourced from the primary keyword + landing type intent) and writes them via the existing `Yoast_Meta_Writer` whenever Yoast is available/active. The capability check is `is_plugin_active( 'wordpress-seo/wordpress-seo.php' )` OR `defined( 'WPSEO_VERSION' )`. If neither is true, the meta generation is skipped with a notice logged to `rms_wizard_log` and the landing still completes successfully.
+7. **Landing page template** — v1 uses `pages/landing-page.php` (Template Name: "SEO Landing Page") for every landing page, regardless of `landing_type`. The template already hardcodes the section order; both SEO and Ads landings render the same template with different content/metadata.
+8. **Landing type** — Each landing carries a `landing_type` field with two values:
+   - `seo` — indexable by default, menu-eligible, organic-intent metadata and content.
+   - `ads` — `noindex` by default, NOT added to menu by default, orphan/campaign page, conversion-focused metadata and content.
+9. **Menu integration** — SEO landings may be added to the menu (the Landing step exposes a `menu_eligible` flag, defaulting to `true` for SEO). Ads landings have `menu_eligible = false` by default and are never auto-added to a menu. The existing `Step_Menu_Setup` is the integration point; it filters by `menu_eligible`.
+10. **Controlled unlock for completed wizard sites** — On sites where `rms_wizard_completed = true`, the wizard is read-only by default. A controlled unlock path (admin notice + an explicit "Unlock wizard for editing" action, gated by `manage_options`) re-opens the wizard without destroying state. No destructive reset.
+11. **Page template at insert time** — `_wp_page_template = 'pages/landing-page.php'` is set inside `wp_insert_post`'s `meta_input` argument (or an equivalent insert-time mechanism such as `wp_update_post( [ 'ID' => $id, 'meta_input' => [ '_wp_page_template' => ... ] ] )` immediately after the page is created in the same request). Never via a `post_updated`/`save_post` hook. The first render must see the correct template.
+12. **Keyword scope is strict** — Only `hero` and `seo-content` consume `primary_keyword` and `subkeywords`. Reusable sections, including landing-specific overrides, stay keyword-neutral. The harness never injects `{{primary_keyword}}` or `{{subkeywords}}` for any layout other than `hero` and `seo-content`. Overrides (`override_canonical = true`) are subject to the same rule: even when regenerating, the harness is called without keyword placeholders and `validate_fields()` continues to enforce the no-invention contract.
+13. **Overrides never overwrite canonical** — The override path writes to the landing's `page_sections` only. The canonical store is read-only on the override path. If the AI returns an empty/invalid payload, the override falls back to the canonical copy (and logs the failure) so the landing never ends up with placeholders.
+14. **Untracked local docs are preserved** — `Wizard ai harness prompt guide.md` and `wizard-prd.html` are untracked reference documents. They are not committed, not modified, and not part of the change artifacts.
+
+## What Already Exists (Reusable)
+
+| Component | File | Relevance |
+|---|---|---|
+| `Step_Controller::REQUIRED_STEPS` and dispatch switch | `inc/wizard/class-step-controller.php:17-25, 124-159` | Pattern for adding a new step: append slug, add `case`, optional aliases, append to `maybe_mark_completed()` in step service |
+| `Step_Generate_Pages` page-list + Home/Blog role model | `inc/wizard/class-step-generate-pages.php` | Reuse the same `{slug, title}` model for landing list; reuse the destructive-confirmation pattern; landing roles must include `landing` distinct from `home`/`blog` |
+| `Step_Home_Page_Builder` per-section AI generation loop | `inc/wizard/class-step-home-page-builder.php:41-125` | The architectural template for Landing Page Builder; same harness call, same reviewer pass, same `build_page( [ 'section_only' => true, 'sections' => ... ] )` save path |
+| `AI_Content_Harness` fillable/blocked/text-repeater contracts | `inc/wizard/class-ai-content-harness.php:29-96` | Single source of truth for which fields are keyword-driven vs reusable. The reusable set is implicit: any layout that is NOT hero or seo-content. |
+| `AI_Content_Harness::PAGE_LANDING` constant | `inc/wizard/class-ai-content-harness.php:19` | Exists but `get_layer2()` only returns the PAGE_HOME block. A `PAGE_LANDING` block must be authored. |
+| `AI_Content_Reviewer` cross-section repetition pass | `inc/wizard/class-ai-content-reviewer.php:130-174` | Already accepts arbitrary `prior_sections`; reusable across landings if the builder passes prior landing + canonical payloads. |
+| `Content_Builder::build_page( [ 'id', 'section_only', 'sections', 'seo' ] )` | `inc/wizard/class-content-builder.php:59-107` | Saves `page_sections` and Yoast meta in one call. Works for any `post_type=page` regardless of template. |
+| `Yoast_Meta_Writer` | `inc/wizard/class-yoast-meta-writer.php` | Already wired in `build_page()` when `seo` is provided. Use for per-landing meta title/description when Yoast is active. |
+| `pages/landing-page.php` (Template Name: SEO Landing Page) | `pages/landing-page.php` | The existing rendering target. v1 uses this for every landing regardless of `landing_type`. |
+| ACF `hero` and `seo-content` layouts | `acf-json/group_rms_page_sections.json` (hero at L20-145, seo-content at L1582-1680) | Both layouts already exist with the exact fillable fields (`hero_title`, `hero_description`; `seo_headline`, `seo_subheadline`, `seo_text`). Keyword-driven sections are ready. |
+| `state.home_sections` and `selected_home_sections` | `class-step-home-page-builder.php:115-119` | Proven shape for a per-page sections registry. Replicate as `state.landing_pages[].sections`. |
+| Wizard TS step-list and per-step collectors | `src/ts/admin/wizard.ts:160-167, 472-505` | Add the new slug to `steps[]`; add a `landing-page-builder` branch in `collectPayload()`. |
+| `<script type="application/json">` panels for static choice data | `inc/wizard/wizard-init.php:483-484, 615-617` | Pattern for shipping layout options / common-section shortcuts to TS without an extra REST round-trip. |
+| Destructive-confirmation modal + checkbox pattern | `inc/wizard/wizard-init.php:549-561, 568-582` | Reuse for the landing-deletion warning (only "delete this landing" though, not bulk — landings are N independent pages, not a single set). |
+| `data-wizard-add-section` / common-shortcut UX | `inc/wizard/wizard-init.php:486-535` | Same UI vocabulary as Home Page Builder: layout dropdown + item count + per-row override checkbox. |
+
+## What Does Not Exist Yet
+
+| Gap | Why it matters |
+|---|---|
+| Dedicated `rms_wizard_canonical_sections` option | The canonical store must be a separate option, not part of `state`. Without it, the wizard state row keeps growing and the 64KB `wp_options.option_value` LONGTEXT path becomes a real risk. |
+| First-write canonical guard | The current Home Page Builder always overwrites `home_sections`. A guard that only writes to the canonical store when it is empty for a given layout does not exist; reruns would currently clobber canonical copy. |
+| `landing_type` field on landings | The landing registry needs a `landing_type` (`seo`/`ads`) and a derived `menu_eligible` flag. Today the page list is `{slug, title}` only. |
+| `noindex` enforcement for Ads landings | There is no filter or `meta-robots-noindex` write tied to the wizard today. The Ads path needs a `wp_robots` filter (and Yoast's `meta-robots-noindex` post meta for sites with Yoast) keyed on the landing's `_wp_page_template`. |
+| Per-landing override flag for reusable sections | The Home Page Builder always treats the saved payload as final. Landings need a per-row `override_canonical` toggle that, when off, copies canonical content into the landing's `page_sections` without calling the AI. |
+| Controlled unlock for completed wizard sites | Sites with `rms_wizard_completed = true` need a non-destructive way to re-open the wizard. The existing `RMS_WIZARD_FORCE` dev constant is not appropriate for production sites. |
+| `meta_input` page-template assignment | The current `wp_insert_post` calls do not pass `_wp_page_template` in `meta_input`. The new step must either extend `Content_Builder::build_page()` to accept a template arg, or perform the `meta_input` write inline as part of the page creation step (preferred for BC). |
+| Keyword context in harness Layer 3 | `Wizard ai harness prompt guide.md` (untracked) already documents `{{keyword}}` and `{{subkeywords}}` placeholders for PAGE_LANDING and PAGE_BLOG, but the PHP harness does not replace them. `get_layer3()` only injects `item_count` and `client_json`. |
+| `get_layer2(PAGE_LANDING)` body | Today the method only branches on `PAGE_HOME !== $page_type` and warns. The landing context (purpose, tone, section-ordering guidance, and ads-vs-seo intent) is missing. |
+| Landing page registry / list management | No UI to add, edit, remove, or duplicate landings after the first run. The step is a one-shot today. |
+| `state.landing_pages[].meta` (per-landing Yoast + keyword set) | The `Yoast_Meta_Writer` exists, but the builder step does not yet drive it. The PRD requires per-landing meta title/description generation. |
+| Reviewer cross-landing context | `AI_Content_Reviewer::review()` accepts `prior_sections`, but today the builder only feeds it Home sections from the same run. For landings, the prior context should include canonical reusable payloads so the reviewer can detect contradictions between, e.g., a landing-specific hero and the canonical about-us. |
+| Landing "Reset to canonical" affordance | Required so the admin can drop an override and re-pick up canonical copy for a given row. (Regenerate-as-override is separate and is a per-row checkbox; "reset to canonical" is the reverse.) |
+
+## Affected Areas
+
+### Files that WILL change
+
+| File | Why |
+|---|---|
+| `inc/wizard/class-ai-content-harness.php` | Add `get_layer2(PAGE_LANDING)` body (covers both SEO and Ads intent). Add `{{primary_keyword}}` and `{{subkeywords}}` replacement in `get_layer3()` gated on `string $page_type` (default `PAGE_HOME`) and on the layout being `hero` or `seo-content`. Expose `is_reusable_layout( $layout )` helper. Never inject keyword placeholders for reusable layouts, even when `override_canonical = true`. |
+| `inc/wizard/class-state-manager.php` | Extend `defaults()` with `landing_pages` (array keyed by landing slug, each with `{ id, slug, title, landing_type, menu_eligible, primary_keyword, subkeywords[], section_rows[], sections[], meta, template_assigned, generated_at }`) and a small `canonical_sections_summary` (layout_key → `{ generated_at, source, has_payload }`). Do NOT add the full canonical payloads to the state option; that lives in `rms_wizard_canonical_sections`. |
+| `inc/wizard/class-step-controller.php` | Append `landing-page-builder` to `REQUIRED_STEPS`, add `case 'landing-page-builder':` to `dispatch_step()`, add alias `landing_page_builder` in `normalize_step()`. Update `complete()` to detect already-completed wizard sites and gate re-completion behind the controlled unlock path. |
+| `inc/wizard/class-step-generate-pages.php` | When a landing slug is in the payload, set `_wp_page_template = 'pages/landing-page.php'` inside `wp_insert_post`'s `meta_input` so the first render is correct. Add a `landing` role distinct from `home`/`blog`. Landings do not receive Home/Blog reading settings. |
+| `inc/wizard/class-step-home-page-builder.php` | After a successful Home run, copy the produced `home_sections` payloads into `Canonical_Section_Store` for the reusable layouts (skip `hero` and `seo-content`) **only when the store is empty for that layout**. On re-runs, the existing `home_sections` payload is regenerated, but the canonical store is read-only. `maybe_mark_completed()` must be updated to include `landing-page-builder`. |
+| `inc/wizard/class-ai-content-reviewer.php` | No new diagnoses required. Optionally extend `critique_system_prompt` to mention "ignore keyword repetition in the Hero and SEO Content sections; flag keyword stuffing only if it appears elsewhere." |
+| `inc/wizard/wizard-init.php` | Add `'landing-page-builder' => __( 'Landing Page Builder' )` to `$steps` and a description. Add `rms_wizard_render_landing_page_builder_form()` mirroring the Home form, plus a landing-list block above it. Add a `landing_type` selector (seo/ads) and a per-row `override_canonical` checkbox. Add the controlled-unlock admin notice + action handler (gated by `manage_options`). Register the new step in the per-step `if/elseif` chain. Wire `Step_Menu_Setup` to filter by `menu_eligible` so Ads landings are not auto-added. |
+| `src/ts/admin/wizard.ts` | Append `{ slug: 'landing-page-builder', label: 'Landing Page Builder' }` to `steps[]`. Add a `landing-page-builder` branch in `collectPayload()`. Add `collectLandingPageBuilderPayload()` that emits `{ landings: [ { slug, title, landing_type, menu_eligible, primary_keyword, subkeywords[], sections: [ { layout, item_count, override_canonical } ] } ] }`. Add UI handlers for add-landing, remove-landing, landing-type toggle, per-landing keyword inputs (clamped to 10), and per-row `override_canonical` checkboxes. |
+| `src/scss/admin/wizard.scss` | New BEM blocks: `rms-wizard-landing-list`, `rms-wizard-landing-card`, `rms-wizard-landing-keywords`, `rms-wizard-landing-type`, `rms-wizard-section-row__override-canonical`, `rms-wizard-controlled-unlock`. |
+| `inc/wizard/wizard-init.php` (controlled unlock) | New admin notice + a nonce-protected `admin-post.php` action `rms_wizard_unlock` that flips a transient/option and re-renders the wizard. Capability check: `manage_options`. Reversible (the admin can re-lock). |
+
+### New PHP classes (proposed)
+
+| Class | File | Purpose |
+|---|---|---|
+| `Step_Landing_Page_Builder` | `inc/wizard/class-step-landing-page-builder.php` | Orchestrates one or more landing pages. Reuses `Content_Builder`, `AI_Content_Harness`, `AI_Content_Reviewer`, and a new `Canonical_Section_Store`. Sets `_wp_page_template` in `meta_input` at page-insert time. Writes per-landing Yoast meta when Yoast is active. Sets `meta-robots-noindex` for Ads landings. |
+| `Canonical_Section_Store` | `inc/wizard/class-canonical-section-store.php` | Encapsulates the canonical reusable section store. Methods: `get( $layout )`, `set_if_empty( $layout, $payload, $source )`, `replace( $layout, $payload, $source )` (explicit user action), `has( $layout )`, `all()`, `summary()`. Backed by a dedicated option `rms_wizard_canonical_sections` (single key per site, small payload) — separate from the wizard state option. |
+| `Landing_Keyword_Resolver` | (could live in `AI_Content_Harness` as a new public method `get_landing_keyword_context( $landing_state )`) | Returns the keyword context block that Layer 3 will inject for `hero` and `seo-content` on a given landing. Clamps subkeywords to 0-10. Not strictly required; can be a private method on the harness in v1. |
+| `Landing_Page_Repository` (optional) | `inc/wizard/class-landing-page-repository.php` | Read/write helpers over `state.landing_pages` and the `pages/landing-page.php` template assignment. Can be inlined in `Step_Landing_Page_Builder` for v1; pull it out only if it grows. |
+| `Wizard_Unlock_Controller` | `inc/wizard/class-wizard-unlock-controller.php` | Handles the controlled-unlock flow for completed wizard sites. Methods: `is_locked()`, `request_unlock()`, `lock_again()`. Capability-gated; reversible; no destructive state reset. |
+
+### Files that MUST NOT change (untracked local docs)
+
+- `Wizard ai harness prompt guide.md` — untracked reference, do not commit or modify.
+- `wizard-prd.html` — untracked PRD, do not commit or modify.
+
+### Files that should NOT change (BC / scope guards)
+
+- `inc/wizard/class-content-builder.php` — `build_page()` already supports `section_only` + per-page sections + Yoast. Reuse. Page-template assignment is performed inline by `Step_Landing_Page_Builder` via `meta_input` on the `wp_insert_post`/`wp_update_post` call, not by extending `build_page()`.
+- `inc/wizard/class-ai-provider-registry.php`, `inc/wizard/class-ai-provider.php` — provider interface is provider-neutral and the home builder already exercises it; no new interface change needed.
+- `inc/wizard/class-flexible-content-layouts.php` — layout definitions are layout-keyed; no new layout needed for v1.
+- `inc/wizard/class-step-menu-setup.php`, `inc/wizard/class-step-acf-import.php`, `inc/wizard/class-step-dependencies.php`, `inc/wizard/class-step-client-data.php` — out of scope; reuse as-is. `Step_Menu_Setup` may be filtered by `menu_eligible` but its public API does not change.
+
+## Approaches
+
+### Approach A — New step "Landing Page Builder" with dedicated canonical store (recommended)
+
+Add `landing-page-builder` as the 8th wizard step, sitting after `home-page-builder`. Each landing page is a row in a new `state.landing_pages` registry with `landing_type` (`seo`|`ads`), `menu_eligible` (derived), `primary_keyword`, and `subkeywords[]` (0-10). A `Canonical_Section_Store` (backed by a dedicated `rms_wizard_canonical_sections` option) holds the reusable content with first-write semantics. The step's loop, for each landing:
+
+1. For each row, classify it as `reusable` (all layouts except `hero` and `seo-content`) or `keyword` (`hero`, `seo-content`).
+2. For `reusable` rows:
+   - If the row has `override_canonical = false` AND the canonical store has a payload for the layout → copy it directly into the landing's `page_sections`, skip the AI call. If the AI later fails on an override row, fall back to the canonical copy and log.
+   - If the row has `override_canonical = true` OR the canonical store is empty for the layout → call the harness as in the Home Page Builder, then `validate_fields()`. If the canonical store is empty, persist the resulting payload into it via `set_if_empty()` (first-write). If the canonical store already has a payload AND the row is `override_canonical = true`, the result is written to the landing's `page_sections` only and marked `landing_specific = true`. The canonical store is not modified.
+3. For `keyword` rows → always call the harness with `Layer 2 = PAGE_LANDING` (which encodes the ads-vs-seo intent), and inject `{{primary_keyword}}` and `{{subkeywords}}` into `Layer 3`. Never canonicalize.
+4. Build the page via `Content_Builder::build_page( [ 'id' => $post_id, 'section_only' => true, 'sections' => $prepared, 'seo' => $meta ] )` where `seo` is generated from the primary keyword and `landing_type`.
+5. If Yoast is active (`is_plugin_active('wordpress-seo/wordpress-seo.php')` OR `defined('WPSEO_VERSION')`), write the meta title/description via `Yoast_Meta_Writer`. If not, log a notice and continue.
+6. Set `_wp_page_template = 'pages/landing-page.php'` inside `wp_insert_post`'s `meta_input` for the created page (or via an equivalent insert-time `wp_update_post` call in the same request). The first render must see the correct template.
+7. If `landing_type = ads`, write `meta-robots-noindex = 1` post meta and register a `wp_robots` filter scoped to the landing template that emits `noindex`. If `landing_type = seo`, do not set the noindex flag and let Yoast's defaults apply.
+8. If `menu_eligible = true` (default for `seo`, false for `ads`), the page becomes visible to `Step_Menu_Setup`. `Step_Menu_Setup` filters out non-eligible landings.
+9. Persist `state.landing_pages[ slug ]` and the updated `canonical_sections_summary`.
+
+The harness needs two surgical changes: a real `get_layer2(PAGE_LANDING)` block, and `{{primary_keyword}}`/`{{subkeywords}}` placeholders honored in `get_layer3()` when the active page type is landing and the layout is `hero` or `seo-content`.
+
+- Pros: Clear separation between canonical reusable content and landing-specific content. New step fits the existing 7-step pattern with no BC break. The harness already supports `PAGE_LANDING` as a constant; this just fills it in. First-write semantics are enforced by `set_if_empty()` in the store; the admin never silently loses canonical copy on a rerun. Dedicated `rms_wizard_canonical_sections` option keeps the wizard state option small (mitigates the 64KB LONGTEXT risk). The Home Page Builder also benefits: the existing `home_sections` payloads populate the canonical store on first run via `set_if_empty()`, so the very first landing that references `about-us` reuses what the Home already produced, while a Home rerun that changes the about copy does not silently clobber canonical.
+- Cons: Adds an 8th step that runs after `home-page-builder`; the completion gate must include it. State grows, but only by summary metadata — canonical payloads are offloaded to their own option. SEO/Ads noindex enforcement adds a `wp_robots` filter (small) and Yoast post-meta writes (small). The Step_Controller's `REQUIRED_STEPS` list and `Step_Home_Page_Builder::maybe_mark_completed()` both need to grow.
+- Effort: Medium-High
+
+### Approach B — Fold landings into the existing `home-page-builder` step
+
+Add a "landing tabs" UI inside the same step: one Home tab + N landing tabs. Single `state.home_sections` becomes `state.pages[].sections` (Home + landings). Reuses everything in place.
+
+- Pros: No new step. No `REQUIRED_STEPS` change. Single review pass per run. Smaller surface area.
+- Cons: Breaks the existing `selected_home_sections`, `home_sections`, and `home_page_id()` lookups. The Home tab's prior-section context would now include landing sections, which contaminates the existing cross-section repetition detection. The completion gate is satisfied by the Home tab, even when no landing exists. The UI becomes harder to resume — the admin cannot run "add another landing" without re-running the Home tab. The state shape diverges further from the existing v1 contract and would need a one-time migration in `State_Manager::defaults()`. Does not give landings a `landing_type`, a `menu_eligible` flag, or a per-landing template assignment without overloading the Home tab's data model. Controlled unlock becomes harder because re-opening the wizard for landing-only edits would also re-expose the Home tab.
+- Effort: Medium
+
+### Approach C — Single multi-page payload (no per-landing state, no canonical store)
+
+The admin submits a list of landings in one big payload. The step generates N landings, stores their sections directly in `page_sections`, and forgets them. No canonical store; every landing gets its own AI-generated copy for every section.
+
+- Pros: Smallest code. No canonical store. Keyword-only on Hero/SEO.
+- Cons: Violates the user's explicit canonical-reusable requirement. Generates redundant AI content for About / Services / Mission / Testimonials / etc. across N landings, which is exactly what the PRD and the product intent say to avoid. The reviewer will flag repetition across landings with no way to consolidate. No `landing_type`, no menu-eligibility filtering, no Ads vs SEO split.
+- Effort: Low
+
+### Approach D — Post-meta "canonical" flag, no new step
+
+Add a checkbox per row in the existing `home-page-builder` form: "this is the canonical version of this section." The first run sets canonical post-meta on a hidden "source of truth" page; later landings deep-link those sections at render time via a `get_template_part` override.
+
+- Pros: No new step, no canonical store. Uses existing WP post-meta.
+- Cons: Couples content reuse to template rendering, which means the canonical page must always be reachable and the landing template must dynamically load parts. This makes the canonical content harder to audit and impossible to version in state. The "override tied only to that landing" rule requires the landing to either inline its own copy or short-circuit at render — both options leak the wizard's design into template logic. Reviewer cross-section context is harder to wire because the canonical payload is not in the wizard state. First-write semantics are not enforceable: the admin can flip the canonical flag on a later run and silently overwrite.
+- Effort: Medium (but in the wrong direction — pushes content reuse into templates instead of the wizard)
+
+## Recommendation
+
+**Approach A** — a new `landing-page-builder` step + a `Canonical_Section_Store` backed by the dedicated `rms_wizard_canonical_sections` option, with first-write semantics, per-landing `landing_type` (seo/ads), per-landing `menu_eligible`, per-row `override_canonical`, strict keyword scope, and controlled unlock for completed wizard sites. It is the only approach that satisfies all 14 product decisions without leaking keyword context into reusable sections and without coupling content reuse to template rendering.
+
+Concretely:
+- The new step is the 8th and last step. It reuses `Content_Builder`, `AI_Content_Harness`, `AI_Content_Reviewer`, and `Yoast_Meta_Writer` exactly as the Home Page Builder does.
+- The `Canonical_Section_Store` is backed by `rms_wizard_canonical_sections` (a map `layout_key => [ 'payload' => [...], 'source' => 'home'|'landing', 'generated_at' => 'mysql' ]`). On the first `home-page-builder` run, after a successful save, the step calls `set_if_empty()` for every reusable payload (`! in_array( $layout, ['hero','seo-content'] )`). On the first `landing-page-builder` run for a given layout, if the store is empty, the AI result becomes the canonical entry via `set_if_empty()`; on subsequent runs, the landing writes its own copy only and the store is untouched. Replacements require an explicit `replace()` call from a user-confirmed action (see Open Questions).
+- The override is per-row and per-landing. A landing can opt to regenerate a reusable section even when canonical content exists; the AI result is stored in the landing's `page_sections` only and is marked `landing_specific = true` in the row metadata, which signals "do NOT touch the canonical store." The harness `validate_fields()` keeps enforcing the no-invention guardrails so the override copy remains keyword-neutral and grounded in `client_data`. If the AI returns empty/invalid, the override falls back to the canonical copy.
+- Hero and SEO Content are never canonical. They are landing-specific, keyword-driven, and always call the AI with the landing's primary keyword + subkeywords (0-10). The harness `get_layer3()` learns to replace `{{primary_keyword}}` and `{{subkeywords}}` placeholders when the page type is `PAGE_LANDING` and the layout is `hero` or `seo-content`. Reusable layouts, including override rows, are never given keyword placeholders. The `Wizard ai harness prompt guide.md` already documents these placeholders; this change moves them from doc-only to PHP-enforced.
+- `get_layer2(PAGE_LANDING)` is filled in with the page-type block: landing purpose (single conversion goal), tone (specific, not generic), section-ordering guidance that aligns with the existing `pages/landing-page.php` template order, and ads-vs-seo intent branching.
+- Per-landing meta title/description are generated with the primary keyword and `landing_type` and written via `Yoast_Meta_Writer` whenever Yoast is available/active. When Yoast is not active, the generation is skipped and logged.
+- Generated landing pages get `_wp_page_template = 'pages/landing-page.php'` set inside `wp_insert_post`'s `meta_input` (or an equivalent insert-time `wp_update_post` in the same request). The first render is always correct.
+- `landing_type = ads` writes `meta-robots-noindex = 1` post meta and registers a `wp_robots` filter scoped to the landing template. `landing_type = seo` does not set the noindex flag.
+- `menu_eligible` is derived from `landing_type` (`seo = true`, `ads = false`) and is consumed by `Step_Menu_Setup`. SEO landings may be added; Ads landings are never auto-added.
+- Completed wizard sites use a `Wizard_Unlock_Controller` for the controlled unlock path. No destructive reset.
+
+This approach honors all 14 product decisions:
+1. Keyword only on Hero and SEO Content — enforced by a layout allowlist inside the harness, with `{{primary_keyword}}`/`{{subkeywords}}` replacement gated on both page type and layout.
+2. Reusable sections keyword-neutral — enforced by `AI_Content_Harness::validate_fields()` (no keyword field in fillable contracts for reusable layouts) and by never injecting keyword placeholders for those layouts, even on override.
+3. Canonical-first / first-write / explicit replace — enforced by `Canonical_Section_Store::set_if_empty()` and `replace()`.
+4. Override does not overwrite canonical — enforced because the override path writes only into the landing's `page_sections` and never into the store.
+5. Testimonials are canonical/reusable — `testimonials-v1/v2/v3` participate in `set_if_empty()` like every other reusable layout.
+6. SEO vs Ads — enforced by `landing_type` and the resulting noindex, menu, and meta behavior.
+7. Yoast meta when available — capability check at the top of the Yoast write path; skip-and-log otherwise.
+8. Controlled unlock — `Wizard_Unlock_Controller` with capability check and reversible state.
+9. Page template at insert time — `meta_input` on `wp_insert_post` (or equivalent `wp_update_post` in the same request).
+
+## Risks
+
+- **Completion-gate drift**: `Step_Controller::REQUIRED_STEPS` and `Step_Home_Page_Builder::maybe_mark_completed()` both hardcode the same 7-step list. Adding an 8th step means updating both call sites in the same change. Mitigation: add a unit-style sanity check in `Step_Controller::complete()` that compares `REQUIRED_STEPS` against the keys present in `state.step_status` and returns a `WP_Error` if they diverge. Combined with the controlled unlock, the existing-wizard path is non-destructive.
+- **Canonical content drift across Home re-runs**: If the admin re-runs the Home Page Builder and changes the canonical About copy, every landing that previously reused it will be stale. Because of first-write semantics, the rerun does NOT update the canonical store; the existing canonical copy stays. Mitigation: surface a "Reusable content changed since your last landing run" notice in the Landing step UI by comparing `state.landing_pages[].sections[ layout ].generated_at` against the current Home run's `home_sections[ layout ].generated_at` and the canonical store's `generated_at`. The admin can choose to explicitly `replace()` the canonical copy (or keep the old one). A future enhancement could add a "Reset to canonical" affordance per row.
+- **Harness layer 2/3 changes affect Home Page Builder**: The Home Page Builder calls `get_layer2(PAGE_HOME)` and `get_layer3()`. If the `PAGE_LANDING` branch accidentally becomes the default for non-landing contexts, the Home will start using landing rules. Mitigation: keep the default branch in `get_layer2()` as the current `PAGE_HOME` block, and gate the keyword replacement in `get_layer3()` behind a third `string $page_type` argument (defaulting to `PAGE_HOME`) plus a layout allowlist (`hero`, `seo-content`). Update both call sites (`Step_Home_Page_Builder` and the new `Step_Landing_Page_Builder`) explicitly.
+- **State option size**: `state.landing_pages` and `canonical_sections_summary` will grow with each landing. The full canonical payloads are offloaded to `rms_wizard_canonical_sections`, so the wizard state option only carries summary metadata. The MySQL `wp_options.option_value` LONGTEXT risk is mitigated. Mitigation: keep only the section list and last generated payload per landing in state; full review reports stay in `rms_wizard_log` (which is already capped in `class-logger.php` to last 20 entries for the UI).
+- **Reviewer repetition flags for intentional keyword use**: The reviewer already flags `keyword_stuffing`. Hero and SEO Content intentionally use the primary keyword. If the reviewer over-flags them, the rewrite pass may dilute the keyword and force a fall-back to the original (preserving keyword). Mitigation: the fall-back path is the safety net today, but the right fix is to teach the reviewer that hero/seo-content layouts are allowed to repeat the primary keyword once or twice. This can be a small `Layer 3` extension in the harness rather than a reviewer change.
+- **Page-template assignment race**: Setting `_wp_page_template` after the page is created means a render between insert and meta update shows the default template. Mitigation: pass `_wp_page_template` in `wp_insert_post`'s `meta_input` so the first render is correct, or perform an equivalent insert-time `wp_update_post` in the same request. The new step performs the `meta_input` write inline at insert time.
+- **Override regressions**: If `override_canonical = true` on a reusable section and the harness returns an empty payload (AI failure), the landing loses the canonical copy and ends up with placeholders. Mitigation: if AI fails AND the canonical store has the layout, fall back to the canonical copy and log the failure. This keeps the landing functional even when the override attempt fails.
+- **Cross-landing reviewer context**: Without feeding prior landing payloads into the reviewer, two landings that both regenerate the same reusable section can drift. Mitigation: pass the canonical payload as the prior-section context for any reusable section that is being overridden, so the reviewer can warn if the new copy contradicts the canonical version.
+- **Ads landing indexability**: Forgetting to set `meta-robots-noindex = 1` or forgetting to register the `wp_robots` filter would leave an Ads landing indexable. Mitigation: write both as part of the same insert path (Yoast post meta + a `wp_robots` filter scoped to `_wp_page_template = pages/landing-page.php` and `landing_type = ads`). Add an explicit assertion in `Step_Landing_Page_Builder::finalize_landing()` that reads back the post meta and refuses to mark the landing complete if the post meta is missing.
+- **SEO landing accidentally noindexed**: A misapplied `wp_robots` filter could suppress SEO landings. Mitigation: scope the filter on BOTH `_wp_page_template` AND the landing's stored `landing_type` post meta. Do not use a single-key check.
+- **Ads landing in menu**: Forgetting to filter `Step_Menu_Setup` by `menu_eligible` would add Ads landings to the menu. Mitigation: add a single `array_filter( $pages, fn( $p ) => $p['menu_eligible'] ?? true )` at the top of `Step_Menu_Setup::collect_pages()`. Add a unit-style assertion that no landing with `landing_type = ads` appears in the menu output.
+- **Controlled unlock abuse**: A controlled unlock that flips a flag without an audit trail or a re-lock path leaves wizard re-runs running unsupervised. Mitigation: `Wizard_Unlock_Controller` writes a `rms_wizard_unlocked_at` timestamp and `rms_wizard_unlocked_by` user ID, exposes a re-lock action, and only flips the lock on a `manage_options` capability check + a nonce. The original `rms_wizard_completed` is not destroyed; the unlock is a transient override.
+- **TS payload shape growth**: `collectLandingPageBuilderPayload()` will be the most complex collector in `wizard.ts`. The existing `collectHomePageBuilderPayload()` is already non-trivial. Mitigation: extract a shared `collectSectionRows(form, scope)` helper that both collectors reuse, and keep the keyword + override + landing_type fields on a single row template.
+- **Resource budget**: 8 steps push the wizard close to the existing 7-step review budget (400 lines per PR). The change is naturally chained: PR 1 = `Canonical_Section_Store` (dedicated option) + state summary + harness Layer 2/3 changes; PR 2 = `Step_Landing_Page_Builder` + step controller wiring + controlled unlock; PR 3 = TS + SCSS + completion-gate update. Per `openspec/config.yaml` chained-pr strategy is `force-chained`.
+
+## Open Questions
+
+None blocking proposal. The five previously open questions are now resolved by the confirmed defaults below and are promoted into the change contract alongside the existing 14 product decisions.
+
+### Confirmed defaults (formerly open questions)
+
+1. **Canonical overwrite affordance** — Confirmed: explicit button/action in the builder where the section is visible (per-row "Replace canonical" button, gated by a confirmation modal and a nonce). No automatic replace. The button is available wherever the canonical store is read for that layout (Home Page Builder + Landing Page Builder). It calls `Canonical_Section_Store::replace( $layout, $payload, $source )` only after the user confirms.
+2. **Controlled unlock UX** — Confirmed: Setup Wizard notice + an explicit user action ("Unlock wizard for editing"), gated by `manage_options` and a nonce. No destructive reset of `rms_wizard_completed`. The unlock writes `rms_wizard_unlocked_at` and `rms_wizard_unlocked_by`, is reversible via a re-lock action, and may be paired with a `wp rms wizard unlock` WP-CLI command for ops.
+3. **Subkeywords default** — Confirmed: empty subkeywords field means `0` subkeywords. The server clamps to the 0-10 range and silently drops empties; the harness is never given invented default subkeywords. The UI does not seed a starting number when the field is left empty.
+4. **Ads `noindex` belt-and-suspenders** — Confirmed: double protection. (a) Write `meta-robots-noindex = 1` Yoast post meta whenever Yoast is available/active (`is_plugin_active('wordpress-seo/wordpress-seo.php')` OR `defined('WPSEO_VERSION')`). (b) Register a `wp_robots` filter scoped to the Ads landing pages (filter on BOTH `_wp_page_template = pages/landing-page.php` AND the stored `landing_type` post meta = `ads`). The post meta is the source of truth; the filter is read-only on it. `Step_Landing_Page_Builder::finalize_landing()` reads the post meta back and refuses to mark the landing complete if the noindex post meta is missing.
+5. **Ads `landing_type` persistence** — Confirmed: custom post meta `rms_landing_type` written at insert time (inside `wp_insert_post`'s `meta_input` or an equivalent insert-time `wp_update_post` in the same request). It is decoupled from any plugin, survives wizard state resets, and is the key the `wp_robots` filter reads.
+
+## Ready for Proposal
+
+**Yes** — the 14 product decisions plus the 5 confirmed defaults are now part of the exploration (19 contract items total), the Open Questions list has no remaining blockers, and the recommended approach (Approach A) is concrete enough to write a proposal against.
+
+The orchestrator should proceed to `sdd-propose` for change `wizard-landing-page-builder`. The product decisions in §"Product Decisions" and the confirmed defaults in §"Open Questions" are part of the change contract and are not open for renegotiation in the proposal.

--- a/openspec/changes/wizard-landing-page-builder/proposal.md
+++ b/openspec/changes/wizard-landing-page-builder/proposal.md
@@ -1,0 +1,72 @@
+# Proposal: Wizard Landing Page Builder
+
+## Intent
+
+The wizard ends at one Home page. Owners need N landing pages (SEO and Ads) without duplicating reusable copy or leaking keywords into shared sections. This adds an 8th step: keyword-governed landings plus a canonical reusable store.
+
+## Scope
+
+### In Scope
+- New `landing-page-builder` step generating N landings from `pages/landing-page.php`.
+- Per-landing keyword + 0–10 subkeywords; only Hero and SEO Content consume them.
+- Canonical store `rms_wizard_canonical_sections` for neutral reusable sections (About, Services, FAQ, Mission, Vision, Why Choose Us, Testimonials…); first-write, explicit replace only.
+- Per-landing `override_canonical` regeneration never writes canonical.
+- `rms_landing_type` meta (`seo`|`ads`): SEO indexable/menu-eligible, Ads noindex/orphan.
+- Per-landing Yoast title/description when active.
+- Non-destructive unlock for completed wizard sites.
+
+### Out of Scope
+- New ACF layouts; changes to `Content_Builder`, provider registry, or other steps' APIs.
+- Bulk regenerate action; new REST routes (generic `/steps/{step}/run` reused).
+
+## Capabilities
+
+### New Capabilities
+- `wizard-landing-page-builder`: 8th step orchestrating N landings (keyword governance, landing_type, menu-eligibility, Yoast meta, noindex).
+- `wizard-canonical-sections`: first-write reusable store with explicit replace and per-landing override.
+- `wizard-controlled-unlock`: capability-gated, reversible re-open of completed sites.
+
+### Modified Capabilities
+- `wizard-ai-content-harness`: add `PAGE_LANDING` Layer 2; inject `{{primary_keyword}}`/`{{subkeywords}}` only for `hero`/`seo-content`.
+- `wizard-home-page-builder`: on success, first-write reusable payloads to the canonical store (skip hero/seo-content).
+
+## Approach
+
+Approach A. Add `landing-page-builder` last. A `Canonical_Section_Store` (dedicated option) holds reusable payloads via `set_if_empty()`/`replace()`. Reusable rows copy canonical or first-write; keyword rows call the harness with keywords; a layout allowlist keeps other sections neutral, including overrides. Pages use `Content_Builder::build_page()` with `_wp_page_template` in `meta_input`. Ads landings get `rms_landing_type=ads`, `meta-robots-noindex`, and a scoped `wp_robots` filter; `Step_Menu_Setup` filters `menu_eligible`.
+
+## Affected Areas
+
+| Area | Impact |
+|---|---|
+| `class-step-landing-page-builder.php`, `class-canonical-section-store.php`, `class-wizard-unlock-controller.php` | New classes |
+| `class-ai-content-harness.php` | Mod: PAGE_LANDING + keywords |
+| `class-step-home-page-builder.php` | Mod: first-write canonical |
+| `class-step-controller.php`, `class-state-manager.php`, `class-step-generate-pages.php`, `wizard-init.php` | Mod: wiring, state, UI, unlock |
+| `wizard.ts`, `wizard.scss` | Mod: collector, styles |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Completion-gate drift | High | Update both; assert lists match |
+| Canonical clobber on Home re-run | Med | `set_if_empty()` only |
+| Ads landing left indexable | Med | Yoast meta + `wp_robots`; assert |
+| Keyword leak into reusable sections | Med | Layout allowlist |
+| Override AI failure loses copy | Low | Fall back to canonical |
+
+## Rollback Plan
+
+Revert the chained PRs. Delete option `rms_wizard_canonical_sections` and `state.landing_pages`; no schema migration, so existing steps are unaffected. Unlock is a transient override: re-lock restores read-only state without destroying `rms_wizard_completed`.
+
+## Dependencies
+
+- ACF Pro `hero`/`seo-content` layouts and `pages/landing-page.php` (exist).
+- Yoast optional (`is_plugin_active(...)` OR `WPSEO_VERSION`); skip-and-log if absent.
+
+## Success Criteria
+
+- [ ] Admin generates ≥1 SEO and ≥1 Ads landing; each renders `pages/landing-page.php` on first load.
+- [ ] Hero/SEO Content use the landing keyword; reusable sections stay neutral.
+- [ ] Canonical is first-write; re-runs never overwrite it.
+- [ ] Ads landings `noindex` and unlisted; SEO landings indexable/menu-eligible.
+- [ ] Completed sites re-open via controlled unlock, no destructive reset.

--- a/openspec/changes/wizard-landing-page-builder/specs/wizard-ai-content-harness/spec.md
+++ b/openspec/changes/wizard-landing-page-builder/specs/wizard-ai-content-harness/spec.md
@@ -1,0 +1,47 @@
+# Delta for wizard-ai-content-harness
+
+## ADDED Requirements
+
+### Requirement: Landing Page Type Context (Layer 2)
+
+The harness MUST provide a `PAGE_LANDING` Layer 2 context block that encodes landing purpose (single conversion goal), tone, section-ordering guidance aligned with `pages/landing-page.php`, and ads-vs-seo intent branching. `get_layer2()` MUST continue to return the `PAGE_HOME` block by default and MUST return the `PAGE_LANDING` block only when the active page type is landing. Existing `PAGE_HOME` behavior MUST remain unchanged.
+
+#### Scenario: Landing page type returns landing context
+
+- GIVEN a caller requests Layer 2 with page type `PAGE_LANDING`
+- WHEN `get_layer2()` executes
+- THEN the landing context (purpose, tone, ordering, ads/seo intent) is returned
+
+#### Scenario: Default page type stays Home
+
+- GIVEN no page type or `PAGE_HOME` is passed
+- WHEN `get_layer2()` executes
+- THEN the existing PAGE_HOME block is returned unchanged
+
+### Requirement: Landing Keyword Injection (Layer 3)
+
+When the active page type is `PAGE_LANDING` AND the layout is `hero` or `seo-content`, `get_layer3()` MUST replace `{{primary_keyword}}` and `{{subkeywords}}` with the landing's keyword context, with subkeywords clamped to the 0–10 range. For any other layout, and for any non-landing page type, the harness MUST NOT inject keyword placeholders — including reusable rows regenerated via `override_canonical`. The existing `{{item_count}}` and `{{client_json}}` replacement behavior MUST remain unchanged.
+
+#### Scenario: Hero on landing receives keyword context
+
+- GIVEN page type `PAGE_LANDING` and layout `hero`
+- WHEN `get_layer3()` composes the prompt
+- THEN `{{primary_keyword}}` and `{{subkeywords}}` are replaced with the landing's keyword context
+
+#### Scenario: Reusable layout never receives keyword
+
+- GIVEN page type `PAGE_LANDING` and layout `about-us`
+- WHEN `get_layer3()` composes the prompt
+- THEN no keyword placeholders are injected
+
+#### Scenario: Override row stays keyword-neutral
+
+- GIVEN a reusable layout regenerated with `override_canonical = true`
+- WHEN the harness composes the prompt
+- THEN no keyword placeholders are injected
+
+#### Scenario: Home page type unaffected
+
+- GIVEN page type `PAGE_HOME` for any layout
+- WHEN `get_layer3()` composes the prompt
+- THEN no keyword placeholders are injected and item_count/client_json behavior is unchanged

--- a/openspec/changes/wizard-landing-page-builder/specs/wizard-canonical-sections/spec.md
+++ b/openspec/changes/wizard-landing-page-builder/specs/wizard-canonical-sections/spec.md
@@ -1,0 +1,83 @@
+# Wizard Canonical Sections Specification
+
+## Purpose
+
+A dedicated first-write store for neutral, reusable section content shared across the Home page and all landings. It keeps reusable copy consistent, prevents accidental overwrites, and supports per-landing overrides without leaking keywords.
+
+## Requirements
+
+### Requirement: Dedicated Canonical Store
+
+Canonical reusable section content MUST be persisted in a dedicated option `rms_wizard_canonical_sections`, separate from the wizard state option. The wizard state MUST hold only a small summary (which layouts have a canonical payload and a `generated_at` timestamp), not the full payloads. The store MUST be lazy-loaded on demand rather than read on every state access.
+
+#### Scenario: Payload stored in dedicated option
+
+- GIVEN a reusable section is canonicalized
+- WHEN the payload is saved
+- THEN it is written to `rms_wizard_canonical_sections`, not the wizard state option
+
+#### Scenario: State keeps only a summary
+
+- GIVEN a canonical payload exists for `about-us`
+- WHEN the wizard state is read
+- THEN it exposes only a summary entry (has-payload + timestamp), not the full copy
+
+### Requirement: First-Write Semantics
+
+The store MUST write a layout's canonical payload only when it is empty for that layout (`set_if_empty()`). Automatic re-runs MUST NOT overwrite existing canonical content. Overwriting MUST require an explicit user replace action (`replace()`) gated by a confirmation affordance; no automatic replace is permitted.
+
+#### Scenario: First write populates an empty layout
+
+- GIVEN no canonical payload exists for `services`
+- WHEN a run produces a `services` payload
+- THEN `set_if_empty()` stores it as the canonical entry
+
+#### Scenario: Re-run does not overwrite canonical
+
+- GIVEN a canonical payload already exists for `services`
+- WHEN a later run regenerates `services`
+- THEN the canonical entry is unchanged
+
+#### Scenario: Explicit replace overwrites after confirmation
+
+- GIVEN a canonical payload exists and the admin confirms a replace action
+- WHEN `replace()` is invoked
+- THEN the canonical entry is overwritten with the new payload
+
+### Requirement: Reusable Section Neutrality
+
+Canonical content MUST remain keyword-neutral. Reusable layouts include About, Services, FAQ, Mission, Vision, Why Choose Us, Testimonials, and similar shared sections — every layout except `hero` and `seo-content`. Testimonials MUST participate in the canonical store like any other reusable layout. The keyword-driven layouts `hero` and `seo-content` MUST NOT be stored as canonical content.
+
+#### Scenario: Testimonials are canonical/reusable
+
+- GIVEN a `testimonials-v1` section is produced
+- WHEN it is processed for canonicalization
+- THEN it participates in the canonical store like any other reusable layout
+
+#### Scenario: Keyword layouts excluded from store
+
+- GIVEN a run produces `hero` and `seo-content` payloads
+- WHEN canonicalization runs
+- THEN neither `hero` nor `seo-content` is written to the canonical store
+
+### Requirement: Per-Landing Override
+
+A per-landing `override_canonical` checkbox MUST allow regenerating a reusable section for that landing only. Override results MUST be written to the landing's own sections only and MUST NOT overwrite canonical content. Overrides MUST stay keyword-neutral. If an override regeneration returns an empty or invalid payload, the landing MUST fall back to the canonical copy and log the failure, and MUST NOT persist placeholders.
+
+#### Scenario: Override writes landing-only
+
+- GIVEN a landing row for `about-us` with `override_canonical = true`
+- WHEN the section is regenerated
+- THEN the result is stored in that landing's sections only and the canonical store is untouched
+
+#### Scenario: Override failure falls back to canonical
+
+- GIVEN an override regeneration returns an empty payload and canonical `about-us` exists
+- WHEN the step handles the failure
+- THEN the landing uses the canonical copy and the failure is logged
+
+#### Scenario: Override stays keyword-neutral
+
+- GIVEN a reusable section is regenerated via override
+- WHEN the prompt is composed
+- THEN no keyword context is injected for that section

--- a/openspec/changes/wizard-landing-page-builder/specs/wizard-controlled-unlock/spec.md
+++ b/openspec/changes/wizard-landing-page-builder/specs/wizard-controlled-unlock/spec.md
@@ -1,0 +1,45 @@
+# Wizard Controlled Unlock Specification
+
+## Purpose
+
+A capability-gated, reversible path to re-open a completed wizard site so owners can add landings without a destructive reset of completion state.
+
+## Requirements
+
+### Requirement: Controlled Unlock
+
+Sites where `rms_wizard_completed = true` MUST be read-only by default. Re-opening MUST occur through a Setup Wizard admin notice plus an explicit "Unlock wizard for editing" action, gated by the `manage_options` capability and a nonce. The unlock MUST NOT destroy `rms_wizard_completed` and MUST NOT perform any destructive reset of wizard state.
+
+#### Scenario: Completed site is read-only by default
+
+- GIVEN a site with `rms_wizard_completed = true` and no active unlock
+- WHEN an admin opens the Setup Wizard
+- THEN the wizard is read-only and shows the unlock notice
+
+#### Scenario: Unlock re-opens without destroying completion
+
+- GIVEN a completed site
+- WHEN an admin triggers "Unlock wizard for editing"
+- THEN the wizard becomes editable AND `rms_wizard_completed` is preserved
+
+#### Scenario: Unlock requires capability and nonce
+
+- GIVEN a request to unlock without `manage_options` or with an invalid nonce
+- WHEN the action is handled
+- THEN the unlock is refused and the wizard stays read-only
+
+### Requirement: Reversible Unlock with Audit
+
+The unlock MUST be reversible via a re-lock action that restores the read-only state without destroying completion. The unlock MUST record `rms_wizard_unlocked_at` and `rms_wizard_unlocked_by`. Re-locking MUST restore read-only state and MUST NOT delete the completion flag.
+
+#### Scenario: Re-lock restores read-only state
+
+- GIVEN the wizard is unlocked
+- WHEN an admin triggers the re-lock action
+- THEN the wizard returns to read-only AND `rms_wizard_completed` is preserved
+
+#### Scenario: Unlock records who and when
+
+- GIVEN an admin unlocks the wizard
+- WHEN the unlock is applied
+- THEN `rms_wizard_unlocked_at` and `rms_wizard_unlocked_by` are stored

--- a/openspec/changes/wizard-landing-page-builder/specs/wizard-home-page-builder/spec.md
+++ b/openspec/changes/wizard-landing-page-builder/specs/wizard-home-page-builder/spec.md
@@ -1,0 +1,25 @@
+# Delta for wizard-home-page-builder
+
+## ADDED Requirements
+
+### Requirement: Canonical First-Write on Home Success
+
+After a successful Home Page Builder run, the step MUST copy each produced reusable section payload into the canonical store using first-write semantics (`set_if_empty()`), skipping the keyword-driven layouts `hero` and `seo-content`. Re-runs MUST NOT overwrite existing canonical content; the canonical store MUST be read-only on re-run. The step MUST update the state summary to record which layouts now have a canonical payload. This behavior is additive: the existing generation, review, validation, and save flow MUST remain unchanged.
+
+#### Scenario: First Home run seeds empty canonical layouts
+
+- GIVEN a successful Home run produces `about-us` and `services` payloads and the canonical store is empty for them
+- WHEN the step finalizes
+- THEN `set_if_empty()` stores both as canonical entries and the state summary records them
+
+#### Scenario: Home re-run does not clobber canonical
+
+- GIVEN canonical payloads already exist for `about-us` and `services`
+- WHEN a later Home run regenerates those sections
+- THEN the canonical store entries are unchanged
+
+#### Scenario: Keyword layouts are skipped
+
+- GIVEN a Home run produces `hero` and `seo-content` payloads
+- WHEN canonical first-write runs
+- THEN neither `hero` nor `seo-content` is written to the canonical store

--- a/openspec/changes/wizard-landing-page-builder/specs/wizard-landing-page-builder/spec.md
+++ b/openspec/changes/wizard-landing-page-builder/specs/wizard-landing-page-builder/spec.md
@@ -1,0 +1,99 @@
+# Wizard Landing Page Builder Specification
+
+## Purpose
+
+The 8th wizard step generates N WordPress landing pages from `pages/landing-page.php`, governing per-landing keywords, landing type, indexability, menu eligibility, and Yoast meta.
+
+## Requirements
+
+### Requirement: Landing Page Generation
+
+The step MUST create one independent WordPress page per landing using `pages/landing-page.php`, setting `_wp_page_template` at insert time via `wp_insert_post` `meta_input` (never a `save_post`/`post_updated` hook) so the first render is correct. Landings MUST NOT receive Home/Blog reading settings.
+
+#### Scenario: First render uses landing template
+
+- GIVEN the admin requests a new landing
+- WHEN the step creates the page
+- THEN `_wp_page_template` is `pages/landing-page.php` at insert time and the first load renders it
+
+#### Scenario: N landings created independently
+
+- GIVEN the admin requests three landings in one run
+- WHEN the step runs
+- THEN three separate pages are created, each with its own sections and metadata
+
+### Requirement: Landing Keyword Governance
+
+Each landing MUST carry one primary keyword and 0–10 subkeywords; empty MUST mean 0, and the server MUST clamp the count to 10 and drop empties. Only `hero` and `seo-content` MUST consume keyword context; all other reusable sections, including override rows, MUST stay keyword-neutral.
+
+#### Scenario: Keyword sections consume the keyword
+
+- GIVEN a landing with a primary keyword and 3 subkeywords
+- WHEN the step generates `hero` and `seo-content`
+- THEN those sections receive the primary keyword and subkeywords
+
+#### Scenario: Reusable section stays neutral
+
+- GIVEN the same landing includes an `about-us` section
+- WHEN the step generates it
+- THEN no keyword context is injected
+
+#### Scenario: Subkeyword count is bounded
+
+- GIVEN 12 subkeywords with 2 blanks, or an empty field
+- WHEN the server processes them
+- THEN empties are dropped and the count is at most 10 (0 when empty)
+
+### Requirement: Landing Type and Menu Eligibility
+
+Each landing MUST persist `rms_landing_type` post meta (`seo`|`ads`) at insert time. SEO landings MUST be indexable and menu-eligible by default; Ads landings MUST be orphan/campaign pages, noindex by default and never auto-added to a menu. `menu_eligible` MUST default to `true` for `seo` and `false` for `ads`; menu setup MUST include only eligible landings.
+
+#### Scenario: SEO landing is indexable and menu-eligible
+
+- GIVEN a landing with `landing_type = seo`
+- WHEN it is generated
+- THEN `rms_landing_type` is `seo`, `menu_eligible` is `true`, and it may join the menu
+
+#### Scenario: Ads landing is orphan and excluded from menu
+
+- GIVEN a landing with `landing_type = ads`
+- WHEN it is generated
+- THEN `rms_landing_type` is `ads`, `menu_eligible` is `false`, and it is not auto-added to any menu
+
+### Requirement: Ads Landing Noindex Enforcement
+
+For `ads` landings the step MUST apply noindex via Yoast/post meta where available AND a `wp_robots` filter scoped to BOTH `_wp_page_template = pages/landing-page.php` AND `rms_landing_type = ads`. It MUST read the meta back and MUST NOT complete the landing if it is missing. SEO landings MUST NOT be noindexed by this filter.
+
+#### Scenario: Ads landing is noindex with double protection
+
+- GIVEN an `ads` landing is generated
+- WHEN it finalizes
+- THEN noindex meta is written and the scoped `wp_robots` filter emits noindex for it
+
+#### Scenario: Missing noindex blocks completion
+
+- GIVEN an `ads` landing whose noindex meta failed to persist
+- WHEN the step reads the meta back
+- THEN the landing is not marked complete and the failure is logged
+
+#### Scenario: SEO landing is not noindexed
+
+- GIVEN an `seo` landing on the same template
+- WHEN the `wp_robots` filter runs
+- THEN it does not emit noindex because `rms_landing_type` is not `ads`
+
+### Requirement: Per-Landing Yoast Meta
+
+When Yoast is active (`is_plugin_active('wordpress-seo/wordpress-seo.php')` OR `defined('WPSEO_VERSION')`) the step MUST generate and write a per-landing meta title and description from the primary keyword and landing type. When Yoast is absent it MUST skip, log a notice, and still complete the landing.
+
+#### Scenario: Yoast active writes meta
+
+- GIVEN Yoast is active
+- WHEN a landing is generated
+- THEN a meta title and description are written for that landing
+
+#### Scenario: Yoast absent skips and logs
+
+- GIVEN neither Yoast check passes
+- WHEN a landing is generated
+- THEN meta generation is skipped, a notice is logged, and the landing still completes

--- a/openspec/changes/wizard-landing-page-builder/tasks.md
+++ b/openspec/changes/wizard-landing-page-builder/tasks.md
@@ -66,13 +66,13 @@ Chain strategy: feature-branch-chain
 
 ## Phase 3: Menu, SEO, UI, Template Slice
 
-- [ ] 3.1 Modify `inc/wizard/class-menu-builder.php` with idempotent `append_page_items()`, `remove_page_items()`, and shared landing reconciliation.
-- [ ] 3.2 Modify `inc/wizard/class-step-menu-setup.php` to merge eligible SEO landings, exclude Ads, and reconcile after destructive menu replacement.
-- [ ] 3.3 Modify `inc/wizard/class-yoast-meta-writer.php` and `inc/wizard/wizard-init.php` for Yoast meta, noindex read-back, `wp_robots`, and Ads sitemap exclusion.
-- [ ] 3.4 Modify `src/ts/admin/wizard.ts` for landing collection, keyword validation, skip-all, identity hydration, duplicate reset, unlock/relock, and replace modal.
-- [ ] 3.5 Modify `src/scss/admin/wizard.scss` for landing and unlock admin states only.
-- [ ] 3.6 Modify `pages/landing-page.php` to render flexible `page_sections` and inject `breadcrumb-slim` once after the first Hero.
-- [ ] 3.7 **Activate** `landing-page-builder` atomically: add to `REQUIRED_STEPS` + `DISPATCHABLE_STEPS` (alias + dispatch case already present) together with UI + noindex/menu final-state sync. Do not activate required/dispatch without the visible skip/payload path.
+- [x] 3.1 Modify `inc/wizard/class-menu-builder.php` with idempotent `append_page_items()`, `remove_page_items()`, and shared landing reconciliation.
+- [x] 3.2 Modify `inc/wizard/class-step-menu-setup.php` to merge eligible SEO landings, exclude Ads, and reconcile after destructive menu replacement.
+- [x] 3.3 Modify `inc/wizard/class-yoast-meta-writer.php` and `inc/wizard/wizard-init.php` for Yoast meta, noindex read-back, `wp_robots`, and Ads sitemap exclusion.
+- [x] 3.4 Modify `src/ts/admin/wizard.ts` for landing collection, keyword validation, skip-all, identity hydration, duplicate reset, unlock/relock, and replace modal.
+- [x] 3.5 Modify `src/scss/admin/wizard.scss` for landing and unlock admin states only.
+- [x] 3.6 Modify `pages/landing-page.php` to render flexible `page_sections` and inject `breadcrumb-slim` once after the first Hero.
+- [x] 3.7 **Activate** `landing-page-builder` atomically: add to `REQUIRED_STEPS` + `DISPATCHABLE_STEPS` (alias + dispatch case already present) together with UI + noindex/menu final-state sync. Do not activate required/dispatch without the visible skip/payload path.
 
 ## Phase 4: Verification
 

--- a/openspec/changes/wizard-landing-page-builder/tasks.md
+++ b/openspec/changes/wizard-landing-page-builder/tasks.md
@@ -45,12 +45,24 @@ Chain strategy: feature-branch-chain
 
 ## Phase 2: Backend Landing Slice
 
-- [ ] 2.1 Modify `inc/wizard/class-ai-content-harness.php` with `PAGE_LANDING` Layer 2 and Layer 3 keywords only for `hero` / `seo-content`.
-- [ ] 2.2 Modify `inc/wizard/class-step-home-page-builder.php` to first-write reusable prepared rows to `Canonical_Section_Store`, excluding `hero` / `seo-content`.
-- [ ] 2.3 Create `inc/wizard/class-step-landing-page-builder.php` with payload validation, id/key/slug matching, duplicate/collision rejection, renames, and skip-all completion.
-- [ ] 2.4 Add lazy bootstrap in `inc/wizard/class-step-landing-page-builder.php`: `state.home_sections` → Home `page_sections` → neutral generation; block with actionable error if missing.
-- [ ] 2.5 Modify `inc/wizard/class-content-builder.php` to whitelist `meta_input` for `_wp_page_template` and `rms_landing_type` only.
-- [ ] 2.6 Modify `inc/wizard/class-step-generate-pages.php` so `delete_unselected_pages()` excludes pages with `rms_landing_type` meta.
+- [x] 2.1 Modify `inc/wizard/class-ai-content-harness.php` with `PAGE_LANDING` Layer 2 and Layer 3 keywords only for `hero` / `seo-content`.
+- [x] 2.2 Modify `inc/wizard/class-step-home-page-builder.php` to first-write reusable prepared rows to `Canonical_Section_Store`, excluding `hero` / `seo-content`.
+- [x] 2.3 Create `inc/wizard/class-step-landing-page-builder.php` with payload validation, id/key/slug matching, duplicate/collision rejection, renames, and skip-all completion.
+- [x] 2.4 Add lazy bootstrap in `inc/wizard/class-step-landing-page-builder.php`: `state.home_sections` → Home `page_sections` → neutral generation; block with actionable error if missing.
+- [x] 2.5 Modify `inc/wizard/class-content-builder.php` to whitelist `meta_input` for `_wp_page_template` and `rms_landing_type` only.
+- [x] 2.6 Modify `inc/wizard/class-step-generate-pages.php` so `delete_unselected_pages()` excludes pages with `rms_landing_type` meta.
+
+### Phase 2 compatibility notes (PR2 review follow-up)
+
+- **Backend class exists; activation deferred to Phase 3.** `Step_Landing_Page_Builder` is fully implemented (tasks 2.3–2.4), but `landing-page-builder` is **not** in active `REQUIRED_STEPS` or `DISPATCHABLE_STEPS` until Phase 3 wires admin UI + Ads noindex/menu final-state sync. Dispatch `case` + `landing_page_builder` alias remain in code for that activation; alias alone is safe (unknown-step reject before status writes).
+- Existing 7-step UI completion stays valid. Do **not** require the 8th step while UI cannot send payload/`skip_all` visibly.
+- Identity preflight: non-empty `id` + `landing_key` must refer to the same state row; reject duplicate ids/keys, non-landing and other-landing slug collisions, and stale cross-pair identity. Match order is deterministic: id → key → slug.
+- Keyword sections (`hero` / `seo-content`): AI generation/decode/review/empty-validation failures return `WP_Error` (no placeholder publish) unless a valid existing landing payload can be preserved.
+- Multi-landing partial failure: successful `landing_pages` are persisted before marking the step failed; counts/post IDs logged; status write failures logged.
+- Critical persistence (`save_state`, `set_step_status`, meta safety-net, canonical `replace`/`set_if_empty`) verified via post-state checks and logged/`WP_Error` on failure.
+- Reviewer throwables and invalid JSON-on-success are logged with landing key/slug/layout. Reusable/canonical generation/review filters out keyword-driven priors.
+- Shared section-assembly helper extraction deferred (deliberate duplication with Home builder) — extract after PR3 or before archive.
+- Controlled unlock remains enabled with the 2.6 deletion guard (unchanged by this follow-up).
 
 ## Phase 3: Menu, SEO, UI, Template Slice
 
@@ -60,6 +72,7 @@ Chain strategy: feature-branch-chain
 - [ ] 3.4 Modify `src/ts/admin/wizard.ts` for landing collection, keyword validation, skip-all, identity hydration, duplicate reset, unlock/relock, and replace modal.
 - [ ] 3.5 Modify `src/scss/admin/wizard.scss` for landing and unlock admin states only.
 - [ ] 3.6 Modify `pages/landing-page.php` to render flexible `page_sections` and inject `breadcrumb-slim` once after the first Hero.
+- [ ] 3.7 **Activate** `landing-page-builder` atomically: add to `REQUIRED_STEPS` + `DISPATCHABLE_STEPS` (alias + dispatch case already present) together with UI + noindex/menu final-state sync. Do not activate required/dispatch without the visible skip/payload path.
 
 ## Phase 4: Verification
 

--- a/openspec/changes/wizard-landing-page-builder/tasks.md
+++ b/openspec/changes/wizard-landing-page-builder/tasks.md
@@ -1,0 +1,69 @@
+# Tasks: Wizard Landing Page Builder
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | 900-1300 |
+| 400-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Suggested split | PR 1 foundation → PR 2 backend → PR 3 UI/verification |
+| Delivery strategy | auto-chain (`force-chained` from `openspec/config.yaml`) |
+| Chain strategy | feature-branch-chain |
+
+Decision needed before apply: No
+Chained PRs recommended: Yes
+Chain strategy: feature-branch-chain
+400-line budget risk: High
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Notes |
+|------|------|-----------|-------|
+| 1 | Canonical store, state, unlock, completion gate | PR 1 | base = tracker; `php -l` |
+| 2 | Landing backend, identity, bootstrap, deletion guard | PR 2 | base = PR 1; PHP/manual |
+| 3 | Menu/SEO sync, admin UI, template, verification | PR 3 | base = PR 2; TS/build/manual |
+
+## Phase 1: Foundation Slice
+
+- [x] 1.1 Create `inc/wizard/class-canonical-section-store.php` with lazy option load, `get/has/set_if_empty/replace/summary`, and first-write semantics.
+- [x] 1.2 Modify `inc/wizard/class-state-manager.php` and `inc/wizard/class-step-controller.php` for `landing_pages`, `canonical_sections`, shared required steps, parity, and unlock-aware completion.
+- [x] 1.3 Create `inc/wizard/class-wizard-unlock-controller.php` and modify `inc/wizard/wizard-init.php` for nonce/capability unlock UI plus `rms_wizard_unlocked_at` / `rms_wizard_unlocked_by`.
+- [x] 1.4 Modify `inc/wizard/class-step-controller.php` so only `unlock`/`relock` bypass the completed gate and skip `set_current_step()` / `set_step_status()`.
+
+### Phase 1 compatibility notes (review follow-up)
+
+- Active `REQUIRED_STEPS` remains the existing 7-step list so current completion stays valid. Do **not** require `landing-page-builder` until Phase 2 registers dispatch + UI. `Step_Home_Page_Builder::maybe_mark_completed()` and `Step_Controller::complete()` both consume `get_required_steps()`.
+- Do **not** expose or normalize `landing_page_builder` / `landing-page-builder` as executable until Phase 2 adds dispatch. `Step_Controller` keeps a `DISPATCHABLE_STEPS` allowlist (7 real steps + `unlock`/`relock`) and rejects unknown steps **before** `set_current_step()` / `set_step_status()`. Re-add the alias + dispatch case together in Phase 2.
+- Canonical store and unlock/relock only report success after real option persistence (or verified equal post-state).
+- Controlled unlock stays disabled (`CONTROLLED_UNLOCK_ENABLED = false`) until Phase 2 task 2.6 ships the generate-pages landing deletion guard. Unlock admin-post is not registered while disabled; REST unlock returns 503 via controller gate. Relock remains for stale-marker cleanup. Enable unlock registration + UI in the same 2.6 change.
+- Completion flag source of truth is `State_Manager::has_completion_flag()` only (no duplicate unlock-controller helper).
+- Stale `rms_wizard_unlocked_at` markers do **not** bypass lock while controlled unlock is disabled (`has_unlock_marker()` vs effective `is_unlocked()`). Relock still clears stale markers. `RMS_WIZARD_FORCE` still bypasses lock.
+- Admin view trusts only `get_resume_state()` flags for completed/unlocked/force/controlled-unlock UI.
+- `execute_step()` marks progress steps `failed` on unexpected throwables so status cannot stick on `running`; logs if that status write fails; unlock/relock never write step status.
+- Verification note: automated behavioral tests unavailable by project config (`strict_tdd: false` / testing unavailable). Phase 1 relies on `php -l` + 4R fresh review + later manual runtime verification (Phase 4).
+
+## Phase 2: Backend Landing Slice
+
+- [ ] 2.1 Modify `inc/wizard/class-ai-content-harness.php` with `PAGE_LANDING` Layer 2 and Layer 3 keywords only for `hero` / `seo-content`.
+- [ ] 2.2 Modify `inc/wizard/class-step-home-page-builder.php` to first-write reusable prepared rows to `Canonical_Section_Store`, excluding `hero` / `seo-content`.
+- [ ] 2.3 Create `inc/wizard/class-step-landing-page-builder.php` with payload validation, id/key/slug matching, duplicate/collision rejection, renames, and skip-all completion.
+- [ ] 2.4 Add lazy bootstrap in `inc/wizard/class-step-landing-page-builder.php`: `state.home_sections` → Home `page_sections` → neutral generation; block with actionable error if missing.
+- [ ] 2.5 Modify `inc/wizard/class-content-builder.php` to whitelist `meta_input` for `_wp_page_template` and `rms_landing_type` only.
+- [ ] 2.6 Modify `inc/wizard/class-step-generate-pages.php` so `delete_unselected_pages()` excludes pages with `rms_landing_type` meta.
+
+## Phase 3: Menu, SEO, UI, Template Slice
+
+- [ ] 3.1 Modify `inc/wizard/class-menu-builder.php` with idempotent `append_page_items()`, `remove_page_items()`, and shared landing reconciliation.
+- [ ] 3.2 Modify `inc/wizard/class-step-menu-setup.php` to merge eligible SEO landings, exclude Ads, and reconcile after destructive menu replacement.
+- [ ] 3.3 Modify `inc/wizard/class-yoast-meta-writer.php` and `inc/wizard/wizard-init.php` for Yoast meta, noindex read-back, `wp_robots`, and Ads sitemap exclusion.
+- [ ] 3.4 Modify `src/ts/admin/wizard.ts` for landing collection, keyword validation, skip-all, identity hydration, duplicate reset, unlock/relock, and replace modal.
+- [ ] 3.5 Modify `src/scss/admin/wizard.scss` for landing and unlock admin states only.
+- [ ] 3.6 Modify `pages/landing-page.php` to render flexible `page_sections` and inject `breadcrumb-slim` once after the first Hero.
+
+## Phase 4: Verification
+
+- [ ] 4.1 Run `php -l` on `inc/wizard/class-step-landing-page-builder.php`, `inc/wizard/class-canonical-section-store.php`, `inc/wizard/class-wizard-unlock-controller.php`, and modified `inc/wizard/*.php` above.
+- [ ] 4.2 Run `npx tsc --noEmit` for `src/ts/admin/wizard.ts` and `npm run build` for `src/scss/admin/wizard.scss` / `pages/landing-page.php` assets.
+- [ ] 4.3 Manually verify `inc/wizard/class-step-landing-page-builder.php`: SEO+Ads, keyword scope, canonical first-write/replace/override, identity/collisions, type flips, Yoast, sitemap/noindex, deletion guard.
+- [ ] 4.4 Manually verify `src/ts/admin/wizard.ts`, `inc/wizard/class-step-controller.php`, and `pages/landing-page.php`: skip-all, duplicate-row reset, unlock/relock, no step-status pollution, first render, breadcrumb once, DOM < 1500.

--- a/pages/landing-page.php
+++ b/pages/landing-page.php
@@ -1,18 +1,79 @@
 <?php
 /**
  * Template Name: SEO Landing Page
+ *
+ * Renders wizard-generated flexible `page_sections` when present.
+ * Injects `breadcrumb-slim` once after the first Hero row only.
+ * Falls back to the hardcoded section order when ACF is available but empty.
+ * When ACF functions are missing, renders a minimal safe title/content fallback
+ * (template parts call `get_sub_field()` and would fatal without ACF).
+ *
+ * @package Simple_RMS_Theme
  */
 
 get_header();
 
-get_template_part('templates/hero');
-get_template_part('templates/breadcrumb-slim');
-get_template_part('templates/seo-content');
-get_template_part('templates/vision-mission-v1');
-get_template_part('templates/badges');
-get_template_part('templates/portfolio-v1');
-get_template_part('templates/seo-content');
-get_template_part('templates/testimonials-v1');
-get_template_part('templates/seo-content');
+// ACF flexible helpers required for both generated rows and hardcoded parts.
+$acf_available = function_exists( 'have_rows' )
+	&& function_exists( 'the_row' )
+	&& function_exists( 'get_row_layout' )
+	&& function_exists( 'get_sub_field' );
+
+$has_flexible_sections = $acf_available && have_rows( 'page_sections' );
+
+if ( $has_flexible_sections ) :
+	$breadcrumb_injected = false;
+
+	while ( have_rows( 'page_sections' ) ) :
+		the_row();
+		$layout = get_row_layout();
+
+		if ( ! is_string( $layout ) || '' === $layout ) {
+			continue;
+		}
+
+		get_template_part( 'templates/' . $layout );
+
+		// Inject breadcrumb once after the first Hero row only (not an ACF layout).
+		// No Hero in flexible content ⇒ no breadcrumb in this path.
+		if ( ! $breadcrumb_injected && 'hero' === $layout ) {
+			get_template_part( 'templates/breadcrumb-slim' );
+			$breadcrumb_injected = true;
+		}
+	endwhile;
+elseif ( $acf_available ) :
+	// ACF present but empty flexible content — legacy hardcoded section order.
+	// Template parts may call get_sub_field(); safe only when ACF is loaded.
+	get_template_part( 'templates/hero' );
+	get_template_part( 'templates/breadcrumb-slim' );
+	get_template_part( 'templates/seo-content' );
+	get_template_part( 'templates/vision-mission-v1' );
+	get_template_part( 'templates/badges' );
+	get_template_part( 'templates/portfolio-v1' );
+	get_template_part( 'templates/seo-content' );
+	get_template_part( 'templates/testimonials-v1' );
+	get_template_part( 'templates/seo-content' );
+else :
+	// ACF missing/degraded — do not load template parts that call get_sub_field().
+	?>
+	<main id="main" class="landing-page landing-page--acf-missing">
+		<?php
+		while ( have_posts() ) :
+			the_post();
+			?>
+			<article <?php post_class( 'landing-page__article' ); ?>>
+				<header class="landing-page__header">
+					<h1 class="landing-page__title"><?php echo esc_html( get_the_title() ); ?></h1>
+				</header>
+				<div class="landing-page__content entry-content">
+					<?php the_content(); ?>
+				</div>
+			</article>
+			<?php
+		endwhile;
+		?>
+	</main>
+	<?php
+endif;
 
 get_footer();

--- a/src/scss/admin/wizard.scss
+++ b/src/scss/admin/wizard.scss
@@ -846,6 +846,196 @@
   background: var(--rms-wizard-success);
 }
 
+/* Landing Page Builder + unlock admin states */
+.rms-setup-wizard.is-locked .rms-wizard-step-panel {
+  opacity: 0.92;
+}
+
+.rms-setup-wizard.is-unlocked .rms-wizard-step-nav.is-complete {
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--rms-wizard-warning), #fff 40%);
+}
+
+.rms-wizard-controlled-unlock__form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  margin-top: 10px;
+}
+
+.rms-wizard-landing-skip-all {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 12px 14px;
+  margin: 0 0 14px;
+  font-weight: 600;
+  background: #f0f6fc;
+  border: 1px solid #c3d9ed;
+  border-radius: 10px;
+}
+
+.rms-wizard-landing-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.rms-wizard-landing-toolbar .rms-wizard-field__instructions {
+  flex-basis: 100%;
+  margin: 0;
+}
+
+.rms-wizard-landing-builder {
+  display: grid;
+  gap: 12px;
+}
+
+.rms-wizard-landing-rows {
+  display: grid;
+  gap: 14px;
+}
+
+.rms-wizard-landing-row {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+  background: #fff;
+  border: 1px solid var(--rms-wizard-border);
+  border-radius: 12px;
+  box-shadow: 0 1px 1px rgb(0 0 0 / 0.03);
+}
+
+.rms-wizard-landing-row.is-ads {
+  border-color: color-mix(in srgb, var(--rms-wizard-warning), #fff 35%);
+  background: #fffdf8;
+}
+
+.rms-wizard-landing-row__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.rms-wizard-landing-row__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.rms-wizard-landing-row__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.rms-wizard-landing-row__subkeywords {
+  grid-column: 1 / -1;
+}
+
+.rms-wizard-landing-sections {
+  display: grid;
+  gap: 10px;
+  padding-top: 4px;
+  border-top: 1px dashed var(--rms-wizard-border);
+}
+
+.rms-wizard-landing-sections__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.rms-wizard-landing-section-rows {
+  display: grid;
+  gap: 8px;
+}
+
+.rms-wizard-landing-section-row {
+  display: grid;
+  grid-template-columns: minmax(180px, 1.2fr) minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 12px;
+  background: #f8fafc;
+  border: 1px solid #edf0f2;
+  border-radius: 10px;
+}
+
+.rms-wizard-landing-section-override {
+  display: inline-flex;
+  gap: 8px;
+  align-items: flex-start;
+  margin: 0;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--rms-wizard-muted);
+}
+
+.rms-wizard-landing-section-override[hidden] {
+  display: none;
+}
+
+.rms-wizard-landing-builder__empty {
+  padding: 16px;
+  margin: 0;
+  color: var(--rms-wizard-muted);
+  text-align: center;
+  background: #fff;
+  border: 1px dashed var(--rms-wizard-border);
+  border-radius: 12px;
+}
+
+.rms-wizard-landing-replace-panel {
+  display: grid;
+  gap: 8px;
+  margin-top: 16px;
+  padding: 14px;
+  background: #fff8e5;
+  border: 1px solid color-mix(in srgb, var(--rms-wizard-warning), #fff 55%);
+  border-left: 4px solid var(--rms-wizard-warning);
+  border-radius: 10px;
+}
+
+.rms-wizard-landing-replace-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 8px;
+}
+
+.rms-wizard-landing-replace-option {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  margin: 0;
+  padding: 8px 10px;
+  background: #fff;
+  border: 1px solid #f0e2b8;
+  border-radius: 8px;
+  font-size: 13px;
+}
+
+.rms-wizard-fields.is-skip-all .rms-wizard-landing-builder,
+.rms-wizard-fields.is-skip-all .rms-wizard-landing-toolbar,
+.rms-wizard-fields.is-skip-all .rms-wizard-landing-replace-panel {
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+@media (max-width: 782px) {
+  .rms-wizard-landing-row__grid,
+  .rms-wizard-landing-section-row {
+    grid-template-columns: 1fr;
+  }
+}
+
 .rms-wizard-next-step.is-ready:hover,
 .rms-wizard-next-step.is-ready:focus-visible {
   filter: brightness(0.95);

--- a/src/ts/admin/wizard.ts
+++ b/src/ts/admin/wizard.ts
@@ -20,6 +20,21 @@ interface GeneratedPage {
   role?: string;
 }
 
+interface LandingPageState {
+  id?: number | string;
+  landing_key?: string;
+  title?: string;
+  slug?: string;
+  landing_type?: 'seo' | 'ads' | string;
+  menu_eligible?: boolean;
+  primary_keyword?: string;
+  subkeywords?: string[];
+  keywords?: {
+    primary_keyword?: string;
+    subkeywords?: string[];
+  };
+}
+
 interface WizardPageTemplate {
   title?: string;
   slug?: string;
@@ -36,9 +51,35 @@ interface HomeSectionTemplate {
   default_item_count?: number;
 }
 
+interface LandingSectionOption {
+  layout?: string;
+  label?: string;
+  description?: string;
+  is_keyword_layout?: boolean;
+  is_default?: boolean;
+  default_item_count?: number;
+  has_fillable_fields?: boolean;
+}
+
 interface HomeSectionPayload {
   layout: string;
   item_count: number;
+}
+
+interface LandingSectionPayload {
+  layout: string;
+  override_canonical: boolean;
+}
+
+interface LandingPayloadItem {
+  id: number | null;
+  landing_key: string;
+  title: string;
+  slug: string;
+  landing_type: 'seo' | 'ads';
+  primary_keyword: string;
+  subkeywords: string[];
+  sections: LandingSectionPayload[];
 }
 
 interface PagePayloadItem {
@@ -64,7 +105,13 @@ interface WizardState {
     configured_at?: string;
   };
   generated_pages?: GeneratedPage[];
+  landing_pages?: LandingPageState[];
   locked?: boolean;
+  unlocked?: boolean;
+  completed_flag?: boolean;
+  force_unlocked?: boolean;
+  controlled_unlock_ui?: boolean;
+  has_unlock_marker?: boolean;
   logs?: WizardLogEntry[];
 }
 
@@ -164,6 +211,7 @@ declare global {
     { slug: 'menu-setup', label: 'Menu Setup' },
     { slug: 'ia-generation', label: 'IA Generation' },
     { slug: 'home-page-builder', label: 'Home Page Builder' },
+    { slug: 'landing-page-builder', label: 'Landing Page Builder' },
   ];
 
   const destructiveWarnings: Record<string, { message: string; checkboxMessage: string }> = {
@@ -174,6 +222,10 @@ declare global {
     'menu-setup': {
       message: 'Existing menus and location assignments will be removed and replaced. This cannot be undone.',
       checkboxMessage: 'Confirm that existing menus and location assignments can be replaced before continuing.',
+    },
+    'landing-page-builder': {
+      message: 'Replacing canonical reusable sections overwrites shared copy used by future landings. This cannot be undone.',
+      checkboxMessage: 'Confirm replace canonical before overwriting shared reusable sections.',
     },
   };
 
@@ -278,9 +330,15 @@ declare global {
     }).join('');
   };
 
+  const isWizardLocked = (): boolean => Boolean(state.locked) && !state.unlocked && !state.force_unlocked;
+
   const updateButtons = (): void => {
-    const isLocked = Boolean(state.locked);
+    const isLocked = isWizardLocked();
     const isHydrating = root.classList.contains('is-hydrating');
+
+    root.classList.toggle('is-unlocked', Boolean(state.unlocked) && !state.force_unlocked);
+    root.classList.toggle('is-force-unlocked', Boolean(state.force_unlocked));
+    root.classList.toggle('is-locked', isLocked);
 
     navButtons.forEach((button) => {
       button.disabled = isHydrating || runningStep !== null;
@@ -316,6 +374,8 @@ declare global {
       const allComplete = steps.every((step) => statusFor(step.slug) === 'complete');
       completeButton.disabled = isHydrating || isLocked || runningStep !== null || !allComplete;
     }
+
+    syncLandingSkipAllUi();
   };
 
   const render = (): void => {
@@ -325,6 +385,8 @@ declare global {
 
     renderGeneratedPageControls();
     hydrateIaGenerationForm();
+    hydrateLandingRowsFromState();
+    renderLandingReplaceOptions();
     syncGuidedControlState();
     setActiveStep(nextStep);
     updateNav();
@@ -332,8 +394,10 @@ declare global {
     updateLogs();
     updateButtons();
 
-    if (state.locked) {
-      setNotice('The setup wizard is complete and locked. Define RMS_WIZARD_FORCE as true for development reruns.', 'success');
+    if (isWizardLocked()) {
+      setNotice('The setup wizard is complete and locked. Unlock it for editing or define RMS_WIZARD_FORCE as true for development reruns.', 'success');
+    } else if (state.unlocked && !state.force_unlocked) {
+      setNotice('The setup wizard is unlocked for editing. Completion state is preserved.', 'info');
     }
   };
 
@@ -501,6 +565,10 @@ declare global {
       return collectHomePageBuilderPayload(form);
     }
 
+    if (step === 'landing-page-builder') {
+      return collectLandingPageBuilderPayload(form);
+    }
+
     return collectFormPayload(form);
   };
 
@@ -645,6 +713,24 @@ declare global {
   };
 
   const ensureDestructiveConfirmation = async (step: string, payload: StepPayload): Promise<boolean> => {
+    if (step === 'landing-page-builder') {
+      const replaceMap = (payload.replace_canonical ?? {}) as Record<string, boolean>;
+      const needsReplaceConfirm = Object.values(replaceMap).some(Boolean);
+
+      if (!needsReplaceConfirm) {
+        return true;
+      }
+
+      const warning = destructiveWarnings[step];
+      const confirmed = await openConfirmationModal(warning.message);
+
+      if (confirmed) {
+        payload.confirm_replace_canonical = true;
+      }
+
+      return confirmed;
+    }
+
     const warning = destructiveWarnings[step];
 
     if (!warning) {
@@ -665,6 +751,121 @@ declare global {
     }
 
     return confirmed;
+  };
+
+  const collectLandingPageBuilderPayload = (form: HTMLFormElement): StepPayload => {
+    const skipAll = Boolean(form.querySelector<HTMLInputElement>('[data-wizard-landing-skip-all]')?.checked);
+
+    if (skipAll) {
+      return { skip_all: true, landings: [] };
+    }
+
+    const landings: LandingPayloadItem[] = [];
+    const seenSlugs = new Set<string>();
+    const seenKeys = new Set<string>();
+    const seenIds = new Set<number>();
+
+    form.querySelectorAll<HTMLElement>('[data-wizard-landing-row]').forEach((row, index) => {
+      const title = row.querySelector<HTMLInputElement>('[data-wizard-landing-title]')?.value.trim() ?? '';
+      const slugInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-slug]')?.value.trim() ?? '';
+      const slug = sanitizeSlug(slugInput || title);
+      const landingTypeRaw = row.querySelector<HTMLSelectElement>('[data-wizard-landing-type]')?.value ?? 'seo';
+      const landingType: 'seo' | 'ads' = landingTypeRaw === 'ads' ? 'ads' : 'seo';
+      const primaryKeyword = row.querySelector<HTMLInputElement>('[data-wizard-landing-primary-keyword]')?.value.trim() ?? '';
+      const subkeywordsRaw = row.querySelector<HTMLInputElement>('[data-wizard-landing-subkeywords]')?.value ?? '';
+      const idRaw = row.querySelector<HTMLInputElement>('[data-wizard-landing-id]')?.value.trim() ?? '';
+      const landingKey = row.querySelector<HTMLInputElement>('[data-wizard-landing-key]')?.value.trim() || mintLandingKey();
+      const id = idRaw ? Number.parseInt(idRaw, 10) : null;
+
+      if (!title && !slug && !primaryKeyword) {
+        return;
+      }
+
+      if (!title) {
+        throw new Error(`Landing ${index + 1} needs a title.`);
+      }
+
+      if (!slug) {
+        throw new Error(`Landing "${title}" needs a valid slug.`);
+      }
+
+      if (!primaryKeyword) {
+        throw new Error(`Landing "${title}" requires a primary keyword.`);
+      }
+
+      if (seenSlugs.has(slug)) {
+        throw new Error(`Landing slugs must be unique. "${slug}" is already used.`);
+      }
+
+      if (landingKey && seenKeys.has(landingKey)) {
+        throw new Error('Duplicate landing keys are not allowed in one run.');
+      }
+
+      if (id && Number.isFinite(id) && id > 0) {
+        if (seenIds.has(id)) {
+          throw new Error('Duplicate landing ids are not allowed in one run.');
+        }
+
+        seenIds.add(id);
+      }
+
+      seenSlugs.add(slug);
+      seenKeys.add(landingKey);
+
+      const subkeywords = subkeywordsRaw
+        .split(',')
+        .map((value) => value.trim())
+        .filter(Boolean)
+        .slice(0, 10);
+
+      const sections: LandingSectionPayload[] = [];
+
+      row.querySelectorAll<HTMLElement>('[data-wizard-landing-section-row]').forEach((sectionRow) => {
+        const layout = sectionRow.querySelector<HTMLSelectElement>('[data-wizard-landing-section-layout]')?.value.trim() ?? '';
+        const override = Boolean(sectionRow.querySelector<HTMLInputElement>('[data-wizard-landing-section-override]')?.checked);
+
+        if (!layout) {
+          return;
+        }
+
+        sections.push({ layout, override_canonical: override });
+      });
+
+      if (sections.length === 0) {
+        throw new Error(`Landing "${title}" needs at least one section.`);
+      }
+
+      landings.push({
+        id: id && Number.isFinite(id) && id > 0 ? id : null,
+        landing_key: landingKey,
+        title,
+        slug,
+        landing_type: landingType,
+        primary_keyword: primaryKeyword,
+        subkeywords,
+        sections,
+      });
+    });
+
+    if (landings.length === 0) {
+      throw new Error('Add at least one landing page or enable skip-all to complete without landings.');
+    }
+
+    const replaceCanonical: Record<string, boolean> = {};
+
+    form.querySelectorAll<HTMLInputElement>('[data-wizard-landing-replace-layout]:checked').forEach((input) => {
+      const layout = input.value.trim();
+
+      if (layout) {
+        replaceCanonical[layout] = true;
+      }
+    });
+
+    return {
+      landings,
+      replace_canonical: replaceCanonical,
+      skip_all: false,
+    };
   };
 
   const openConfirmationModal = (message: string): Promise<boolean> => {
@@ -783,14 +984,449 @@ declare global {
     });
   };
 
-  const getGeneratedPages = (): GeneratedPage[] => (
-    Array.isArray(state.generated_pages) ? state.generated_pages.filter((page) => Boolean(generatedPageValue(page))) : []
-  );
+  /**
+   * Pages available to the Menu Setup UI.
+   *
+   * Merges standard `state.generated_pages` with menu-eligible SEO landings
+   * from `state.landing_pages`. Ads and `menu_eligible=false` landings are
+   * excluded via `getMenuEligibleLandings()` so they never appear as menu options.
+   */
+  const getGeneratedPages = (): GeneratedPage[] => {
+    const standard = Array.isArray(state.generated_pages)
+      ? state.generated_pages.filter((page) => Boolean(generatedPageValue(page)))
+      : [];
+    const landings = getMenuEligibleLandings().map((landing) => ({
+      id: landing.id,
+      title: landing.title,
+      slug: landing.slug,
+      role: landing.landing_type === 'seo' ? 'landing-seo' : 'landing',
+    }));
 
-  const generatedPageValue = (page: GeneratedPage): string => {
+    const seen = new Set<string>();
+    const merged: GeneratedPage[] = [];
+
+    [...standard, ...landings].forEach((page) => {
+      const value = generatedPageValue(page);
+
+      if (!value || seen.has(value)) {
+        return;
+      }
+
+      seen.add(value);
+      merged.push(page);
+    });
+
+    return merged;
+  };
+
+  /**
+   * SEO landings that may appear in Menu Setup.
+   *
+   * Filters `state.landing_pages` to `landing_type=seo` with `menu_eligible`
+   * true (default true for SEO when the flag is absent). Ads and ineligible
+   * rows are always excluded. Requires a resolvable id/slug via
+   * `generatedPageValue()`.
+   */
+  const getMenuEligibleLandings = (): LandingPageState[] => {
+    if (!Array.isArray(state.landing_pages)) {
+      return [];
+    }
+
+    return state.landing_pages.filter((landing) => {
+      const type = landing.landing_type === 'ads' ? 'ads' : 'seo';
+      const eligible = typeof landing.menu_eligible === 'boolean' ? landing.menu_eligible : type === 'seo';
+
+      return type === 'seo' && eligible && Boolean(generatedPageValue(landing));
+    });
+  };
+
+  const generatedPageValue = (page: GeneratedPage | LandingPageState): string => {
     const id = typeof page.id === 'number' || typeof page.id === 'string' ? String(page.id) : '';
 
     return id || sanitizeSlug(page.slug ?? '');
+  };
+
+  const mintLandingKey = (): string => {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return `lp_${crypto.randomUUID().replace(/-/g, '').slice(0, 12)}`;
+    }
+
+    return `lp_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+  };
+
+  const readLandingSectionOptions = (): LandingSectionOption[] => {
+    const source = root.querySelector<HTMLScriptElement>('script[data-wizard-landing-sections]');
+
+    if (!source?.textContent) {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(source.textContent) as unknown;
+
+      return Array.isArray(parsed)
+        ? parsed.filter((item): item is LandingSectionOption => typeof item === 'object' && item !== null)
+        : [];
+    } catch (_error) {
+      return [];
+    }
+  };
+
+  const readLandingDefaultLayouts = (): string[] => {
+    const source = root.querySelector<HTMLScriptElement>('script[data-wizard-landing-default-layouts]');
+
+    if (!source?.textContent) {
+      return ['hero', 'seo-content', 'vision-mission-v1', 'badges', 'portfolio-v1', 'seo-content', 'testimonials-v1', 'seo-content'];
+    }
+
+    try {
+      const parsed = JSON.parse(source.textContent) as unknown;
+
+      return Array.isArray(parsed) ? parsed.map(String).filter(Boolean) : [];
+    } catch (_error) {
+      return ['hero', 'seo-content'];
+    }
+  };
+
+  const getLandingRowsContainer = (): HTMLElement | null => root.querySelector<HTMLElement>('[data-wizard-landing-rows]');
+
+  const getLandingRowTemplate = (): HTMLTemplateElement | null => root.querySelector<HTMLTemplateElement>('template[data-wizard-landing-row-template]');
+
+  const getLandingSectionRowTemplate = (): HTMLTemplateElement | null => root.querySelector<HTMLTemplateElement>('template[data-wizard-landing-section-row-template]');
+
+  const hydrateLandingRowsFromState = (): void => {
+    const rows = getLandingRowsContainer();
+
+    if (!rows) {
+      return;
+    }
+
+    // Never clobber in-progress edits; only seed when the builder is empty.
+    if (rows.querySelector('[data-wizard-landing-row]')) {
+      syncLandingBuilderEmptyState();
+      return;
+    }
+
+    const landings = Array.isArray(state.landing_pages) ? state.landing_pages : [];
+
+    if (landings.length === 0) {
+      syncLandingBuilderEmptyState();
+      return;
+    }
+
+    landings.forEach((landing) => {
+      const rawId = landing.id;
+      const parsedId = typeof rawId === 'number'
+        ? rawId
+        : (typeof rawId === 'string' ? Number.parseInt(rawId, 10) : NaN);
+
+      addLandingRow({
+        id: Number.isFinite(parsedId) && parsedId > 0 ? parsedId : null,
+        landing_key: landing.landing_key || mintLandingKey(),
+        title: landing.title || '',
+        slug: landing.slug || '',
+        landing_type: landing.landing_type === 'ads' ? 'ads' : 'seo',
+        primary_keyword: landing.primary_keyword || landing.keywords?.primary_keyword || '',
+        subkeywords: landing.subkeywords || landing.keywords?.subkeywords || [],
+      });
+    });
+  };
+
+  const addLandingRow = (data: Partial<LandingPayloadItem> = {}): HTMLElement | null => {
+    const rows = getLandingRowsContainer();
+    const template = getLandingRowTemplate();
+
+    if (!rows || !template) {
+      return null;
+    }
+
+    const index = rows.querySelectorAll('[data-wizard-landing-row]').length;
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = template.innerHTML.replaceAll('__INDEX__', String(index)).trim();
+    const row = wrapper.firstElementChild instanceof HTMLElement ? wrapper.firstElementChild : null;
+
+    if (!row) {
+      return null;
+    }
+
+    const idInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-id]');
+    const keyInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-key]');
+    const titleInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-title]');
+    const slugInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-slug]');
+    const typeSelect = row.querySelector<HTMLSelectElement>('[data-wizard-landing-type]');
+    const keywordInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-primary-keyword]');
+    const subkeywordsInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-subkeywords]');
+    const heading = row.querySelector<HTMLElement>('[data-wizard-landing-heading]');
+
+    if (idInput) {
+      idInput.value = data.id && Number(data.id) > 0 ? String(data.id) : '';
+    }
+
+    if (keyInput) {
+      keyInput.value = data.landing_key || mintLandingKey();
+    }
+
+    if (titleInput) {
+      titleInput.value = data.title || '';
+    }
+
+    if (slugInput) {
+      slugInput.value = sanitizeSlug(data.slug || data.title || '');
+      slugInput.dataset.wizardSlugAuto = data.slug ? '0' : '1';
+    }
+
+    if (typeSelect) {
+      typeSelect.value = data.landing_type === 'ads' ? 'ads' : 'seo';
+    }
+
+    if (keywordInput) {
+      keywordInput.value = data.primary_keyword || '';
+    }
+
+    if (subkeywordsInput) {
+      subkeywordsInput.value = (data.subkeywords || []).join(', ');
+    }
+
+    if (heading) {
+      heading.textContent = data.title || `Landing ${index + 1}`;
+    }
+
+    rows.append(row);
+    row.classList.toggle('is-ads', typeSelect?.value === 'ads');
+
+    const sectionLayouts = (data.sections && data.sections.length > 0)
+      ? data.sections.map((section) => section.layout)
+      : readLandingDefaultLayouts();
+
+    sectionLayouts.forEach((layout, sectionIndex) => {
+      const override = Boolean(data.sections?.[sectionIndex]?.override_canonical);
+      addLandingSectionRow(row, layout, override);
+    });
+
+    reindexLandingRows();
+    syncLandingBuilderEmptyState();
+    syncLandingSkipAllUi();
+    titleInput?.focus();
+
+    return row;
+  };
+
+  const addLandingSectionRow = (landingRow: HTMLElement, layout = '', override = false): void => {
+    const container = landingRow.querySelector<HTMLElement>('[data-wizard-landing-section-rows]');
+    const template = getLandingSectionRowTemplate();
+
+    if (!container || !template) {
+      return;
+    }
+
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = template.innerHTML
+      .replaceAll('__LINDEX__', '0')
+      .replaceAll('__SINDEX__', String(container.querySelectorAll('[data-wizard-landing-section-row]').length))
+      .trim();
+    const sectionRow = wrapper.firstElementChild instanceof HTMLElement ? wrapper.firstElementChild : null;
+
+    if (!sectionRow) {
+      return;
+    }
+
+    const select = sectionRow.querySelector<HTMLSelectElement>('[data-wizard-landing-section-layout]');
+    const overrideInput = sectionRow.querySelector<HTMLInputElement>('[data-wizard-landing-section-override]');
+    const options = readLandingSectionOptions();
+
+    if (select) {
+      select.replaceChildren();
+      options.forEach((option) => {
+        if (!option.layout) {
+          return;
+        }
+
+        const opt = new Option(
+          option.label ? `${option.label} (${option.layout})` : option.layout,
+          option.layout
+        );
+        select.append(opt);
+      });
+
+      if (layout) {
+        select.value = layout;
+      } else if (options[0]?.layout) {
+        select.value = options[0].layout;
+      }
+
+      syncLandingSectionOverrideVisibility(sectionRow);
+    }
+
+    if (overrideInput) {
+      overrideInput.checked = override;
+    }
+
+    container.append(sectionRow);
+    reindexLandingRows();
+  };
+
+  const syncLandingSectionOverrideVisibility = (sectionRow: HTMLElement): void => {
+    const layout = sectionRow.querySelector<HTMLSelectElement>('[data-wizard-landing-section-layout]')?.value ?? '';
+    const overrideLabel = sectionRow.querySelector<HTMLElement>('.rms-wizard-landing-section-override');
+    const isKeyword = layout === 'hero' || layout === 'seo-content';
+
+    if (overrideLabel) {
+      overrideLabel.hidden = isKeyword;
+    }
+
+    if (isKeyword) {
+      const overrideInput = sectionRow.querySelector<HTMLInputElement>('[data-wizard-landing-section-override]');
+
+      if (overrideInput) {
+        overrideInput.checked = false;
+      }
+    }
+  };
+
+  const duplicateLandingRow = (button: HTMLButtonElement): void => {
+    const source = button.closest<HTMLElement>('[data-wizard-landing-row]');
+
+    if (!source) {
+      return;
+    }
+
+    const title = source.querySelector<HTMLInputElement>('[data-wizard-landing-title]')?.value.trim() ?? '';
+    const slug = source.querySelector<HTMLInputElement>('[data-wizard-landing-slug]')?.value.trim() ?? '';
+    const landingType = source.querySelector<HTMLSelectElement>('[data-wizard-landing-type]')?.value === 'ads' ? 'ads' : 'seo';
+    const primaryKeyword = source.querySelector<HTMLInputElement>('[data-wizard-landing-primary-keyword]')?.value.trim() ?? '';
+    const subkeywords = (source.querySelector<HTMLInputElement>('[data-wizard-landing-subkeywords]')?.value ?? '')
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean);
+    const sections: LandingSectionPayload[] = Array.from(source.querySelectorAll<HTMLElement>('[data-wizard-landing-section-row]')).map((sectionRow) => ({
+      layout: sectionRow.querySelector<HTMLSelectElement>('[data-wizard-landing-section-layout]')?.value.trim() ?? '',
+      override_canonical: Boolean(sectionRow.querySelector<HTMLInputElement>('[data-wizard-landing-section-override]')?.checked),
+    })).filter((section) => section.layout);
+
+    // Duplicate must clear id and mint a new landing_key.
+    addLandingRow({
+      id: null,
+      landing_key: mintLandingKey(),
+      title: title ? `${title} copy` : '',
+      slug: slug ? `${slug}-copy` : '',
+      landing_type: landingType,
+      primary_keyword: primaryKeyword,
+      subkeywords,
+      sections,
+    });
+  };
+
+  const removeLandingRow = (button: HTMLButtonElement): void => {
+    button.closest<HTMLElement>('[data-wizard-landing-row]')?.remove();
+    reindexLandingRows();
+    syncLandingBuilderEmptyState();
+  };
+
+  const reindexLandingRows = (): void => {
+    const rows = Array.from(root.querySelectorAll<HTMLElement>('[data-wizard-landing-row]'));
+
+    rows.forEach((row, index) => {
+      row.dataset.wizardLandingIndex = String(index);
+
+      const heading = row.querySelector<HTMLElement>('[data-wizard-landing-heading]');
+      const title = row.querySelector<HTMLInputElement>('[data-wizard-landing-title]')?.value.trim() ?? '';
+
+      if (heading) {
+        heading.textContent = title || `Landing ${index + 1}`;
+      }
+
+      row.classList.toggle('is-ads', row.querySelector<HTMLSelectElement>('[data-wizard-landing-type]')?.value === 'ads');
+
+      row.querySelectorAll<FieldElement>('[name]').forEach((field) => {
+        field.name = field.name
+          .replace(/landings\[\d+\]/g, `landings[${index}]`)
+          .replace(/landings\[__INDEX__\]/g, `landings[${index}]`);
+      });
+
+      row.querySelectorAll<HTMLElement>('[id]').forEach((element) => {
+        element.id = element.id.replace(/rms-wizard-landing-([a-z-]+)-\d+/g, `rms-wizard-landing-$1-${index}`);
+      });
+
+      row.querySelectorAll<HTMLLabelElement>('label[for]').forEach((label) => {
+        label.htmlFor = label.htmlFor.replace(/rms-wizard-landing-([a-z-]+)-\d+/g, `rms-wizard-landing-$1-${index}`);
+      });
+
+      Array.from(row.querySelectorAll<HTMLElement>('[data-wizard-landing-section-row]')).forEach((sectionRow, sectionIndex) => {
+        sectionRow.querySelectorAll<FieldElement>('[name]').forEach((field) => {
+          field.name = field.name
+            .replace(/landings\[\d+\]/g, `landings[${index}]`)
+            .replace(/sections\[\d+\]/g, `sections[${sectionIndex}]`)
+            .replace(/__LINDEX__/g, String(index))
+            .replace(/__SINDEX__/g, String(sectionIndex));
+        });
+      });
+    });
+  };
+
+  const syncLandingBuilderEmptyState = (): void => {
+    const hasRows = Boolean(root.querySelector('[data-wizard-landing-row]'));
+    const emptyMessage = root.querySelector<HTMLElement>('[data-wizard-landing-empty]');
+
+    if (emptyMessage) {
+      emptyMessage.hidden = hasRows;
+    }
+  };
+
+  const syncLandingSkipAllUi = (): void => {
+    const form = root.querySelector<HTMLFormElement>('[data-wizard-landing-page-builder-form]');
+    const skip = form?.querySelector<HTMLInputElement>('[data-wizard-landing-skip-all]');
+    const builder = form?.querySelector<HTMLElement>('[data-wizard-landing-builder]');
+    const toolbar = form?.querySelector<HTMLElement>('.rms-wizard-landing-toolbar');
+    const replacePanel = form?.querySelector<HTMLElement>('[data-wizard-landing-replace-panel]');
+    const skipped = Boolean(skip?.checked);
+
+    if (builder) {
+      builder.hidden = skipped;
+    }
+
+    if (toolbar) {
+      toolbar.hidden = skipped;
+    }
+
+    if (replacePanel) {
+      replacePanel.hidden = skipped;
+    }
+
+    form?.classList.toggle('is-skip-all', skipped);
+  };
+
+  const renderLandingReplaceOptions = (): void => {
+    const list = root.querySelector<HTMLElement>('[data-wizard-landing-replace-list]');
+
+    if (!list || list.dataset.wizardRendered === '1') {
+      return;
+    }
+
+    const options = readLandingSectionOptions().filter((option) => option.layout && !option.is_keyword_layout);
+    list.replaceChildren();
+
+    options.forEach((option) => {
+      if (!option.layout) {
+        return;
+      }
+
+      const label = document.createElement('label');
+      label.className = 'rms-wizard-landing-replace-option';
+
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      input.value = option.layout;
+      input.dataset.wizardLandingReplaceLayout = '1';
+      input.name = `replace_canonical[${option.layout}]`;
+
+      const text = document.createElement('span');
+      text.textContent = option.label ? `${option.label} (${option.layout})` : option.layout;
+
+      label.append(input, text);
+      list.append(label);
+    });
+
+    list.dataset.wizardRendered = '1';
   };
 
   const syncGuidedControlState = (): void => {
@@ -1669,6 +2305,52 @@ declare global {
       if (removePageButton) {
         event.preventDefault();
         removePageRow(removePageButton);
+        return;
+      }
+
+      const addLandingButton = target.closest<HTMLButtonElement>('[data-wizard-add-landing]');
+
+      if (addLandingButton) {
+        event.preventDefault();
+        addLandingRow();
+        return;
+      }
+
+      const duplicateLandingButton = target.closest<HTMLButtonElement>('[data-wizard-duplicate-landing]');
+
+      if (duplicateLandingButton) {
+        event.preventDefault();
+        duplicateLandingRow(duplicateLandingButton);
+        return;
+      }
+
+      const removeLandingButton = target.closest<HTMLButtonElement>('[data-wizard-remove-landing]');
+
+      if (removeLandingButton) {
+        event.preventDefault();
+        removeLandingRow(removeLandingButton);
+        return;
+      }
+
+      const addLandingSectionButton = target.closest<HTMLButtonElement>('[data-wizard-add-landing-section]');
+
+      if (addLandingSectionButton) {
+        event.preventDefault();
+        const landingRow = addLandingSectionButton.closest<HTMLElement>('[data-wizard-landing-row]');
+
+        if (landingRow) {
+          addLandingSectionRow(landingRow);
+        }
+
+        return;
+      }
+
+      const removeLandingSectionButton = target.closest<HTMLButtonElement>('[data-wizard-remove-landing-section]');
+
+      if (removeLandingSectionButton) {
+        event.preventDefault();
+        removeLandingSectionButton.closest<HTMLElement>('[data-wizard-landing-section-row]')?.remove();
+        reindexLandingRows();
       }
     });
 
@@ -1682,6 +2364,24 @@ declare global {
       if (target instanceof HTMLInputElement && target.matches('[data-wizard-page-slug]')) {
         updatePageRowFromSlug(target);
       }
+
+      if (target instanceof HTMLInputElement && target.matches('[data-wizard-landing-title]')) {
+        const row = target.closest<HTMLElement>('[data-wizard-landing-row]');
+        const slugInput = row?.querySelector<HTMLInputElement>('[data-wizard-landing-slug]');
+        const heading = row?.querySelector<HTMLElement>('[data-wizard-landing-heading]');
+
+        if (slugInput && slugInput.dataset.wizardSlugAuto !== '0') {
+          slugInput.value = sanitizeSlug(target.value);
+        }
+
+        if (heading) {
+          heading.textContent = target.value.trim() || 'Landing';
+        }
+      }
+
+      if (target instanceof HTMLInputElement && target.matches('[data-wizard-landing-slug]')) {
+        target.dataset.wizardSlugAuto = '0';
+      }
     });
 
     root.addEventListener('blur', (event) => {
@@ -1689,6 +2389,11 @@ declare global {
 
       if (target instanceof HTMLInputElement && target.matches('[data-wizard-page-slug]')) {
         updatePageRowFromSlug(target, true);
+      }
+
+      if (target instanceof HTMLInputElement && target.matches('[data-wizard-landing-slug]')) {
+        target.value = sanitizeSlug(target.value);
+        target.dataset.wizardSlugAuto = '0';
       }
     }, true);
 
@@ -1711,6 +2416,26 @@ declare global {
 
       if (target instanceof HTMLSelectElement && target.matches('[data-wizard-home-section-select]')) {
         syncGuidedControlState();
+        return;
+      }
+
+      if (target instanceof HTMLInputElement && target.matches('[data-wizard-landing-skip-all]')) {
+        syncLandingSkipAllUi();
+        return;
+      }
+
+      if (target instanceof HTMLSelectElement && target.matches('[data-wizard-landing-type]')) {
+        const row = target.closest<HTMLElement>('[data-wizard-landing-row]');
+        row?.classList.toggle('is-ads', target.value === 'ads');
+        return;
+      }
+
+      if (target instanceof HTMLSelectElement && target.matches('[data-wizard-landing-section-layout]')) {
+        const sectionRow = target.closest<HTMLElement>('[data-wizard-landing-section-row]');
+
+        if (sectionRow) {
+          syncLandingSectionOverrideVisibility(sectionRow);
+        }
       }
     });
 


### PR DESCRIPTION
Closes #16

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds the foundation for the wizard landing page builder change: canonical reusable section store, unlock controller plumbing, and shared completion-step handling.
- Keeps the existing 7-step wizard completion path valid until the landing runtime ships in PR 2.
- Adds OpenSpec artifacts for the full landing builder change and Phase 1 apply progress.

## Chain Context

Strategy: feature-branch-chain

```text
feature/wizard-setup  (chain base / prior wizard setup work)
└── 📍 PR 1: feat/wizard-landing-foundation
    └── PR 2: backend landing generation (next)
        └── PR 3: menu/SEO/UI/template verification (next)
```

Current PR boundary: foundation only. Landing generation, menu/SEO sync, admin TS, SCSS, and landing template changes are out of scope for this PR.

## Changes

| File | Change |
|------|--------|
| `.gitignore` | Ignores local-only prompt/PRD docs to prevent accidental commits. |
| `inc/wizard/class-canonical-section-store.php` | Adds first-write reusable section option store. |
| `inc/wizard/class-wizard-unlock-controller.php` | Adds disabled-by-default controlled unlock/relock plumbing and stale marker cleanup. |
| `inc/wizard/class-state-manager.php` | Adds landing/canonical state defaults and unlock-aware completion helpers. |
| `inc/wizard/class-step-controller.php` | Adds dispatchability guard, pseudo-step handling, shared required steps, and exception failure handling. |
| `inc/wizard/class-step-home-page-builder.php` | Uses shared required-step source for completion parity. |
| `inc/wizard/wizard-init.php` | Adds Phase 1-safe unlock/readonly/force messaging and handlers. |
| `openspec/changes/wizard-landing-page-builder/` | Adds exploration, proposal, specs, approved design, tasks, and apply progress. |

## Test Plan

- [x] `php -l` passed on touched PHP files via delegated apply verification.
- [x] 4R pre-PR review completed: risk PASS, resilience PASS, readability PASS.
- [x] Reliability reviewed; automated behavior tests are unavailable by project config (`strict_tdd: false`, no test runner). Manual runtime verification is tracked for Phase 4.
- [x] Confirmed Phase 1 preserves current 7-step completion; `landing-page-builder` is not active required runtime yet.
- [x] Confirmed local-only docs are ignored and not included in the PR.

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran applicable syntax checks
- [x] SDD artifacts updated
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers