### PR TITLE
feat(wizard): add landing builder backend

### DIFF
--- a/inc/wizard/class-ai-content-harness.php
+++ b/inc/wizard/class-ai-content-harness.php
@@ -325,7 +325,39 @@ PROMPT;
 		return strtr( $template, self::get_editorial_rule_replacements() );
 	}
 
+	/**
+	 * Layouts that may receive landing keyword context.
+	 *
+	 * @var string[]
+	 */
+	private const KEYWORD_LAYOUTS = [
+		'hero',
+		'seo-content',
+	];
+
 	public function get_layer2( string $page_type = self::PAGE_HOME ): string {
+		if ( self::PAGE_LANDING === $page_type ) {
+			return <<<'PROMPT'
+PAGE CONTEXT: Landing Page
+
+You are writing content for a dedicated landing page with a single conversion goal. Visitors arrive with a specific intent (organic search or paid campaign) and should be guided toward one clear action.
+
+Editorial purpose:
+- Focus the page on one primary offer, service, or search intent without inventing proof.
+- Keep the conversion path clear: promise, proof/trust, process or value, and call to action.
+- Align section roles with a typical landing order: hero, SEO content, trust/value sections (vision/mission, badges, portfolio), social proof, and closing SEO content.
+- Give each section a distinct job so the page does not repeat the same headline pattern or praise language.
+
+Ads vs SEO intent:
+- SEO landings support organic discovery, trust, and long-form helpful copy around a search intent.
+- Ads landings support paid traffic with a tighter offer focus and stronger conversion urgency, still without inventing guarantees or proof.
+
+Tone: Specific, confident, local, and human. Never generic brochure copy, corporate jargon, exaggerated claims, or keyword stuffing.
+
+Write for visitors who already have intent. Content should feel purposeful and conversion-ready, not like a broad Home page overview.
+PROMPT;
+		}
+
 		if ( self::PAGE_HOME !== $page_type ) {
 			$this->log_warning( sprintf( 'Unsupported AI content harness page type "%s"; falling back to PAGE_HOME.', $page_type ) );
 		}
@@ -347,7 +379,64 @@ Write for a general audience discovering this business. Content should feel like
 PROMPT;
 	}
 
-	public function get_layer3( string $layout, int $item_count, array $client_context ): string {
+	/**
+	 * Whether a layout may consume landing keyword placeholders.
+	 */
+	public function is_keyword_layout( string $layout ): bool {
+		return in_array( $this->normalize_layout_key( $layout ), self::KEYWORD_LAYOUTS, true );
+	}
+
+	/**
+	 * Whether a layout is reusable/canonical-eligible (not keyword-driven).
+	 */
+	public function is_reusable_layout( string $layout ): bool {
+		$layout = $this->normalize_layout_key( $layout );
+
+		return '' !== $layout && ! $this->is_keyword_layout( $layout );
+	}
+
+	/**
+	 * Normalize landing keyword context: drop empties and clamp subkeywords to 0–10.
+	 *
+	 * @param array<string,mixed> $keywords Raw keyword payload.
+	 *
+	 * @return array{primary_keyword:string,subkeywords:string[]}
+	 */
+	public function normalize_keywords( array $keywords ): array {
+		$primary = trim( \sanitize_text_field( (string) ( $keywords['primary_keyword'] ?? $keywords['keyword'] ?? '' ) ) );
+		$raw     = $keywords['subkeywords'] ?? $keywords['sub_keywords'] ?? [];
+
+		if ( is_string( $raw ) ) {
+			$raw = preg_split( '/[\n,]+/', $raw ) ?: [];
+		}
+
+		$subkeywords = [];
+
+		foreach ( is_array( $raw ) ? $raw : [] as $item ) {
+			$item = trim( \sanitize_text_field( (string) $item ) );
+
+			if ( '' === $item ) {
+				continue;
+			}
+
+			$subkeywords[] = $item;
+
+			if ( count( $subkeywords ) >= 10 ) {
+				break;
+			}
+		}
+
+		return [
+			'primary_keyword' => $primary,
+			'subkeywords'     => $subkeywords,
+		];
+	}
+
+	/**
+	 * @param array<string,mixed> $client_context Approved client context.
+	 * @param array<string,mixed> $keywords       Optional landing keywords (PAGE_LANDING only).
+	 */
+	public function get_layer3( string $layout, int $item_count, array $client_context, string $page_type = self::PAGE_HOME, array $keywords = [] ): string {
 		$layout        = $this->normalize_layout_key( $layout );
 		$fillable      = $this->get_fillable_fields( $layout );
 		$blocked       = $this->get_blocked_fields( $layout );
@@ -355,19 +444,36 @@ PROMPT;
 		$client_json   = false === $client_json ? '{}' : $client_json;
 		$service_rules = isset( self::SERVICE_DESCRIPTION_FIELDS[ $layout ] ) ? sprintf( ' For service repeaters, preserve the order of client_json.company_services. Service names/titles and service-specific benefits must come only from company_services[].service_name and service_short_description; return descriptions only in %s.', (string) self::SERVICE_DESCRIPTION_FIELDS[ $layout ]['description'] ) : '';
 		$layout_rules  = $this->layout_rules( $layout, $item_count );
+		$normalized    = $this->normalize_keywords( $keywords );
+		$inject_kw     = self::PAGE_LANDING === $page_type && $this->is_keyword_layout( $layout );
+		$primary       = $inject_kw ? $normalized['primary_keyword'] : '';
+		$subkeywords   = $inject_kw ? implode( ', ', $normalized['subkeywords'] ) : '';
+		$keyword_block = '';
 
-		$template = "Layout: {{layout}}\nRequested item count: {{item_count}}\nAllowed JSON keys: {{fillable_fields}}\nBlocked JSON keys: {{blocked_fields}}\nClient JSON: {{client_json}}\nReturn one compact JSON object using only allowed keys. Do not include blocked or unknown keys.{{service_rules}}\n\n{{layout_rules}}";
+		if ( $inject_kw ) {
+			$keyword_block = "\n\nKEYWORD CONTEXT (mandatory for this section only):\n"
+				. '- Primary keyword: {{primary_keyword}}' . "\n"
+				. '- Subkeywords: {{subkeywords}}' . "\n"
+				. "- Naturally incorporate the primary keyword in headlines and body copy where it fits.\n"
+				. "- Use subkeywords sparingly and only when natural. Do not keyword-stuff.\n"
+				. "- Do not invent services, locations, or proof to force keyword usage.";
+		}
+
+		$template = "Layout: {{layout}}\nRequested item count: {{item_count}}\nAllowed JSON keys: {{fillable_fields}}\nBlocked JSON keys: {{blocked_fields}}\nClient JSON: {{client_json}}\nReturn one compact JSON object using only allowed keys. Do not include blocked or unknown keys.{{service_rules}}\n\n{{layout_rules}}{{keyword_block}}";
 
 		return strtr(
 			$template,
 			[
-				'{{layout}}'          => $layout,
-				'{{item_count}}'      => (string) max( 0, $item_count ),
-				'{{fillable_fields}}' => implode( ', ', $fillable ),
-				'{{blocked_fields}}'  => implode( ', ', $blocked ),
-				'{{client_json}}'     => $client_json,
-				'{{service_rules}}'   => $service_rules,
-				'{{layout_rules}}'    => $layout_rules,
+				'{{layout}}'           => $layout,
+				'{{item_count}}'       => (string) max( 0, $item_count ),
+				'{{fillable_fields}}'  => implode( ', ', $fillable ),
+				'{{blocked_fields}}'   => implode( ', ', $blocked ),
+				'{{client_json}}'      => $client_json,
+				'{{service_rules}}'    => $service_rules,
+				'{{layout_rules}}'     => $layout_rules,
+				'{{keyword_block}}'    => $keyword_block,
+				'{{primary_keyword}}'  => '' !== $primary ? $primary : '(none provided)',
+				'{{subkeywords}}'      => '' !== $subkeywords ? $subkeywords : '(none)',
 			]
 		);
 	}

--- a/inc/wizard/class-content-builder.php
+++ b/inc/wizard/class-content-builder.php
@@ -50,6 +50,16 @@ class Content_Builder {
 	}
 
 	/**
+	 * Post meta keys allowed through build_page() meta_input.
+	 *
+	 * @var string[]
+	 */
+	private const META_INPUT_WHITELIST = [
+		'_wp_page_template',
+		'rms_landing_type',
+	];
+
+	/**
 	 * Build one page from a definition array.
 	 *
 	 * @param array<string,mixed> $page Page definition.
@@ -79,6 +89,12 @@ class Content_Builder {
 			'post_name'    => $slug,
 			'post_content' => $content,
 		];
+
+		$meta_input = $this->whitelisted_meta_input( is_array( $page['meta_input'] ?? null ) ? $page['meta_input'] : [] );
+
+		if ( [] !== $meta_input ) {
+			$post_data['meta_input'] = $meta_input;
+		}
 
 		if ( $post_id > 0 ) {
 			$post_data['ID'] = $post_id;
@@ -111,6 +127,45 @@ class Content_Builder {
 	 */
 	public function fallback_image_url(): string {
 		return \trailingslashit( \get_template_directory_uri() ) . 'assets/images/wizard-placeholder.svg';
+	}
+
+	/**
+	 * Sanitize and whitelist meta_input for insert/update.
+	 *
+	 * Only `_wp_page_template` and `rms_landing_type` are accepted.
+	 *
+	 * @param array<string,mixed> $meta Raw meta_input map.
+	 *
+	 * @return array<string,string>
+	 */
+	private function whitelisted_meta_input( array $meta ): array {
+		$clean = [];
+
+		foreach ( self::META_INPUT_WHITELIST as $key ) {
+			if ( ! array_key_exists( $key, $meta ) ) {
+				continue;
+			}
+
+			if ( '_wp_page_template' === $key ) {
+				$value = \sanitize_text_field( (string) $meta[ $key ] );
+
+				if ( '' !== $value ) {
+					$clean[ $key ] = $value;
+				}
+
+				continue;
+			}
+
+			if ( 'rms_landing_type' === $key ) {
+				$value = \sanitize_key( (string) $meta[ $key ] );
+
+				if ( in_array( $value, [ 'seo', 'ads' ], true ) ) {
+					$clean[ $key ] = $value;
+				}
+			}
+		}
+
+		return $clean;
 	}
 
 	private function save_page_sections( int $post_id, array $sections ): void {

--- a/inc/wizard/class-menu-builder.php
+++ b/inc/wizard/class-menu-builder.php
@@ -154,6 +154,391 @@ class Menu_Builder {
 		return $deleted;
 	}
 
+	/**
+	 * Append page links to a menu without duplicating existing page items.
+	 *
+	 * Best-effort for SEO eligibility paths: failures are reported in the
+	 * structured result (and logged) so callers can warn without fail-closing.
+	 * Ads/ineligible removal remains fail-closed via `remove_page_items()`.
+	 *
+	 * @param int        $menu_id  Menu term ID.
+	 * @param array<int> $page_ids Page post IDs to ensure are present.
+	 *
+	 * @return array{
+	 *   created: array<int,int>,
+	 *   already_present: array<int,int>,
+	 *   failed_page_ids: array<int,int>,
+	 *   verified: bool
+	 * }
+	 */
+	public function append_page_items( int $menu_id, array $page_ids ): array {
+		$menu_id = \absint( $menu_id );
+		$empty   = [
+			'created'          => [],
+			'already_present'  => [],
+			'failed_page_ids'  => [],
+			'verified'         => true,
+		];
+
+		if ( $menu_id <= 0 ) {
+			return $empty;
+		}
+
+		$existing_page_ids = $this->menu_page_ids( $menu_id );
+		$created           = [];
+		$already_present   = [];
+		$create_failed     = [];
+		$requested         = [];
+		$position          = count( $existing_page_ids ) + 1;
+
+		foreach ( $page_ids as $page_id ) {
+			$page_id = \absint( $page_id );
+
+			if ( $page_id <= 0 || 'page' !== \get_post_type( $page_id ) ) {
+				continue;
+			}
+
+			$requested[] = $page_id;
+
+			if ( in_array( $page_id, $existing_page_ids, true ) ) {
+				$already_present[] = $page_id;
+				continue;
+			}
+
+			$item_id = \wp_update_nav_menu_item(
+				$menu_id,
+				0,
+				[
+					'menu-item-object-id' => $page_id,
+					'menu-item-object'    => 'page',
+					'menu-item-type'      => 'post_type',
+					'menu-item-status'    => 'publish',
+					'menu-item-position'  => $position,
+				]
+			);
+
+			if ( \is_wp_error( $item_id ) ) {
+				$create_failed[] = $page_id;
+				$this->logger->log(
+					'error',
+					'Wizard menu item append failed.',
+					[
+						'menu_id'       => $menu_id,
+						'page_id'       => $page_id,
+						'error_code'    => $item_id->get_error_code(),
+						'error_message' => $item_id->get_error_message(),
+					]
+				);
+				continue;
+			}
+
+			$created[]           = (int) $item_id;
+			$existing_page_ids[] = $page_id;
+			$position++;
+		}
+
+		// Bust object cache so read-back reflects freshly written items.
+		if ( function_exists( 'clean_term_cache' ) ) {
+			\clean_term_cache( $menu_id, 'nav_menu' );
+		}
+
+		$present_after = $this->menu_page_ids( $menu_id );
+		$failed        = [];
+
+		foreach ( array_values( array_unique( $requested ) ) as $page_id ) {
+			if ( ! in_array( $page_id, $present_after, true ) ) {
+				$failed[] = $page_id;
+			}
+		}
+
+		// Prefer create-time failures when read-back also missed them.
+		$failed = array_values( array_unique( array_merge( $create_failed, $failed ) ) );
+		$ok     = [] === $failed;
+
+		if ( [] !== $created ) {
+			$this->logger->log(
+				'info',
+				'Wizard menu items appended.',
+				[
+					'menu_id'    => $menu_id,
+					'item_count' => count( $created ),
+					'created'    => $created,
+				]
+			);
+		}
+
+		if ( ! $ok ) {
+			$this->logger->log(
+				'warning',
+				'Wizard menu item append incomplete after verification.',
+				[
+					'menu_id'          => $menu_id,
+					'failed_page_ids'  => $failed,
+					'already_present'  => array_values( array_unique( $already_present ) ),
+					'created'          => $created,
+					'requested'        => array_values( array_unique( $requested ) ),
+				]
+			);
+		}
+
+		return [
+			'created'         => $created,
+			'already_present' => array_values( array_unique( $already_present ) ),
+			'failed_page_ids' => $failed,
+			'verified'        => $ok,
+		];
+	}
+
+	/**
+	 * Remove nav items that point at the given page IDs.
+	 *
+	 * Verifies via read-back that target page IDs are no longer present.
+	 *
+	 * @param int        $menu_id  Menu term ID.
+	 * @param array<int> $page_ids Page post IDs to remove from the menu.
+	 *
+	 * @return array{deleted:array<int,int>,failed_page_ids:array<int,int>,verified:bool}
+	 */
+	public function remove_page_items( int $menu_id, array $page_ids ): array {
+		$menu_id  = \absint( $menu_id );
+		$page_ids = array_values(
+			array_unique(
+				array_filter(
+					array_map( 'absint', $page_ids )
+				)
+			)
+		);
+
+		$empty = [
+			'deleted'          => [],
+			'failed_page_ids'  => [],
+			'verified'         => true,
+		];
+
+		if ( $menu_id <= 0 || [] === $page_ids ) {
+			return $empty;
+		}
+
+		$items = \wp_get_nav_menu_items( $menu_id );
+
+		if ( empty( $items ) || ! is_array( $items ) ) {
+			// Nothing to remove — already verified absent.
+			return $empty;
+		}
+
+		$deleted = [];
+
+		foreach ( $items as $item ) {
+			$object_id = (int) ( $item->object_id ?? 0 );
+			$type      = (string) ( $item->type ?? '' );
+			$object    = (string) ( $item->object ?? '' );
+
+			if ( 'post_type' !== $type || 'page' !== $object ) {
+				continue;
+			}
+
+			if ( ! in_array( $object_id, $page_ids, true ) ) {
+				continue;
+			}
+
+			$item_id = (int) ( $item->ID ?? 0 );
+
+			if ( $item_id <= 0 ) {
+				continue;
+			}
+
+			$result = \wp_delete_post( $item_id, true );
+
+			if ( $result ) {
+				$deleted[] = $item_id;
+			} else {
+				$this->logger->log(
+					'error',
+					'Wizard menu item delete failed.',
+					[
+						'menu_id'  => $menu_id,
+						'item_id'  => $item_id,
+						'page_id'  => $object_id,
+					]
+				);
+			}
+		}
+
+		// Bust nav menu item cache so read-back is not stale.
+		\wp_cache_delete( $menu_id, 'nav_menu_items' );
+		if ( function_exists( 'clean_term_cache' ) ) {
+			\clean_term_cache( $menu_id, 'nav_menu' );
+		}
+
+		$still_present = array_values(
+			array_intersect( $this->menu_page_ids( $menu_id ), $page_ids )
+		);
+		$verified      = [] === $still_present;
+
+		if ( [] !== $deleted ) {
+			$this->logger->log(
+				'info',
+				'Wizard menu items removed for pages.',
+				[
+					'menu_id'    => $menu_id,
+					'page_ids'   => $page_ids,
+					'item_count' => count( $deleted ),
+					'verified'   => $verified,
+				]
+			);
+		}
+
+		if ( ! $verified ) {
+			$this->logger->log(
+				'error',
+				'Wizard menu page removal failed read-back verification.',
+				[
+					'menu_id'         => $menu_id,
+					'page_ids'        => $page_ids,
+					'failed_page_ids' => $still_present,
+					'deleted_items'   => $deleted,
+				]
+			);
+		}
+
+		return [
+			'deleted'         => $deleted,
+			'failed_page_ids' => $still_present,
+			'verified'        => $verified,
+		];
+	}
+
+	/**
+	 * Final-state landing menu reconciliation across configured menus.
+	 *
+	 * Eligible SEO landings are present idempotently; Ads / ineligible landings are removed.
+	 * Removal is verified via read-back; failures are reported in the return payload.
+	 * SEO append is best-effort: `append_failed_page_ids` is reported but does not
+	 * flip `verified` (Ads removal remains fail-closed).
+	 *
+	 * @param array<int>                        $menu_ids       Menu term IDs to reconcile.
+	 * @param array<int,array<string,mixed>>    $landing_pages  Landing state rows.
+	 *
+	 * @return array{
+	 *   appended:array<int,int>,
+	 *   removed:array<int,int>,
+	 *   removal_failed_page_ids:array<int,int>,
+	 *   append_failed_page_ids:array<int,int>,
+	 *   verified:bool
+	 * }
+	 */
+	public function reconcile_landing_menu_items( array $menu_ids, array $landing_pages ): array {
+		$eligible_ids   = [];
+		$ineligible_ids = [];
+
+		foreach ( $landing_pages as $landing ) {
+			if ( ! is_array( $landing ) ) {
+				continue;
+			}
+
+			$page_id = \absint( $landing['id'] ?? 0 );
+
+			if ( $page_id <= 0 || 'page' !== \get_post_type( $page_id ) ) {
+				continue;
+			}
+
+			$type          = \sanitize_key( (string) ( $landing['landing_type'] ?? '' ) );
+			$menu_eligible = array_key_exists( 'menu_eligible', $landing )
+				? (bool) $landing['menu_eligible']
+				: ( 'seo' === $type );
+
+			if ( 'seo' === $type && $menu_eligible ) {
+				$eligible_ids[] = $page_id;
+			} else {
+				$ineligible_ids[] = $page_id;
+			}
+		}
+
+		$eligible_ids   = array_values( array_unique( $eligible_ids ) );
+		$ineligible_ids = array_values( array_unique( $ineligible_ids ) );
+		$appended       = [];
+		$removed        = [];
+		$failed_pages   = [];
+		$append_failed  = [];
+
+		foreach ( $menu_ids as $menu_id ) {
+			$menu_id = \absint( $menu_id );
+
+			if ( $menu_id <= 0 ) {
+				continue;
+			}
+
+			if ( [] !== $ineligible_ids ) {
+				$removal      = $this->remove_page_items( $menu_id, $ineligible_ids );
+				$removed      = array_merge( $removed, is_array( $removal['deleted'] ?? null ) ? $removal['deleted'] : [] );
+				$failed       = is_array( $removal['failed_page_ids'] ?? null ) ? $removal['failed_page_ids'] : [];
+				$failed_pages = array_merge( $failed_pages, $failed );
+			}
+
+			if ( [] !== $eligible_ids ) {
+				$append_result = $this->append_page_items( $menu_id, $eligible_ids );
+				$created       = is_array( $append_result['created'] ?? null ) ? $append_result['created'] : [];
+				$failed_append = is_array( $append_result['failed_page_ids'] ?? null ) ? $append_result['failed_page_ids'] : [];
+				$appended      = array_merge( $appended, $created );
+				$append_failed = array_merge( $append_failed, $failed_append );
+			}
+		}
+
+		$failed_pages  = array_values( array_unique( array_map( 'absint', $failed_pages ) ) );
+		$append_failed = array_values( array_unique( array_map( 'absint', $append_failed ) ) );
+		// verified tracks Ads/ineligible removal only (fail-closed). SEO append is best-effort.
+		$verified = [] === $failed_pages;
+
+		if ( [] !== $append_failed ) {
+			$this->logger->log(
+				'warning',
+				'Landing menu reconciliation SEO append incomplete (best-effort; Ads removal still authoritative).',
+				[
+					'menu_ids'               => array_values( array_map( 'absint', $menu_ids ) ),
+					'append_failed_page_ids' => $append_failed,
+					'removal_failed_page_ids'=> $failed_pages,
+				]
+			);
+		}
+
+		return [
+			'appended'                 => $appended,
+			'removed'                  => $removed,
+			'removal_failed_page_ids'  => $failed_pages,
+			'append_failed_page_ids'   => $append_failed,
+			'verified'                 => $verified,
+		];
+	}
+
+	/**
+	 * Page object IDs currently linked in a menu.
+	 *
+	 * @return array<int,int>
+	 */
+	private function menu_page_ids( int $menu_id ): array {
+		$items = \wp_get_nav_menu_items( $menu_id );
+
+		if ( empty( $items ) || ! is_array( $items ) ) {
+			return [];
+		}
+
+		$page_ids = [];
+
+		foreach ( $items as $item ) {
+			if ( 'post_type' !== (string) ( $item->type ?? '' ) || 'page' !== (string) ( $item->object ?? '' ) ) {
+				continue;
+			}
+
+			$page_id = (int) ( $item->object_id ?? 0 );
+
+			if ( $page_id > 0 ) {
+				$page_ids[] = $page_id;
+			}
+		}
+
+		return array_values( array_unique( $page_ids ) );
+	}
+
 	private function delete_menu_items( int $menu_id ): void {
 		$items = \wp_get_nav_menu_items( $menu_id );
 

--- a/inc/wizard/class-step-controller.php
+++ b/inc/wizard/class-step-controller.php
@@ -30,11 +30,8 @@ class Step_Controller {
 	 * Single source of truth for currently required wizard steps.
 	 * Consumed by complete() and step services (e.g. maybe_mark_completed).
 	 *
-	 * PR2 keeps the existing 7-step completion surface. `landing-page-builder`
-	 * backend class exists, but required/dispatch/UI activation is deferred to
-	 * Phase 3 (menu/SEO/noindex + admin UI) so Ads landings cannot go live
-	 * without final-state controls and the UI cannot show 7/7 while an 8th
-	 * invisible step is required.
+	 * Phase 3 activates `landing-page-builder` atomically with admin UI +
+	 * Ads noindex/menu final-state sync (tasks 3.1–3.7).
 	 *
 	 * @var string[]
 	 */
@@ -46,15 +43,12 @@ class Step_Controller {
 		'menu-setup',
 		'ia-generation',
 		'home-page-builder',
+		'landing-page-builder',
 	];
 
 	/**
 	 * Steps that may be dispatched by execute_step() right now.
 	 * Must stay in sync with dispatch_step() cases.
-	 *
-	 * PR2: `landing-page-builder` is intentionally NOT dispatchable until
-	 * Phase 3 wires UI + noindex/menu final-state sync. The dispatch case and
-	 * `Step_Landing_Page_Builder` class remain for that activation.
 	 *
 	 * @var string[]
 	 */
@@ -66,6 +60,7 @@ class Step_Controller {
 		'menu-setup',
 		'ia-generation',
 		'home-page-builder',
+		'landing-page-builder',
 		'unlock',
 		'relock',
 	];
@@ -260,8 +255,6 @@ class Step_Controller {
 			case 'home-page-builder':
 				return ( new Step_Home_Page_Builder( $this->logger, $this->state_manager ) )->run( $payload );
 
-			// Kept for Phase 3 activation. Not reachable until REQUIRED_STEPS +
-			// DISPATCHABLE_STEPS + UI re-include `landing-page-builder` together.
 			case 'landing-page-builder':
 				return ( new Step_Landing_Page_Builder( $this->logger, $this->state_manager ) )->run( $payload );
 
@@ -367,10 +360,6 @@ class Step_Controller {
 			'generate_pages'    => 'generate-pages',
 			'menu_setup'        => 'menu-setup',
 			'home_page_builder' => 'home-page-builder',
-			// Phase 3 activation: re-enable `landing_page_builder` alias together
-			// with DISPATCHABLE_STEPS, REQUIRED_STEPS, dispatch case, and admin UI.
-			// Alias alone is safe (unknown-step reject runs before status writes)
-			// but must not be treated as "live" until that full activation set lands.
 			'landing_page_builder' => 'landing-page-builder',
 		];
 

--- a/inc/wizard/class-step-controller.php
+++ b/inc/wizard/class-step-controller.php
@@ -30,9 +30,11 @@ class Step_Controller {
 	 * Single source of truth for currently required wizard steps.
 	 * Consumed by complete() and step services (e.g. maybe_mark_completed).
 	 *
-	 * Phase 1 keeps the existing 7-step completion path valid. Append
-	 * `landing-page-builder` only when that step is registered/dispatched
-	 * (Phase 2+), never while the runtime/UI is absent.
+	 * PR2 keeps the existing 7-step completion surface. `landing-page-builder`
+	 * backend class exists, but required/dispatch/UI activation is deferred to
+	 * Phase 3 (menu/SEO/noindex + admin UI) so Ads landings cannot go live
+	 * without final-state controls and the UI cannot show 7/7 while an 8th
+	 * invisible step is required.
 	 *
 	 * @var string[]
 	 */
@@ -50,9 +52,9 @@ class Step_Controller {
 	 * Steps that may be dispatched by execute_step() right now.
 	 * Must stay in sync with dispatch_step() cases.
 	 *
-	 * Phase 1 intentionally omits `landing-page-builder` until Phase 2
-	 * registers its runtime. Unknown/unimplemented steps must be rejected
-	 * before any current_step / step_status writes.
+	 * PR2: `landing-page-builder` is intentionally NOT dispatchable until
+	 * Phase 3 wires UI + noindex/menu final-state sync. The dispatch case and
+	 * `Step_Landing_Page_Builder` class remain for that activation.
 	 *
 	 * @var string[]
 	 */
@@ -258,6 +260,11 @@ class Step_Controller {
 			case 'home-page-builder':
 				return ( new Step_Home_Page_Builder( $this->logger, $this->state_manager ) )->run( $payload );
 
+			// Kept for Phase 3 activation. Not reachable until REQUIRED_STEPS +
+			// DISPATCHABLE_STEPS + UI re-include `landing-page-builder` together.
+			case 'landing-page-builder':
+				return ( new Step_Landing_Page_Builder( $this->logger, $this->state_manager ) )->run( $payload );
+
 			case 'unlock':
 				return ( new Wizard_Unlock_Controller( $this->state_manager, $this->logger ) )->unlock();
 
@@ -351,9 +358,6 @@ class Step_Controller {
 	private function normalize_step( string $step ): string {
 		$step = \sanitize_key( $step );
 
-		// Do not alias landing_page_builder → landing-page-builder until Phase 2
-		// registers dispatch + runtime. Premature normalization would make an
-		// unimplemented step look "real" before the dispatchability guard runs.
 		$aliases = [
 			'acf_import'        => 'acf-import',
 			'client_data'       => 'client-data',
@@ -363,6 +367,11 @@ class Step_Controller {
 			'generate_pages'    => 'generate-pages',
 			'menu_setup'        => 'menu-setup',
 			'home_page_builder' => 'home-page-builder',
+			// Phase 3 activation: re-enable `landing_page_builder` alias together
+			// with DISPATCHABLE_STEPS, REQUIRED_STEPS, dispatch case, and admin UI.
+			// Alias alone is safe (unknown-step reject runs before status writes)
+			// but must not be treated as "live" until that full activation set lands.
+			'landing_page_builder' => 'landing-page-builder',
 		];
 
 		return $aliases[ $step ] ?? $step;

--- a/inc/wizard/class-step-generate-pages.php
+++ b/inc/wizard/class-step-generate-pages.php
@@ -49,6 +49,15 @@ class Step_Generate_Pages {
 			return $roles;
 		}
 
+		// Fail closed: never select/update/assign residual SEO/Ads landings via generate-pages.
+		$landing_conflict = $this->reject_selected_landing_slugs( array_keys( $pages ) );
+
+		if ( \is_wp_error( $landing_conflict ) ) {
+			$this->state_manager->set_step_status( self::STEP, 'failed' );
+
+			return $landing_conflict;
+		}
+
 		if ( ! $this->confirmed_cleanup( $payload ) ) {
 			$this->state_manager->set_step_status( self::STEP, 'pending' );
 
@@ -65,7 +74,15 @@ class Step_Generate_Pages {
 
 		foreach ( $pages as $slug => $page ) {
 			$existing = \get_page_by_path( $slug, \OBJECT, 'page' );
-			$post_id  = $this->content_builder->build_page(
+
+			// Defense-in-depth: residual landings must never be updated/published here.
+			if ( $existing && $this->is_landing_page( (int) $existing->ID ) ) {
+				$this->state_manager->set_step_status( self::STEP, 'failed' );
+
+				return $this->landing_slug_conflict_error( $slug, (int) $existing->ID );
+			}
+
+			$post_id = $this->content_builder->build_page(
 				[
 					'id'      => $existing ? (int) $existing->ID : 0,
 					'title'   => $page['title'],
@@ -79,6 +96,12 @@ class Step_Generate_Pages {
 				$this->state_manager->set_step_status( self::STEP, 'failed' );
 
 				return new \WP_Error( 'rms_wizard_page_create_failed', \__( 'One or more selected pages could not be created.', 'simple-rms-theme' ), [ 'status' => 500 ] );
+			}
+
+			if ( $this->is_landing_page( $post_id ) ) {
+				$this->state_manager->set_step_status( self::STEP, 'failed' );
+
+				return $this->landing_slug_conflict_error( $slug, $post_id );
 			}
 
 			$role = '';
@@ -97,7 +120,13 @@ class Step_Generate_Pages {
 			];
 		}
 
-		$this->assign_reading_pages( $generated_pages, $roles['home_slug'], $roles['blog_slug'] );
+		$reading = $this->assign_reading_pages( $generated_pages, $roles['home_slug'], $roles['blog_slug'] );
+
+		if ( \is_wp_error( $reading ) ) {
+			$this->state_manager->set_step_status( self::STEP, 'failed' );
+
+			return $reading;
+		}
 
 		$state['created_posts']   = $created_posts;
 		$state['generated_pages'] = $generated_pages;
@@ -198,7 +227,8 @@ class Step_Generate_Pages {
 	}
 
 	private function delete_unselected_pages( array $selected_slugs ): void {
-		$page_ids = \get_posts(
+		$protected_slugs = $this->protected_landing_slugs();
+		$page_ids        = \get_posts(
 			[
 				'post_type'      => 'page',
 				'post_status'    => 'any',
@@ -214,8 +244,109 @@ class Step_Generate_Pages {
 				continue;
 			}
 
+			// Primary guard: never hard-delete wizard landing pages on generate-pages cleanup.
+			if ( $this->is_landing_page( (int) $page_id ) ) {
+				continue;
+			}
+
+			// Defense-in-depth: protect slugs still tracked in state.landing_pages.
+			if ( in_array( $post->post_name, $protected_slugs, true ) ) {
+				continue;
+			}
+
 			\wp_delete_post( (int) $page_id, true );
 		}
+	}
+
+	/**
+	 * Reject payload slugs that already resolve to residual SEO/Ads landing pages.
+	 *
+	 * @param string[] $slugs
+	 *
+	 * @return true|\WP_Error
+	 */
+	private function reject_selected_landing_slugs( array $slugs ) {
+		foreach ( $slugs as $slug ) {
+			$slug = \sanitize_title( (string) $slug );
+
+			if ( '' === $slug ) {
+				continue;
+			}
+
+			$existing = \get_page_by_path( $slug, \OBJECT, 'page' );
+
+			if ( $existing && $this->is_landing_page( (int) $existing->ID ) ) {
+				return $this->landing_slug_conflict_error( $slug, (int) $existing->ID );
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Whether a page is a wizard SEO/Ads landing (post meta rms_landing_type).
+	 */
+	private function is_landing_page( int $post_id ): bool {
+		if ( $post_id <= 0 ) {
+			return false;
+		}
+
+		$landing_type = \sanitize_key( (string) \get_post_meta( $post_id, 'rms_landing_type', true ) );
+
+		return in_array( $landing_type, [ 'seo', 'ads' ], true );
+	}
+
+	/**
+	 * Operator-facing error when generate-pages collides with a landing page.
+	 */
+	private function landing_slug_conflict_error( string $slug, int $post_id ): \WP_Error {
+		$this->logger->log(
+			'error',
+			'Generate-pages rejected slug that belongs to an existing landing page.',
+			[
+				'slug'    => $slug,
+				'post_id' => $post_id,
+			]
+		);
+
+		return new \WP_Error(
+			'rms_wizard_page_slug_is_landing',
+			sprintf(
+				/* translators: %s: page slug. */
+				\__( 'Slug "%s" belongs to an existing landing page and cannot be selected, updated, or assigned as Home/Blog by generate-pages.', 'simple-rms-theme' ),
+				$slug
+			),
+			[
+				'status'  => 400,
+				'slug'    => $slug,
+				'post_id' => $post_id,
+			]
+		);
+	}
+
+	/**
+	 * Slugs from state.landing_pages that must survive generate-pages cleanup.
+	 *
+	 * @return string[]
+	 */
+	private function protected_landing_slugs(): array {
+		$state    = $this->state_manager->get_state();
+		$landings = is_array( $state['landing_pages'] ?? null ) ? $state['landing_pages'] : [];
+		$slugs    = [];
+
+		foreach ( $landings as $landing ) {
+			if ( ! is_array( $landing ) ) {
+				continue;
+			}
+
+			$slug = \sanitize_title( (string) ( $landing['slug'] ?? '' ) );
+
+			if ( '' !== $slug ) {
+				$slugs[] = $slug;
+			}
+		}
+
+		return array_values( array_unique( $slugs ) );
 	}
 
 	private function generate_page_content( string $title, string $slug, array $client_data, array $ai_config ): string {
@@ -244,7 +375,14 @@ class Step_Generate_Pages {
 		return '<p>' . \esc_html( $company ) . ' provides reliable, professional service with clear communication from start to finish.</p><p>This ' . \esc_html( $title ) . ' page was generated by the setup wizard and can be refined after launch.</p>';
 	}
 
-	private function assign_reading_pages( array $generated_pages, string $home_slug, string $blog_slug ): void {
+	/**
+	 * Assign Reading settings. Never promote a landing page to Home/Blog.
+	 *
+	 * @param array<int,array<string,mixed>> $generated_pages
+	 *
+	 * @return true|\WP_Error
+	 */
+	private function assign_reading_pages( array $generated_pages, string $home_slug, string $blog_slug ) {
 		$ids_by_slug = [];
 
 		foreach ( $generated_pages as $page ) {
@@ -252,11 +390,29 @@ class Step_Generate_Pages {
 		}
 
 		if ( ! empty( $ids_by_slug[ $home_slug ] ) ) {
+			$home_id = (int) $ids_by_slug[ $home_slug ];
+
+			if ( $this->is_landing_page( $home_id ) ) {
+				return $this->landing_slug_conflict_error( $home_slug, $home_id );
+			}
+
 			\update_option( 'show_on_front', 'page', false );
-			\update_option( 'page_on_front', $ids_by_slug[ $home_slug ], false );
+			\update_option( 'page_on_front', $home_id, false );
 		}
 
-		\update_option( 'page_for_posts', '' !== $blog_slug && ! empty( $ids_by_slug[ $blog_slug ] ) ? $ids_by_slug[ $blog_slug ] : 0, false );
+		if ( '' !== $blog_slug && ! empty( $ids_by_slug[ $blog_slug ] ) ) {
+			$blog_id = (int) $ids_by_slug[ $blog_slug ];
+
+			if ( $this->is_landing_page( $blog_id ) ) {
+				return $this->landing_slug_conflict_error( $blog_slug, $blog_id );
+			}
+
+			\update_option( 'page_for_posts', $blog_id, false );
+		} else {
+			\update_option( 'page_for_posts', 0, false );
+		}
+
+		return true;
 	}
 
 	private function available_pages(): array {

--- a/inc/wizard/class-step-home-page-builder.php
+++ b/inc/wizard/class-step-home-page-builder.php
@@ -21,14 +21,16 @@ class Step_Home_Page_Builder {
 	private $layout_repository;
 	private $harness;
 	private $reviewer;
+	private $canonical_store;
 
-	public function __construct( ?Logger $logger = null, ?State_Manager $state_manager = null, ?Content_Builder $content_builder = null, ?Flexible_Content_Layouts $layout_repository = null, ?AI_Content_Harness $harness = null, ?AI_Content_Reviewer $reviewer = null ) {
+	public function __construct( ?Logger $logger = null, ?State_Manager $state_manager = null, ?Content_Builder $content_builder = null, ?Flexible_Content_Layouts $layout_repository = null, ?AI_Content_Harness $harness = null, ?AI_Content_Reviewer $reviewer = null, ?Canonical_Section_Store $canonical_store = null ) {
 		$this->logger            = $logger ?? new Logger();
 		$this->state_manager     = $state_manager ?? new State_Manager();
 		$this->content_builder   = $content_builder ?? new Content_Builder( $this->logger, $this->state_manager );
 		$this->layout_repository = $layout_repository ?? new Flexible_Content_Layouts();
 		$this->harness           = $harness ?? new AI_Content_Harness();
 		$this->reviewer          = $reviewer;
+		$this->canonical_store   = $canonical_store ?? new Canonical_Section_Store();
 	}
 
 	/**
@@ -115,6 +117,7 @@ class Step_Home_Page_Builder {
 		$state['selected_home_sections'] = $sections;
 		$state['home_section_rows']      = $section_rows;
 		$state['home_sections']          = $prepared_sections;
+		$state['canonical_sections']     = $this->first_write_canonical_sections( $prepared_sections );
 
 		$this->state_manager->save_state( $state );
 		$this->state_manager->set_step_status( self::STEP, 'complete' );
@@ -122,6 +125,33 @@ class Step_Home_Page_Builder {
 		$this->logger->log( 'info', 'Wizard Home page sections built.', [ 'post_id' => $post_id, 'sections' => $sections ] );
 
 		return [ 'post_id' => $post_id, 'sections' => $sections ];
+	}
+
+	/**
+	 * First-write reusable prepared rows into the canonical store.
+	 *
+	 * Skips keyword layouts (hero / seo-content). Never overwrites existing entries.
+	 *
+	 * @param array<int,array<string,mixed>> $prepared_sections Prepared ACF rows.
+	 *
+	 * @return array<string,array{has_payload:bool,generated_at:string}>
+	 */
+	private function first_write_canonical_sections( array $prepared_sections ): array {
+		foreach ( $prepared_sections as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+
+			$layout = \sanitize_key( (string) ( $row['acf_fc_layout'] ?? '' ) );
+
+			if ( '' === $layout || ! $this->harness->is_reusable_layout( $layout ) ) {
+				continue;
+			}
+
+			$this->canonical_store->set_if_empty( $layout, $row );
+		}
+
+		return $this->canonical_store->summary();
 	}
 
 	private function selected_section_rows( array $payload ): array {

--- a/inc/wizard/class-step-landing-page-builder.php
+++ b/inc/wizard/class-step-landing-page-builder.php
@@ -1,0 +1,2089 @@
+<?php
+/**
+ * Wizard Landing page builder step service.
+ *
+ * @package Simple_RMS_Theme
+ */
+
+namespace Inc\Wizard;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Builds N SEO/Ads landing pages from canonical reusable sections + keyword copy.
+ *
+ * Phase 2 backend scope: identity preflight, lazy canonical bootstrap, page upsert
+ * with template/type meta, and state persistence. Menu/Yoast/noindex final-state
+ * sync remains Phase 3.
+ *
+ * PR2 safety: class is implemented but NOT active in REQUIRED_STEPS / DISPATCHABLE_STEPS
+ * until Phase 3 wires UI + Ads noindex/menu final-state sync.
+ */
+class Step_Landing_Page_Builder {
+	private const STEP     = 'landing-page-builder';
+	private const TEMPLATE = 'pages/landing-page.php';
+
+	/**
+	 * Default section order aligned with pages/landing-page.php.
+	 *
+	 * @var array<int,array{layout:string}>
+	 */
+	private const DEFAULT_SECTIONS = [
+		[ 'layout' => 'hero' ],
+		[ 'layout' => 'seo-content' ],
+		[ 'layout' => 'vision-mission-v1' ],
+		[ 'layout' => 'badges' ],
+		[ 'layout' => 'portfolio-v1' ],
+		[ 'layout' => 'seo-content' ],
+		[ 'layout' => 'testimonials-v1' ],
+		[ 'layout' => 'seo-content' ],
+	];
+
+	private $logger;
+	private $state_manager;
+	private $content_builder;
+	private $layout_repository;
+	private $harness;
+	private $reviewer;
+	private $canonical_store;
+
+	public function __construct(
+		?Logger $logger = null,
+		?State_Manager $state_manager = null,
+		?Content_Builder $content_builder = null,
+		?Flexible_Content_Layouts $layout_repository = null,
+		?AI_Content_Harness $harness = null,
+		?AI_Content_Reviewer $reviewer = null,
+		?Canonical_Section_Store $canonical_store = null
+	) {
+		$this->logger            = $logger ?? new Logger();
+		$this->state_manager     = $state_manager ?? new State_Manager();
+		$this->content_builder   = $content_builder ?? new Content_Builder( $this->logger, $this->state_manager );
+		$this->layout_repository = $layout_repository ?? new Flexible_Content_Layouts();
+		$this->harness           = $harness ?? new AI_Content_Harness();
+		$this->reviewer          = $reviewer;
+		$this->canonical_store   = $canonical_store ?? new Canonical_Section_Store();
+	}
+
+	/**
+	 * Run the Landing page builder.
+	 *
+	 * @param array<string,mixed> $payload Step payload.
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function run( array $payload ) {
+		if ( $this->truthy( $payload['skip_all'] ?? false ) ) {
+			if ( ! $this->mark_step_status( 'complete' ) ) {
+				return new \WP_Error(
+					'rms_wizard_landing_status_persist_failed',
+					\__( 'Landing step completed but status could not be persisted.', 'simple-rms-theme' ),
+					[ 'status' => 500 ]
+				);
+			}
+			$this->maybe_mark_completed();
+			$state = $this->state_manager->get_state();
+
+			return [
+				'skipped'       => true,
+				'landing_pages' => is_array( $state['landing_pages'] ?? null ) ? $state['landing_pages'] : [],
+			];
+		}
+
+		$state     = $this->state_manager->get_state();
+		$ai_config = is_array( $state['ai_config'] ?? null ) ? $state['ai_config'] : [];
+
+		if ( ! $this->has_ai_config( $ai_config ) ) {
+			$this->mark_step_status( 'failed' );
+
+			return new \WP_Error( 'rms_wizard_ai_config_required', \__( 'AI configuration required. Complete the IA Generation step first.', 'simple-rms-theme' ), [ 'status' => 400 ] );
+		}
+
+		$client_data = is_array( $state['client_data'] ?? null ) ? $state['client_data'] : [];
+		$missing     = $this->harness->validate_required_context( $client_data );
+
+		if ( [] !== $missing ) {
+			$this->mark_step_status( 'failed' );
+
+			return new \WP_Error(
+				'rms_wizard_landing_required_client_data_missing',
+				sprintf(
+					/* translators: %s: comma-separated missing client data keys. */
+					\__( 'Missing required client data: %s. Complete your client profile before generating.', 'simple-rms-theme' ),
+					implode( ', ', $missing )
+				),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$existing_landings = $this->normalize_state_landings( is_array( $state['landing_pages'] ?? null ) ? $state['landing_pages'] : [] );
+		$parsed            = $this->parse_landings_payload( $payload, $existing_landings );
+
+		if ( \is_wp_error( $parsed ) ) {
+			$this->mark_step_status( 'failed' );
+
+			return $parsed;
+		}
+
+		/** @var array{rows:array<int,array<string,mixed>>,replace_map:array<string,bool>} $parsed */
+		$rows        = $parsed['rows'];
+		$replace_map = $parsed['replace_map'];
+
+		if ( [] === $rows ) {
+			$this->mark_step_status( 'failed' );
+
+			return new \WP_Error(
+				'rms_wizard_landings_required',
+				\__( 'Add at least one landing page or use skip-all to complete without landings.', 'simple-rms-theme' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$required_layouts = $this->collect_required_reusable_layouts( $rows );
+		$bootstrap        = $this->ensure_canonical_reusables( $required_layouts, $state, $client_data, $ai_config );
+
+		if ( \is_wp_error( $bootstrap ) ) {
+			$this->mark_step_status( 'failed' );
+
+			return $bootstrap;
+		}
+
+		$client_context = $this->harness->get_harness_context( $client_data );
+		$landing_pages  = $existing_landings;
+		$built          = [];
+		$prior_payloads = [];
+		$built_ids      = [];
+
+		foreach ( $rows as $row ) {
+			try {
+				$result = $this->build_one_landing( $row, $replace_map, $client_data, $client_context, $ai_config, $landing_pages, $prior_payloads );
+			} catch ( \Throwable $exception ) {
+				// Convert thrown failures so partial persistence still runs before returning.
+				$landing_key = (string) ( $row['landing_key'] ?? '' );
+				$slug        = (string) ( $row['slug'] ?? '' );
+
+				$this->logger->log(
+					'error',
+					'Wizard landing build threw an exception.',
+					[
+						'landing_key'     => $landing_key,
+						'slug'            => $slug,
+						'exception_class' => get_class( $exception ),
+						'message'         => $exception->getMessage(),
+					]
+				);
+
+				$result = new \WP_Error(
+					'rms_wizard_landing_build_exception',
+					sprintf(
+						/* translators: 1: landing slug or key, 2: exception message. */
+						\__( 'Landing "%1$s" failed unexpectedly: %2$s', 'simple-rms-theme' ),
+						'' !== $slug ? $slug : $landing_key,
+						$exception->getMessage()
+					),
+					[
+						'status'          => 500,
+						'landing_key'     => $landing_key,
+						'slug'            => $slug,
+						'exception_class' => get_class( $exception ),
+					]
+				);
+			}
+
+			if ( \is_wp_error( $result ) ) {
+				// Persist successful landings before failing so partial progress is not lost.
+				$this->persist_partial_landing_progress( $state, $landing_pages, $built_ids, $result );
+
+				return $result;
+			}
+
+			$landing_pages[ $result['landing_key'] ] = $result['entry'];
+			$built[]                                 = $result['entry'];
+			$built_ids[]                             = (int) ( $result['entry']['id'] ?? 0 );
+			$prior_payloads                          = array_merge( $prior_payloads, $result['prior_payloads'] );
+		}
+
+		$state['landing_pages']      = array_values( $landing_pages );
+		$state['canonical_sections'] = $this->canonical_store->summary();
+
+		if ( ! $this->persist_wizard_state( $state, 'full success' ) ) {
+			$this->mark_step_status( 'failed' );
+
+			return new \WP_Error(
+				'rms_wizard_landing_state_persist_failed',
+				\__( 'Landing pages were built but wizard state could not be persisted.', 'simple-rms-theme' ),
+				[
+					'status'    => 500,
+					'post_ids'  => array_values( array_filter( $built_ids ) ),
+					'built'     => count( $built ),
+				]
+			);
+		}
+
+		if ( ! $this->mark_step_status( 'complete' ) ) {
+			return new \WP_Error(
+				'rms_wizard_landing_status_persist_failed',
+				\__( 'Landing pages were saved but step status could not be marked complete.', 'simple-rms-theme' ),
+				[ 'status' => 500, 'post_ids' => array_values( array_filter( $built_ids ) ) ]
+			);
+		}
+
+		$this->maybe_mark_completed();
+		$this->logger->log(
+			'info',
+			'Wizard landing pages built.',
+			[
+				'count'    => count( $built ),
+				'post_ids' => array_values( array_filter( $built_ids ) ),
+			]
+		);
+
+		return [
+			'landing_pages'      => array_values( $landing_pages ),
+			'built'              => $built,
+			'canonical_sections' => $state['canonical_sections'],
+		];
+	}
+
+	/**
+	 * @param array<string,mixed>              $payload
+	 * @param array<string,array<string,mixed>> $existing_landings Keyed by landing_key.
+	 *
+	 * @return array{rows:array<int,array<string,mixed>>,replace_map:array<string,bool>}|\WP_Error
+	 */
+	private function parse_landings_payload( array $payload, array $existing_landings ) {
+		$raw_landings = is_array( $payload['landings'] ?? null ) ? $payload['landings'] : [];
+		$replace_raw  = is_array( $payload['replace_canonical'] ?? null ) ? $payload['replace_canonical'] : [];
+		$confirm      = $this->truthy( $payload['confirm_replace_canonical'] ?? false );
+		$replace_map  = [];
+
+		foreach ( $replace_raw as $layout => $flag ) {
+			$layout = $this->normalize_layout( (string) $layout );
+
+			if ( '' !== $layout && $this->truthy( $flag ) ) {
+				if ( ! $confirm ) {
+					return new \WP_Error(
+						'rms_wizard_replace_canonical_unconfirmed',
+						\__( 'Confirm replace canonical before overwriting shared reusable sections.', 'simple-rms-theme' ),
+						[ 'status' => 400 ]
+					);
+				}
+
+				$replace_map[ $layout ] = true;
+			}
+		}
+
+		$rows          = [];
+		$seen_ids      = [];
+		$seen_keys     = [];
+		$seen_slugs    = [];
+		$claimed_ids   = [];
+		$claimed_keys  = [];
+		$claimed_slugs = [];
+
+		foreach ( $existing_landings as $entry ) {
+			$id  = (int) ( $entry['id'] ?? 0 );
+			$key = (string) ( $entry['landing_key'] ?? '' );
+			$slug = \sanitize_title( (string) ( $entry['slug'] ?? '' ) );
+
+			if ( $id > 0 ) {
+				$claimed_ids[ $id ] = $key;
+			}
+
+			if ( '' !== $key ) {
+				$claimed_keys[ $key ] = $entry;
+			}
+
+			if ( '' !== $slug ) {
+				$claimed_slugs[ $slug ] = $key;
+			}
+		}
+
+		foreach ( $raw_landings as $raw ) {
+			if ( ! is_array( $raw ) || $this->truthy( $raw['skipped'] ?? false ) ) {
+				continue;
+			}
+
+			$title = \sanitize_text_field( (string) ( $raw['title'] ?? '' ) );
+			$slug  = \sanitize_title( (string) ( $raw['slug'] ?? $title ) );
+			$type  = \sanitize_key( (string) ( $raw['landing_type'] ?? 'seo' ) );
+			$type  = in_array( $type, [ 'seo', 'ads' ], true ) ? $type : 'seo';
+
+			$keywords = $this->harness->normalize_keywords(
+				[
+					'primary_keyword' => $raw['primary_keyword'] ?? '',
+					'subkeywords'     => $raw['subkeywords'] ?? [],
+				]
+			);
+
+			if ( '' === $keywords['primary_keyword'] ) {
+				return new \WP_Error(
+					'rms_wizard_landing_keyword_required',
+					\__( 'Each landing requires a non-empty primary keyword.', 'simple-rms-theme' ),
+					[ 'status' => 400 ]
+				);
+			}
+
+			if ( '' === $title || '' === $slug ) {
+				return new \WP_Error(
+					'rms_wizard_landing_identity_required',
+					\__( 'Each landing requires a title and slug.', 'simple-rms-theme' ),
+					[ 'status' => 400 ]
+				);
+			}
+
+			$id  = isset( $raw['id'] ) && '' !== (string) $raw['id'] && null !== $raw['id'] ? \absint( $raw['id'] ) : 0;
+			$key = \sanitize_key( (string) ( $raw['landing_key'] ?? '' ) );
+
+			if ( $id > 0 ) {
+				if ( isset( $seen_ids[ $id ] ) ) {
+					return new \WP_Error( 'rms_wizard_landing_duplicate_id', \__( 'Duplicate landing id values are not allowed in one run.', 'simple-rms-theme' ), [ 'status' => 400 ] );
+				}
+
+				$seen_ids[ $id ] = true;
+			}
+
+			if ( '' !== $key ) {
+				if ( isset( $seen_keys[ $key ] ) ) {
+					return new \WP_Error( 'rms_wizard_landing_duplicate_key', \__( 'Duplicate landing_key values are not allowed in one run.', 'simple-rms-theme' ), [ 'status' => 400 ] );
+				}
+
+				$seen_keys[ $key ] = true;
+			}
+
+			if ( isset( $seen_slugs[ $slug ] ) ) {
+				return new \WP_Error( 'rms_wizard_landing_duplicate_slug', \__( 'Duplicate landing slugs are not allowed in one run.', 'simple-rms-theme' ), [ 'status' => 400 ] );
+			}
+
+			$seen_slugs[ $slug ] = true;
+
+			$match = $this->match_existing_landing( $id, $key, $slug, $existing_landings, $claimed_ids, $claimed_keys, $claimed_slugs );
+
+			if ( \is_wp_error( $match ) ) {
+				return $match;
+			}
+
+			$matched_key = (string) ( $match['landing_key'] ?? '' );
+			$matched_id  = (int) ( $match['id'] ?? 0 );
+
+			// Rename collision: slug belongs to a different landing in state.
+			if ( isset( $claimed_slugs[ $slug ] ) && $claimed_slugs[ $slug ] !== $matched_key && '' !== $matched_key ) {
+				return new \WP_Error(
+					'rms_wizard_landing_slug_collision',
+					sprintf(
+						/* translators: %s: page slug. */
+						\__( 'Landing slug "%s" collides with another landing page.', 'simple-rms-theme' ),
+						$slug
+					),
+					[ 'status' => 400 ]
+				);
+			}
+
+			// Page collision when creating or claiming by slug (non-landing or other landing).
+			$slug_page = \get_page_by_path( $slug, \OBJECT, 'page' );
+
+			if ( $slug_page ) {
+				$slug_page_id    = (int) $slug_page->ID;
+				$slug_is_landing = $this->page_has_landing_type( $slug_page_id );
+
+				if ( $matched_id > 0 && $slug_page_id !== $matched_id ) {
+					return new \WP_Error(
+						'rms_wizard_landing_slug_collision',
+						sprintf(
+							/* translators: %s: page slug. */
+							\__( 'Landing slug "%s" collides with an existing page.', 'simple-rms-theme' ),
+							$slug
+						),
+						[ 'status' => 400 ]
+					);
+				}
+
+				if ( $matched_id <= 0 && ! $slug_is_landing ) {
+					return new \WP_Error(
+						'rms_wizard_landing_slug_collision',
+						sprintf(
+							/* translators: %s: page slug. */
+							\__( 'Landing slug "%s" collides with an existing non-landing page.', 'simple-rms-theme' ),
+							$slug
+						),
+						[ 'status' => 400 ]
+					);
+				}
+
+				// Slug fallback may only resolve when the existing page is a landing.
+				if ( $matched_id <= 0 && $slug_is_landing ) {
+					$matched_id = $slug_page_id;
+				}
+			}
+
+			if ( '' === $matched_key ) {
+				$matched_key = '' !== $key ? $key : $this->mint_landing_key();
+			}
+
+			$sections = $this->normalize_section_rows( is_array( $raw['sections'] ?? null ) ? $raw['sections'] : [] );
+
+			$rows[] = [
+				'id'              => $matched_id,
+				'landing_key'     => $matched_key,
+				'title'           => $title,
+				'slug'            => $slug,
+				'landing_type'    => $type,
+				'menu_eligible'   => 'seo' === $type,
+				'primary_keyword' => $keywords['primary_keyword'],
+				'subkeywords'     => $keywords['subkeywords'],
+				'sections'        => $sections,
+			];
+		}
+
+		return [
+			'rows'        => $rows,
+			'replace_map' => $replace_map,
+		];
+	}
+
+	/**
+	 * Deterministic identity match order: id → landing_key → slug.
+	 * When both id and landing_key are non-empty they MUST refer to the same state row.
+	 *
+	 * @param array<string,array<string,mixed>> $existing_landings
+	 * @param array<int,string>                 $claimed_ids
+	 * @param array<string,array<string,mixed>> $claimed_keys
+	 * @param array<string,string>              $claimed_slugs
+	 *
+	 * @return array{id:int,landing_key:string}|\WP_Error
+	 */
+	private function match_existing_landing( int $id, string $key, string $slug, array $existing_landings, array $claimed_ids, array $claimed_keys, array $claimed_slugs ) {
+		unset( $existing_landings ); // Claim maps are the authoritative index.
+
+		// Stale cross-pair: payload pairs id+key that point at different rows.
+		if ( $id > 0 && '' !== $key ) {
+			$id_key     = $claimed_ids[ $id ] ?? null;
+			$key_entry  = $claimed_keys[ $key ] ?? null;
+			$key_id     = is_array( $key_entry ) ? (int) ( $key_entry['id'] ?? 0 ) : 0;
+
+			if ( null !== $id_key && $id_key !== $key ) {
+				return new \WP_Error(
+					'rms_wizard_landing_identity_mismatch',
+					\__( 'Landing id and landing_key refer to different existing landings.', 'simple-rms-theme' ),
+					[ 'status' => 400, 'id' => $id, 'landing_key' => $key, 'id_landing_key' => $id_key ]
+				);
+			}
+
+			if ( $key_id > 0 && $key_id !== $id ) {
+				return new \WP_Error(
+					'rms_wizard_landing_identity_mismatch',
+					\__( 'Landing id and landing_key refer to different existing landings.', 'simple-rms-theme' ),
+					[ 'status' => 400, 'id' => $id, 'landing_key' => $key, 'key_id' => $key_id ]
+				);
+			}
+		}
+
+		// 1) Match by id (strongest).
+		if ( $id > 0 ) {
+			if ( isset( $claimed_ids[ $id ] ) ) {
+				$matched_key = $claimed_ids[ $id ];
+
+				if ( '' !== $key && $key !== $matched_key ) {
+					return new \WP_Error(
+						'rms_wizard_landing_identity_mismatch',
+						\__( 'Landing id and landing_key refer to different existing landings.', 'simple-rms-theme' ),
+						[ 'status' => 400, 'id' => $id, 'landing_key' => $key, 'id_landing_key' => $matched_key ]
+					);
+				}
+
+				return [
+					'id'          => $id,
+					'landing_key' => $matched_key,
+				];
+			}
+
+			// ID supplied but not a known landing in state — only accept if page has landing meta.
+			if ( ! $this->page_has_landing_type( $id ) ) {
+				return new \WP_Error(
+					'rms_wizard_landing_unknown_id',
+					\__( 'Landing id does not match an existing landing page.', 'simple-rms-theme' ),
+					[ 'status' => 400 ]
+				);
+			}
+
+			// Key must not already belong to a different post id.
+			if ( '' !== $key && isset( $claimed_keys[ $key ] ) ) {
+				$other_id = (int) ( $claimed_keys[ $key ]['id'] ?? 0 );
+
+				if ( $other_id > 0 && $other_id !== $id ) {
+					return new \WP_Error(
+						'rms_wizard_landing_identity_mismatch',
+						\__( 'Landing id and landing_key refer to different existing landings.', 'simple-rms-theme' ),
+						[ 'status' => 400, 'id' => $id, 'landing_key' => $key, 'key_id' => $other_id ]
+					);
+				}
+			}
+
+			return [
+				'id'          => $id,
+				'landing_key' => '' !== $key ? $key : $this->mint_landing_key(),
+			];
+		}
+
+		// 2) Match by landing_key.
+		if ( '' !== $key && isset( $claimed_keys[ $key ] ) ) {
+			$entry = $claimed_keys[ $key ];
+
+			return [
+				'id'          => (int) ( $entry['id'] ?? 0 ),
+				'landing_key' => $key,
+			];
+		}
+
+		// 3) Match by slug (landing state only; non-landing collisions handled by caller).
+		if ( '' !== $slug && isset( $claimed_slugs[ $slug ] ) ) {
+			$matched_key = $claimed_slugs[ $slug ];
+			$entry       = $claimed_keys[ $matched_key ] ?? [];
+
+			return [
+				'id'          => (int) ( $entry['id'] ?? 0 ),
+				'landing_key' => $matched_key,
+			];
+		}
+
+		return [
+			'id'          => 0,
+			'landing_key' => $key,
+		];
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $rows
+	 *
+	 * @return string[]
+	 */
+	private function collect_required_reusable_layouts( array $rows ): array {
+		$layouts = [];
+
+		foreach ( $rows as $row ) {
+			foreach ( is_array( $row['sections'] ?? null ) ? $row['sections'] : [] as $section ) {
+				$layout = $this->normalize_layout( (string) ( $section['layout'] ?? '' ) );
+
+				if ( '' === $layout || ! $this->harness->is_reusable_layout( $layout ) ) {
+					continue;
+				}
+
+				// Override rows still need a bootstrap fallback if generation fails.
+				$layouts[ $layout ] = true;
+			}
+		}
+
+		return array_keys( $layouts );
+	}
+
+	/**
+	 * Lazy bootstrap: state.home_sections → Home page_sections → neutral generation.
+	 *
+	 * @param string[]            $required_layouts
+	 * @param array<string,mixed> $state
+	 * @param array<string,mixed> $client_data
+	 * @param array<string,mixed> $ai_config
+	 *
+	 * @return true|\WP_Error
+	 */
+	private function ensure_canonical_reusables( array $required_layouts, array $state, array $client_data, array $ai_config ) {
+		$missing = [];
+
+		foreach ( $required_layouts as $layout ) {
+			if ( ! $this->canonical_store->has( $layout ) ) {
+				$missing[] = $layout;
+			}
+		}
+
+		if ( [] === $missing ) {
+			return true;
+		}
+
+		// (1) state.home_sections prepared reusable rows.
+		$this->seed_from_section_rows( is_array( $state['home_sections'] ?? null ) ? $state['home_sections'] : [], $missing );
+		$missing = $this->still_missing( $missing );
+
+		if ( [] === $missing ) {
+			return true;
+		}
+
+		// (2) Home page ACF page_sections.
+		$home_id = $this->home_page_id( $state );
+
+		if ( $home_id > 0 ) {
+			$home_sections = $this->read_page_sections( $home_id );
+			$this->seed_from_section_rows( $home_sections, $missing );
+			$missing = $this->still_missing( $missing );
+		}
+
+		if ( [] === $missing ) {
+			return true;
+		}
+
+		// (3) Neutral generation (PAGE_HOME, no keywords).
+		$client_context = $this->harness->get_harness_context( $client_data );
+
+		foreach ( $missing as $layout ) {
+			if ( ! $this->layout_repository->has_layout( $layout ) ) {
+				continue;
+			}
+
+			$item_count = $this->item_count( $layout, 0 );
+			$overrides  = $this->generate_section_copy(
+				$layout,
+				$item_count,
+				$client_context,
+				$ai_config,
+				AI_Content_Harness::PAGE_HOME,
+				[],
+				[],
+				false,
+				[ 'layout' => $layout, 'bootstrap' => true ]
+			);
+			$overrides  = \is_wp_error( $overrides ) ? [] : $overrides;
+			$row        = $this->content_builder->prepare_image_fallbacks( $this->section_data( $layout, $client_data, $overrides, $item_count ) );
+
+			if ( [] === $row || empty( $row['acf_fc_layout'] ) ) {
+				continue;
+			}
+
+			if ( ! $this->canonical_store->set_if_empty( $layout, $row ) && ! $this->canonical_store->has( $layout ) ) {
+				$this->logger->log(
+					'error',
+					'Canonical bootstrap first-write persistence failed.',
+					[ 'layout' => $layout ]
+				);
+			}
+		}
+
+		$missing = $this->still_missing( $missing );
+
+		if ( [] !== $missing ) {
+			return new \WP_Error(
+				'rms_wizard_canonical_bootstrap_failed',
+				sprintf(
+					/* translators: %s: comma-separated layout keys. */
+					\__( 'Could not prepare shared reusable sections (%s). Re-run Home Page Builder or fix the Home page sections, then try again.', 'simple-rms-theme' ),
+					implode( ', ', $missing )
+				),
+				[ 'status' => 400, 'missing_layouts' => $missing ]
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $rows
+	 * @param string[]                       $missing
+	 */
+	private function seed_from_section_rows( array $rows, array $missing ): void {
+		$want = array_fill_keys( $missing, true );
+
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+
+			$layout = $this->normalize_layout( (string) ( $row['acf_fc_layout'] ?? $row['layout'] ?? '' ) );
+
+			if ( '' === $layout || ! isset( $want[ $layout ] ) || ! $this->harness->is_reusable_layout( $layout ) ) {
+				continue;
+			}
+
+			if ( empty( $row['acf_fc_layout'] ) ) {
+				$row['acf_fc_layout'] = $layout;
+			}
+
+			if ( ! $this->is_valid_section_row( $row ) ) {
+				continue;
+			}
+
+			$this->canonical_store->set_if_empty( $layout, $row );
+		}
+	}
+
+	/**
+	 * @param string[] $layouts
+	 *
+	 * @return string[]
+	 */
+	private function still_missing( array $layouts ): array {
+		$missing = [];
+
+		foreach ( $layouts as $layout ) {
+			if ( ! $this->canonical_store->has( $layout ) ) {
+				$missing[] = $layout;
+			}
+		}
+
+		return $missing;
+	}
+
+	/**
+	 * @param array<string,mixed>               $row
+	 * @param array<string,bool>                $replace_map
+	 * @param array<string,mixed>               $client_data
+	 * @param array<string,mixed>               $client_context
+	 * @param array<string,mixed>               $ai_config
+	 * @param array<string,array<string,mixed>> $landing_pages
+	 * @param array<int,array<string,mixed>>    $prior_payloads
+	 *
+	 * @return array{entry:array<string,mixed>,landing_key:string,prior_payloads:array<int,array<string,mixed>>}|\WP_Error
+	 */
+	private function build_one_landing( array $row, array $replace_map, array $client_data, array $client_context, array $ai_config, array $landing_pages, array $prior_payloads ) {
+		unset( $landing_pages );
+
+		$keywords = [
+			'primary_keyword' => (string) $row['primary_keyword'],
+			'subkeywords'     => is_array( $row['subkeywords'] ?? null ) ? $row['subkeywords'] : [],
+		];
+
+		$log_context = [
+			'landing_key'  => (string) $row['landing_key'],
+			'slug'         => (string) $row['slug'],
+			'title'        => (string) $row['title'],
+			'landing_type' => (string) $row['landing_type'],
+		];
+
+		$prepared     = [];
+		$local_priors = $prior_payloads;
+		$section_rows = is_array( $row['sections'] ?? null ) ? $row['sections'] : [];
+		$existing_id  = (int) $row['id'];
+
+		foreach ( $section_rows as $section_row ) {
+			$layout   = $this->normalize_layout( (string) ( $section_row['layout'] ?? '' ) );
+			$override = $this->truthy( $section_row['override_canonical'] ?? false );
+			$count    = $this->item_count( $layout, (int) ( $section_row['item_count'] ?? 0 ) );
+
+			if ( '' === $layout || ! $this->layout_repository->has_layout( $layout ) ) {
+				continue;
+			}
+
+			$section_context            = $log_context;
+			$section_context['layout']  = $layout;
+
+			if ( $this->harness->is_keyword_layout( $layout ) ) {
+				$copy = $this->generate_section_copy(
+					$layout,
+					$count,
+					$client_context,
+					$ai_config,
+					AI_Content_Harness::PAGE_LANDING,
+					$keywords,
+					$local_priors,
+					true,
+					$section_context
+				);
+
+				if ( \is_wp_error( $copy ) ) {
+					// Preserve existing landing content instead of publishing keyword placeholders.
+					$preserved = $this->try_preserve_existing_landing( $existing_id, $row, $log_context, $copy );
+
+					if ( \is_wp_error( $preserved ) ) {
+						return $preserved;
+					}
+
+					if ( null !== $preserved ) {
+						return $preserved;
+					}
+
+					return $copy;
+				}
+
+				$section = $this->content_builder->prepare_image_fallbacks( $this->section_data( $layout, $client_data, $copy, $count ) );
+			} else {
+				$section = $this->resolve_reusable_section(
+					$layout,
+					$count,
+					$override,
+					! empty( $replace_map[ $layout ] ),
+					$client_data,
+					$client_context,
+					$ai_config,
+					$local_priors,
+					$section_context
+				);
+			}
+
+			if ( ! $this->is_valid_section_row( $section ) ) {
+				return new \WP_Error(
+					'rms_wizard_landing_section_failed',
+					sprintf(
+						/* translators: %s: layout key. */
+						\__( 'Landing section "%s" could not be prepared.', 'simple-rms-theme' ),
+						$layout
+					),
+					array_merge( [ 'status' => 500 ], $section_context )
+				);
+			}
+
+			$prepared[]     = $section;
+			$local_priors[] = [
+				'layout'     => $layout,
+				'item_count' => $count,
+				'payload'    => $section,
+			];
+		}
+
+		if ( [] === $prepared ) {
+			return new \WP_Error( 'rms_wizard_landing_sections_required', \__( 'Each landing requires at least one valid section.', 'simple-rms-theme' ), [ 'status' => 400 ] );
+		}
+
+		// Local catch: build_page may create/update the post before a later throwable.
+		// Convert to WP_Error so outer partial recovery can still persist prior successes.
+		try {
+			$post_id = $this->content_builder->build_page(
+				[
+					'id'           => $existing_id,
+					'title'        => (string) $row['title'],
+					'slug'         => (string) $row['slug'],
+					'status'       => 'publish',
+					'section_only' => $existing_id > 0,
+					'sections'     => $prepared,
+					'meta_input'   => [
+						'_wp_page_template' => self::TEMPLATE,
+						'rms_landing_type'  => (string) $row['landing_type'],
+					],
+				]
+			);
+		} catch ( \Throwable $exception ) {
+			$recovered_id = $this->recover_build_page_post_id( $existing_id, (string) $row['slug'] );
+
+			$this->logger->log(
+				'error',
+				'Wizard landing build_page threw after possible create/update.',
+				array_merge(
+					$log_context,
+					[
+						'post_id'         => $recovered_id > 0 ? $recovered_id : null,
+						'exception_class' => get_class( $exception ),
+						'message'         => $exception->getMessage(),
+					]
+				)
+			);
+
+			$error_data = array_merge(
+				[
+					'status'          => 500,
+					'exception_class' => get_class( $exception ),
+				],
+				$log_context
+			);
+
+			if ( $recovered_id > 0 ) {
+				$error_data['post_id'] = $recovered_id;
+			}
+
+			return new \WP_Error(
+				'rms_wizard_landing_build_page_exception',
+				sprintf(
+					/* translators: 1: landing title or slug, 2: exception message. */
+					\__( 'Landing "%1$s" could not be saved: %2$s', 'simple-rms-theme' ),
+					'' !== (string) $row['title'] ? (string) $row['title'] : (string) $row['slug'],
+					$exception->getMessage()
+				),
+				$error_data
+			);
+		}
+
+		if ( $post_id <= 0 ) {
+			return new \WP_Error( 'rms_wizard_landing_save_failed', \__( 'Landing page could not be saved.', 'simple-rms-theme' ), array_merge( [ 'status' => 500 ], $log_context ) );
+		}
+
+		$meta_ok = $this->ensure_landing_meta( $post_id, (string) $row['landing_type'], $log_context );
+
+		if ( \is_wp_error( $meta_ok ) ) {
+			return $meta_ok;
+		}
+
+		$entry = [
+			'id'              => $post_id,
+			'landing_key'     => (string) $row['landing_key'],
+			'title'           => (string) $row['title'],
+			'slug'            => (string) $row['slug'],
+			'landing_type'    => (string) $row['landing_type'],
+			'menu_eligible'   => ! empty( $row['menu_eligible'] ),
+			'primary_keyword' => (string) $row['primary_keyword'],
+			'subkeywords'     => is_array( $row['subkeywords'] ?? null ) ? array_values( $row['subkeywords'] ) : [],
+			'keywords'        => [
+				'primary_keyword' => (string) $row['primary_keyword'],
+				'subkeywords'     => is_array( $row['subkeywords'] ?? null ) ? array_values( $row['subkeywords'] ) : [],
+			],
+			'generated_at'    => \current_time( 'mysql', true ),
+		];
+
+		return [
+			'entry'          => $entry,
+			'landing_key'    => (string) $row['landing_key'],
+			'prior_payloads' => $local_priors,
+		];
+	}
+
+	/**
+	 * @param array<string,mixed>            $client_data
+	 * @param array<string,mixed>            $client_context
+	 * @param array<string,mixed>            $ai_config
+	 * @param array<int,array<string,mixed>> $prior_payloads
+	 * @param array<string,mixed>            $log_context
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function resolve_reusable_section(
+		string $layout,
+		int $item_count,
+		bool $override,
+		bool $replace_canonical,
+		array $client_data,
+		array $client_context,
+		array $ai_config,
+		array $prior_payloads,
+		array $log_context = []
+	): array {
+		$canonical = $this->canonical_store->get( $layout );
+		// Keep canonical/reusable generation neutral: never feed keyword-driven priors.
+		$neutral_priors = $this->filter_neutral_priors( $prior_payloads );
+
+		if ( $override ) {
+			// Override stays keyword-neutral (PAGE_HOME, empty keywords).
+			$copy = $this->generate_section_copy(
+				$layout,
+				$item_count,
+				$client_context,
+				$ai_config,
+				AI_Content_Harness::PAGE_HOME,
+				[],
+				$neutral_priors,
+				false,
+				$log_context
+			);
+			$copy = \is_wp_error( $copy ) ? [] : $copy;
+			$row  = $this->content_builder->prepare_image_fallbacks( $this->section_data( $layout, $client_data, $copy, $item_count ) );
+
+			if ( ! $this->is_valid_section_row( $row ) ) {
+				$this->logger->log(
+					'warning',
+					'Landing override generation failed; falling back to canonical.',
+					array_merge( [ 'layout' => $layout ], $log_context )
+				);
+
+				return $canonical;
+			}
+
+			// Overrides must never write the canonical store.
+			return $row;
+		}
+
+		if ( $replace_canonical ) {
+			$copy = $this->generate_section_copy(
+				$layout,
+				$item_count,
+				$client_context,
+				$ai_config,
+				AI_Content_Harness::PAGE_HOME,
+				[],
+				$neutral_priors,
+				false,
+				$log_context
+			);
+			$copy = \is_wp_error( $copy ) ? [] : $copy;
+			$row  = $this->content_builder->prepare_image_fallbacks( $this->section_data( $layout, $client_data, $copy, $item_count ) );
+
+			if ( $this->is_valid_section_row( $row ) ) {
+				if ( ! $this->canonical_store->replace( $layout, $row ) ) {
+					// replace() may return false when DB already holds identical payload.
+					$persisted = $this->canonical_store->get( $layout );
+
+					if ( $persisted !== $row ) {
+						$this->logger->log(
+							'error',
+							'Canonical replace persistence failed; keeping previous canonical when available.',
+							array_merge( [ 'layout' => $layout ], $log_context )
+						);
+
+						if ( $this->is_valid_section_row( $canonical ) ) {
+							return $canonical;
+						}
+					}
+				}
+
+				return $row;
+			}
+
+			$this->logger->log(
+				'warning',
+				'Canonical replace generation failed; keeping existing canonical.',
+				array_merge( [ 'layout' => $layout ], $log_context )
+			);
+		}
+
+		if ( $this->is_valid_section_row( $canonical ) ) {
+			return $canonical;
+		}
+
+		// First-write path when store empty after bootstrap race.
+		$copy = $this->generate_section_copy(
+			$layout,
+			$item_count,
+			$client_context,
+			$ai_config,
+			AI_Content_Harness::PAGE_HOME,
+			[],
+			$neutral_priors,
+			false,
+			$log_context
+		);
+		$copy = \is_wp_error( $copy ) ? [] : $copy;
+		$row  = $this->content_builder->prepare_image_fallbacks( $this->section_data( $layout, $client_data, $copy, $item_count ) );
+
+		if ( $this->is_valid_section_row( $row ) ) {
+			if ( ! $this->canonical_store->set_if_empty( $layout, $row ) && ! $this->canonical_store->has( $layout ) ) {
+				$this->logger->log(
+					'error',
+					'Canonical first-write persistence failed.',
+					array_merge( [ 'layout' => $layout ], $log_context )
+				);
+			}
+		}
+
+		return $row;
+	}
+
+	/**
+	 * @param array<string,mixed>            $client_context
+	 * @param array<string,mixed>            $ai_config
+	 * @param array<string,mixed>            $keywords
+	 * @param array<int,array<string,mixed>> $prior_section_payloads
+	 * @param array<string,mixed>            $log_context
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function generate_section_copy(
+		string $section_key,
+		int $item_count,
+		array $client_context,
+		array $ai_config,
+		string $page_type,
+		array $keywords,
+		array $prior_section_payloads,
+		bool $require_ai = false,
+		array $log_context = []
+	) {
+		$fillable = $this->harness->get_fillable_fields( $section_key );
+
+		if ( [] === $fillable ) {
+			return [];
+		}
+
+		$context = array_merge(
+			[
+				'layout'    => $section_key,
+				'page_type' => $page_type,
+			],
+			$log_context
+		);
+
+		// Reusable/canonical review must not see keyword-driven prior sections.
+		$review_priors = $require_ai
+			? $prior_section_payloads
+			: $this->filter_neutral_priors( $prior_section_payloads );
+
+		$provider = \sanitize_key( (string) $ai_config['provider'] );
+		$model    = \sanitize_text_field( (string) $ai_config['model'] );
+		$system   = $this->harness->get_layer1() . "\n\n" . $this->harness->get_layer2( $page_type );
+		$prompt   = $this->harness->get_layer3( $section_key, $item_count, $client_context, $page_type, $keywords );
+		$result   = AI_Provider_Registry::make_provider( $provider )->generate(
+			$model,
+			$prompt,
+			[
+				'section_key' => $section_key,
+				'client_data' => $client_context,
+				'item_count'  => $item_count,
+				'page_type'   => $page_type,
+			],
+			$system
+		);
+
+		if ( empty( $result['success'] ) || empty( $result['content'] ) ) {
+			$this->logger->log(
+				$require_ai ? 'error' : 'warning',
+				$require_ai
+					? 'Wizard landing keyword section AI generation failed.'
+					: 'Wizard landing section AI generation failed; fallback content used.',
+				array_merge( $context, [ 'error' => $result['error'] ?? '' ] )
+			);
+
+			if ( $require_ai ) {
+				return new \WP_Error(
+					'rms_wizard_landing_keyword_ai_failed',
+					sprintf(
+						/* translators: %s: layout key. */
+						\__( 'Keyword section "%s" could not be generated. Landing was not published with placeholder copy.', 'simple-rms-theme' ),
+						$section_key
+					),
+					array_merge( [ 'status' => 502 ], $context )
+				);
+			}
+
+			return [];
+		}
+
+		$decoded = $this->decode_json_content( (string) $result['content'] );
+
+		if ( [] === $decoded ) {
+			$this->logger->log(
+				$require_ai ? 'error' : 'warning',
+				'Wizard landing AI returned success but content was invalid JSON.',
+				array_merge(
+					$context,
+					[
+						'content_preview' => substr( trim( (string) $result['content'] ), 0, 180 ),
+					]
+				)
+			);
+
+			if ( $require_ai ) {
+				return new \WP_Error(
+					'rms_wizard_landing_keyword_json_failed',
+					sprintf(
+						/* translators: %s: layout key. */
+						\__( 'Keyword section "%s" returned invalid JSON. Landing was not published with placeholder copy.', 'simple-rms-theme' ),
+						$section_key
+					),
+					array_merge( [ 'status' => 502 ], $context )
+				);
+			}
+
+			return [];
+		}
+
+		$reviewed = $this->review_section_content(
+			$section_key,
+			$decoded,
+			$review_priors,
+			$ai_config,
+			$client_context,
+			$item_count,
+			$require_ai,
+			$context
+		);
+
+		if ( \is_wp_error( $reviewed ) ) {
+			return $reviewed;
+		}
+
+		$validated = $this->harness->validate_fields( $section_key, $reviewed );
+
+		if ( $require_ai && [] === $validated ) {
+			$this->logger->log(
+				'error',
+				'Wizard landing keyword section validated to empty payload after AI success.',
+				$context
+			);
+
+			return new \WP_Error(
+				'rms_wizard_landing_keyword_empty',
+				sprintf(
+					/* translators: %s: layout key. */
+					\__( 'Keyword section "%s" produced no usable fields. Landing was not published with placeholder copy.', 'simple-rms-theme' ),
+					$section_key
+				),
+				array_merge( [ 'status' => 502 ], $context )
+			);
+		}
+
+		return $validated;
+	}
+
+	/**
+	 * @param array<string,mixed>            $decoded
+	 * @param array<int,array<string,mixed>> $prior_section_payloads
+	 * @param array<string,mixed>            $ai_config
+	 * @param array<string,mixed>            $client_context
+	 * @param array<string,mixed>            $log_context
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function review_section_content(
+		string $section_key,
+		array $decoded,
+		array $prior_section_payloads,
+		array $ai_config,
+		array $client_context,
+		int $item_count,
+		bool $require_ai = false,
+		array $log_context = []
+	) {
+		if ( ! $this->is_review_enabled() ) {
+			return $decoded;
+		}
+
+		$review_config                   = $ai_config;
+		$review_config['client_context'] = $client_context;
+		$review_config['item_count']     = $item_count;
+
+		try {
+			$result = $this->reviewer()->review( $section_key, $decoded, $prior_section_payloads, $review_config );
+		} catch ( \Throwable $error ) {
+			$this->logger->log(
+				'error',
+				'Wizard landing content reviewer threw an exception.',
+				array_merge(
+					[
+						'layout'  => $section_key,
+						'message' => $error->getMessage(),
+					],
+					$log_context
+				)
+			);
+
+			if ( $require_ai ) {
+				return new \WP_Error(
+					'rms_wizard_landing_keyword_review_failed',
+					sprintf(
+						/* translators: %s: layout key. */
+						\__( 'Keyword section "%s" review failed. Landing was not published with placeholder copy.', 'simple-rms-theme' ),
+						$section_key
+					),
+					array_merge( [ 'status' => 502, 'layout' => $section_key ], $log_context )
+				);
+			}
+
+			return $decoded;
+		}
+
+		$payload = $result['payload'] ?? null;
+
+		return is_array( $payload ) ? $payload : $decoded;
+	}
+
+	/**
+	 * @param array<int,mixed> $raw
+	 *
+	 * @return array<int,array{layout:string,item_count:int,override_canonical:bool}>
+	 */
+	private function normalize_section_rows( array $raw ): array {
+		$rows = [];
+
+		foreach ( $raw as $value ) {
+			if ( is_array( $value ) ) {
+				$layout = $this->normalize_layout( (string) ( $value['layout'] ?? $value['section_key'] ?? $value['key'] ?? '' ) );
+				$count  = \absint( $value['item_count'] ?? 0 );
+				$over   = $this->truthy( $value['override_canonical'] ?? false );
+			} else {
+				$layout = $this->normalize_layout( (string) $value );
+				$count  = 0;
+				$over   = false;
+			}
+
+			if ( '' === $layout || ! $this->layout_repository->has_layout( $layout ) ) {
+				continue;
+			}
+
+			$rows[] = [
+				'layout'             => $layout,
+				'item_count'         => $this->item_count( $layout, $count ),
+				'override_canonical' => $over,
+			];
+		}
+
+		if ( [] === $rows ) {
+			foreach ( self::DEFAULT_SECTIONS as $default ) {
+				$layout = $this->normalize_layout( (string) $default['layout'] );
+
+				if ( ! $this->layout_repository->has_layout( $layout ) ) {
+					continue;
+				}
+
+				$rows[] = [
+					'layout'             => $layout,
+					'item_count'         => $this->item_count( $layout, 0 ),
+					'override_canonical' => false,
+				];
+			}
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * @param array<int,mixed> $landings
+	 *
+	 * @return array<string,array<string,mixed>>
+	 */
+	private function normalize_state_landings( array $landings ): array {
+		$normalized = [];
+
+		foreach ( $landings as $landing ) {
+			if ( ! is_array( $landing ) ) {
+				continue;
+			}
+
+			$key = \sanitize_key( (string) ( $landing['landing_key'] ?? '' ) );
+
+			if ( '' === $key ) {
+				$key = $this->mint_landing_key();
+			}
+
+			$landing['landing_key'] = $key;
+			$landing['id']          = \absint( $landing['id'] ?? 0 );
+			$landing['slug']        = \sanitize_title( (string) ( $landing['slug'] ?? '' ) );
+			$normalized[ $key ]     = $landing;
+		}
+
+		return $normalized;
+	}
+
+	private function section_data( string $section_key, array $client_data, array $copy, int $item_count ): array {
+		$section = array_merge( [ 'acf_fc_layout' => $section_key ], $this->placeholder_copy( $section_key, $client_data, $item_count ) );
+		$allowed = array_flip( $this->harness->get_fillable_fields( $section_key ) );
+
+		foreach ( $copy as $field => $value ) {
+			$field = (string) $field;
+
+			if ( false !== strpos( $field, '_services' ) ) {
+				continue;
+			}
+
+			if ( isset( $allowed[ $field ] ) ) {
+				$section[ $field ] = $this->section_value( $value );
+			}
+		}
+
+		$service_rows = $this->service_rows( $section_key, $client_data, $copy, $item_count );
+
+		if ( [] !== $service_rows ) {
+			$section[ $service_rows['field'] ] = $service_rows['rows'];
+		}
+
+		return $section;
+	}
+
+	private function placeholder_copy( string $section_key, array $client_data, int $item_count ): array {
+		if ( ! $this->harness->has_fillable_fields( $section_key ) ) {
+			return [];
+		}
+
+		$company        = $this->text( $client_data['company_name'] ?? \__( 'Your Company', 'simple-rms-theme' ) );
+		$text_repeaters = $this->harness->get_text_repeater_fields( $section_key );
+		$copy           = [];
+
+		foreach ( $this->harness->get_fillable_fields( $section_key ) as $field ) {
+			if ( false !== strpos( $field, '_services' ) || isset( $text_repeaters[ $field ] ) ) {
+				continue;
+			}
+
+			$copy[ $field ] = $this->placeholder_field_value( $field, $company );
+		}
+
+		foreach ( $text_repeaters as $field => $sub_fields ) {
+			$copy[ $field ] = $this->placeholder_repeater_rows( $sub_fields, $company, $item_count );
+		}
+
+		return $copy;
+	}
+
+	private function placeholder_repeater_rows( array $sub_fields, string $company, int $item_count ): array {
+		$rows  = [];
+		$count = max( 1, min( 12, $item_count ) );
+
+		for ( $index = 0; $index < $count; $index++ ) {
+			$row = [];
+
+			foreach ( $sub_fields as $sub_field ) {
+				$row[ (string) $sub_field ] = $this->placeholder_field_value( (string) $sub_field, $company );
+			}
+
+			if ( [] !== $row ) {
+				$rows[] = $row;
+			}
+		}
+
+		return $rows;
+	}
+
+	private function placeholder_field_value( string $field, string $company ): string {
+		if ( false !== strpos( $field, 'headline' ) || false !== strpos( $field, 'title' ) || false !== strpos( $field, 'question' ) ) {
+			return sprintf( /* translators: %s: company name. */ \__( '%s Services You Can Trust', 'simple-rms-theme' ), $company );
+		}
+
+		if ( false !== strpos( $field, 'subheadline' ) || false !== strpos( $field, 'eyebrow' ) || false !== strpos( $field, 'label' ) ) {
+			return \__( 'Dependable service and clear communication', 'simple-rms-theme' );
+		}
+
+		if ( false !== strpos( $field, 'cta' ) || false !== strpos( $field, 'button' ) ) {
+			return \__( 'Get an Estimate', 'simple-rms-theme' );
+		}
+
+		return sprintf( /* translators: %s: company name. */ \__( '%s provides reliable service with careful attention to each project.', 'simple-rms-theme' ), $company );
+	}
+
+	/**
+	 * @return array{field:string,rows:array<int,array<string,string>>}|array{}
+	 */
+	private function service_rows( string $section_key, array $client_data, array $copy, int $item_count ): array {
+		$contracts = [
+			'services-v1' => [ 'field' => 'services_v1_services', 'name' => 'service_title', 'description' => 'service_text' ],
+			'services-v2' => [ 'field' => 'services_v2_services', 'name' => 'service_title', 'description' => 'service_text' ],
+			'services-v3' => [ 'field' => 'services_v3_services', 'name' => 'service_name', 'description' => 'service_overlay_text' ],
+		];
+
+		if ( ! isset( $contracts[ $section_key ] ) ) {
+			return [];
+		}
+
+		$contract = $contracts[ $section_key ];
+		$ai_rows  = is_array( $copy[ $contract['field'] ] ?? null ) ? array_values( $copy[ $contract['field'] ] ) : [];
+		$rows     = [];
+
+		foreach ( array_slice( is_array( $client_data['company_services'] ?? null ) ? $client_data['company_services'] : [], 0, $item_count ) as $index => $service ) {
+			if ( ! is_array( $service ) || empty( $service['service_name'] ) ) {
+				continue;
+			}
+
+			$ai_row      = is_array( $ai_rows[ $index ] ?? null ) ? $ai_rows[ $index ] : [];
+			$description = $ai_row[ $contract['description'] ] ?? $service['service_short_description'] ?? '';
+
+			$rows[] = [
+				$contract['name']        => $this->text( $service['service_name'] ),
+				$contract['description'] => $this->html( $description ),
+			];
+		}
+
+		return [ 'field' => $contract['field'], 'rows' => $rows ];
+	}
+
+	private function item_count( string $section_key, int $requested ): int {
+		if ( ! $this->harness->has_fillable_fields( $section_key ) ) {
+			return 0;
+		}
+
+		$defaults = [
+			'slider'            => 2,
+			'area-coverage-v1'  => 4,
+			'badges'            => 4,
+			'cta-v3'            => 3,
+			'faq-v1'            => 4,
+			'faq-v2'            => 4,
+			'gallery-grid'      => 6,
+			'portfolio-v1'      => 3,
+			'portfolio-v2'      => 3,
+			'portfolio-v3'      => 6,
+			'services-v1'       => 3,
+			'services-v2'       => 3,
+			'services-v3'       => 3,
+			'testimonials-v1'   => 3,
+			'testimonials-v2'   => 3,
+			'testimonials-v3'   => 3,
+			'video-v2'          => 2,
+			'vision-mission-v1' => 2,
+			'vision-mission-v2' => 3,
+		];
+
+		$count = $requested > 0 ? $requested : ( $defaults[ $section_key ] ?? 1 );
+
+		return max( 1, min( 12, $count ) );
+	}
+
+	private function home_page_id( array $state ): int {
+		$home_slug       = \sanitize_title( (string) ( $state['home_page_slug'] ?? '' ) );
+		$generated_pages = is_array( $state['generated_pages'] ?? null ) ? $state['generated_pages'] : [];
+
+		foreach ( $generated_pages as $page ) {
+			if ( ! is_array( $page ) || $home_slug !== \sanitize_title( (string) ( $page['slug'] ?? '' ) ) ) {
+				continue;
+			}
+
+			$post = \get_post( \absint( $page['id'] ?? 0 ) );
+
+			if ( $post && 'page' === $post->post_type ) {
+				return (int) $post->ID;
+			}
+		}
+
+		if ( '' === $home_slug ) {
+			return 0;
+		}
+
+		$post = \get_page_by_path( $home_slug, \OBJECT, 'page' );
+
+		return $post ? (int) $post->ID : 0;
+	}
+
+	/**
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function read_page_sections( int $post_id ): array {
+		if ( function_exists( 'get_field' ) ) {
+			$sections = \get_field( 'page_sections', $post_id );
+
+			if ( is_array( $sections ) ) {
+				return $sections;
+			}
+		}
+
+		$meta = \get_post_meta( $post_id, 'page_sections', true );
+
+		return is_array( $meta ) ? $meta : [];
+	}
+
+	private function is_valid_section_row( array $row ): bool {
+		$layout = $this->normalize_layout( (string) ( $row['acf_fc_layout'] ?? '' ) );
+
+		return '' !== $layout;
+	}
+
+	private function page_has_landing_type( int $post_id ): bool {
+		if ( $post_id <= 0 ) {
+			return false;
+		}
+
+		$type = \sanitize_key( (string) \get_post_meta( $post_id, 'rms_landing_type', true ) );
+
+		return in_array( $type, [ 'seo', 'ads' ], true );
+	}
+
+	private function mint_landing_key(): string {
+		if ( function_exists( 'wp_generate_uuid4' ) ) {
+			return 'lk_' . str_replace( '-', '', \wp_generate_uuid4() );
+		}
+
+		return 'lk_' . \sanitize_key( uniqid( '', true ) );
+	}
+
+	private function normalize_layout( string $layout ): string {
+		$layout = \sanitize_key( $layout );
+
+		return 'cta-bar' === $layout ? 'cta-v1' : $layout;
+	}
+
+	private function has_ai_config( array $ai_config ): bool {
+		$provider        = \sanitize_key( (string) ( $ai_config['provider'] ?? '' ) );
+		$model           = \sanitize_text_field( (string) ( $ai_config['model'] ?? '' ) );
+		$credential      = is_array( $ai_config['credential'] ?? null ) ? $ai_config['credential'] : [];
+		$has_credentials = ! empty( $ai_config['has_credentials'] ) || ! empty( $credential['has_key'] ) || ( '' !== $provider && AI_Credential_Store::has( $provider ) );
+
+		return '' !== $provider && '' !== $model && $has_credentials && AI_Provider_Registry::provider_exists( $provider );
+	}
+
+	private function decode_json_content( string $content ): array {
+		$content = trim( preg_replace( '/^```(?:json)?|```$/m', '', $content ) ?? $content );
+		$data    = json_decode( $content, true );
+
+		return is_array( $data ) ? $data : [];
+	}
+
+	private function reviewer(): AI_Content_Reviewer {
+		if ( ! $this->reviewer instanceof AI_Content_Reviewer ) {
+			$this->reviewer = new AI_Content_Reviewer( $this->harness );
+		}
+
+		return $this->reviewer;
+	}
+
+	private function is_review_enabled(): bool {
+		if ( ! \defined( 'WIZARD_REVIEW_ENABLED' ) ) {
+			return true;
+		}
+
+		$value = \constant( 'WIZARD_REVIEW_ENABLED' );
+
+		if ( is_bool( $value ) ) {
+			return $value;
+		}
+
+		if ( is_int( $value ) ) {
+			return 0 !== $value;
+		}
+
+		if ( is_string( $value ) ) {
+			$value = strtolower( trim( $value ) );
+
+			if ( in_array( $value, [ '0', 'false', 'off', 'no' ], true ) ) {
+				return false;
+			}
+
+			if ( in_array( $value, [ '1', 'true', 'on', 'yes' ], true ) ) {
+				return true;
+			}
+		}
+
+		return (bool) $value;
+	}
+
+	private function section_value( $value ) {
+		if ( is_array( $value ) ) {
+			return array_map( [ $this, 'section_value' ], $value );
+		}
+
+		return $this->html( $value );
+	}
+
+	private function text( $value ): string {
+		return \sanitize_text_field( (string) $value );
+	}
+
+	private function html( $value ): string {
+		return \wp_kses_post( (string) $value );
+	}
+
+	private function truthy( $value ): bool {
+		return true === $value || 1 === $value || '1' === $value || 'true' === $value || 'yes' === $value || 'on' === $value;
+	}
+
+	private function maybe_mark_completed(): void {
+		$state    = $this->state_manager->get_state();
+		$required = Step_Controller::get_required_steps();
+
+		foreach ( $required as $step ) {
+			if ( 'complete' !== ( $state['step_status'][ $step ] ?? '' ) ) {
+				return;
+			}
+		}
+
+		$this->state_manager->mark_completed();
+	}
+
+	/**
+	 * Persist wizard state and verify landing_pages post-state when critical.
+	 *
+	 * update_option() can return false for identical values, so we re-read.
+	 *
+	 * @param array<string,mixed> $state
+	 */
+	private function persist_wizard_state( array $state, string $reason ): bool {
+		$expected = is_array( $state['landing_pages'] ?? null ) ? array_values( $state['landing_pages'] ) : [];
+		$saved    = $this->state_manager->save_state( $state );
+
+		if ( $saved ) {
+			return true;
+		}
+
+		$reloaded = $this->state_manager->get_state();
+		$actual   = is_array( $reloaded['landing_pages'] ?? null ) ? array_values( $reloaded['landing_pages'] ) : [];
+
+		if ( $this->landing_pages_equivalent( $expected, $actual ) ) {
+			return true;
+		}
+
+		$this->logger->log(
+			'error',
+			'Wizard landing state persistence failed.',
+			[
+				'reason'           => $reason,
+				'expected_count'   => count( $expected ),
+				'actual_count'     => count( $actual ),
+				'expected_post_ids'=> $this->collect_landing_post_ids( $expected ),
+				'actual_post_ids'  => $this->collect_landing_post_ids( $actual ),
+			]
+		);
+
+		return false;
+	}
+
+	/**
+	 * On multi-landing partial failure: save successful landings, then mark failed.
+	 *
+	 * @param array<string,mixed>               $state
+	 * @param array<string,array<string,mixed>> $landing_pages
+	 * @param int[]                             $built_ids
+	 * @param \WP_Error                         $error
+	 */
+	private function persist_partial_landing_progress( array $state, array $landing_pages, array $built_ids, \WP_Error $error ): void {
+		$successful = array_values( array_filter( $built_ids ) );
+		$state['landing_pages']      = array_values( $landing_pages );
+		$state['canonical_sections'] = $this->canonical_store->summary();
+
+		$persisted = $this->persist_wizard_state( $state, 'partial failure recovery' );
+
+		$this->logger->log(
+			$persisted ? 'warning' : 'error',
+			$persisted
+				? 'Wizard landing run failed after partial success; successful landings persisted.'
+				: 'Wizard landing run failed after partial success; could not persist successful landings.',
+			[
+				'successful_count' => count( $successful ),
+				'post_ids'         => $successful,
+				'error_code'       => $error->get_error_code(),
+				'error_message'    => $error->get_error_message(),
+			]
+		);
+
+		// Mark failed only after persistence is attempted.
+		if ( ! $this->mark_step_status( 'failed' ) ) {
+			$this->logger->log(
+				'error',
+				'Wizard landing could not mark step status failed after partial failure.',
+				[
+					'post_ids'   => $successful,
+					'error_code' => $error->get_error_code(),
+				]
+			);
+		}
+	}
+
+	/**
+	 * @param string $status pending|running|complete|failed
+	 */
+	private function mark_step_status( string $status ): bool {
+		$saved = $this->state_manager->set_step_status( self::STEP, $status );
+
+		if ( $saved ) {
+			return true;
+		}
+
+		$state  = $this->state_manager->get_state();
+		$actual = (string) ( $state['step_status'][ self::STEP ] ?? '' );
+
+		if ( $actual === $status ) {
+			return true;
+		}
+
+		$this->logger->log(
+			'error',
+			'Wizard landing step status persistence failed.',
+			[
+				'expected' => $status,
+				'actual'   => $actual,
+			]
+		);
+
+		return false;
+	}
+
+	/**
+	 * Safety-net meta writes with post-state verification.
+	 *
+	 * @param array<string,mixed> $log_context
+	 *
+	 * @return true|\WP_Error
+	 */
+	private function ensure_landing_meta( int $post_id, string $landing_type, array $log_context ) {
+		\update_post_meta( $post_id, '_wp_page_template', self::TEMPLATE );
+		\update_post_meta( $post_id, 'rms_landing_type', $landing_type );
+
+		$template = (string) \get_post_meta( $post_id, '_wp_page_template', true );
+		$type     = \sanitize_key( (string) \get_post_meta( $post_id, 'rms_landing_type', true ) );
+
+		if ( self::TEMPLATE !== $template || $landing_type !== $type ) {
+			$this->logger->log(
+				'error',
+				'Wizard landing meta safety-net verification failed.',
+				array_merge(
+					$log_context,
+					[
+						'post_id'           => $post_id,
+						'expected_template' => self::TEMPLATE,
+						'actual_template'   => $template,
+						'expected_type'     => $landing_type,
+						'actual_type'       => $type,
+					]
+				)
+			);
+
+			return new \WP_Error(
+				'rms_wizard_landing_meta_persist_failed',
+				\__( 'Landing page meta could not be verified after save.', 'simple-rms-theme' ),
+				array_merge( [ 'status' => 500, 'post_id' => $post_id ], $log_context )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * When keyword AI fails on an update, preserve the existing landing page payload.
+	 *
+	 * @param array<string,mixed> $row
+	 * @param array<string,mixed> $log_context
+	 * @param \WP_Error           $error
+	 *
+	 * @return array{entry:array<string,mixed>,landing_key:string,prior_payloads:array<int,array<string,mixed>>}|\WP_Error|null
+	 *         array on preserved success, WP_Error when preserve update fails, null when preserve is not applicable.
+	 */
+	private function try_preserve_existing_landing( int $existing_id, array $row, array $log_context, \WP_Error $error ) {
+		if ( $existing_id <= 0 || ! $this->page_has_landing_type( $existing_id ) ) {
+			return null;
+		}
+
+		$sections = $this->read_page_sections( $existing_id );
+		$valid    = false;
+
+		foreach ( $sections as $section ) {
+			if ( is_array( $section ) && $this->is_valid_section_row( $section ) ) {
+				$valid = true;
+				break;
+			}
+		}
+
+		if ( ! $valid ) {
+			return null;
+		}
+
+		$this->logger->log(
+			'warning',
+			'Keyword AI failed; preserving existing landing page payload instead of placeholders.',
+			array_merge(
+				$log_context,
+				[
+					'post_id'       => $existing_id,
+					'error_code'    => $error->get_error_code(),
+					'error_message' => $error->get_error_message(),
+				]
+			)
+		);
+
+		// Refresh title/slug/type meta without rewriting sections.
+		$updated = \wp_update_post(
+			[
+				'ID'         => $existing_id,
+				'post_title' => (string) $row['title'],
+				'post_name'  => (string) $row['slug'],
+			],
+			true
+		);
+
+		if ( \is_wp_error( $updated ) ) {
+			$this->logger->log(
+				'error',
+				'Failed to preserve existing landing page after keyword AI failure (wp_update_post error).',
+				array_merge(
+					$log_context,
+					[
+						'post_id'       => $existing_id,
+						'error_code'    => $updated->get_error_code(),
+						'error_message' => $updated->get_error_message(),
+					]
+				)
+			);
+
+			return new \WP_Error(
+				'rms_wizard_landing_preserve_failed',
+				\__( 'Keyword generation failed and the existing landing page could not be preserved.', 'simple-rms-theme' ),
+				array_merge(
+					[
+						'status'             => 500,
+						'post_id'            => $existing_id,
+						'update_error_code'  => $updated->get_error_code(),
+						'keyword_error_code' => $error->get_error_code(),
+					],
+					$log_context
+				)
+			);
+		}
+
+		if ( ! is_int( $updated ) || $updated <= 0 ) {
+			$this->logger->log(
+				'error',
+				'Failed to preserve existing landing page after keyword AI failure (invalid wp_update_post result).',
+				array_merge(
+					$log_context,
+					[
+						'post_id'       => $existing_id,
+						'update_result' => $updated,
+					]
+				)
+			);
+
+			return new \WP_Error(
+				'rms_wizard_landing_preserve_failed',
+				\__( 'Keyword generation failed and the existing landing page could not be preserved.', 'simple-rms-theme' ),
+				array_merge(
+					[
+						'status'             => 500,
+						'post_id'            => $existing_id,
+						'keyword_error_code' => $error->get_error_code(),
+					],
+					$log_context
+				)
+			);
+		}
+
+		$meta_ok = $this->ensure_landing_meta( $existing_id, (string) $row['landing_type'], $log_context );
+
+		if ( \is_wp_error( $meta_ok ) ) {
+			$this->logger->log(
+				'error',
+				'Failed to preserve existing landing meta after keyword AI failure.',
+				array_merge(
+					$log_context,
+					[
+						'post_id'       => $existing_id,
+						'error_code'    => $meta_ok->get_error_code(),
+						'error_message' => $meta_ok->get_error_message(),
+					]
+				)
+			);
+
+			return $meta_ok;
+		}
+
+		$entry = [
+			'id'              => $existing_id,
+			'landing_key'     => (string) $row['landing_key'],
+			'title'           => (string) $row['title'],
+			'slug'            => (string) $row['slug'],
+			'landing_type'    => (string) $row['landing_type'],
+			'menu_eligible'   => ! empty( $row['menu_eligible'] ),
+			'primary_keyword' => (string) $row['primary_keyword'],
+			'subkeywords'     => is_array( $row['subkeywords'] ?? null ) ? array_values( $row['subkeywords'] ) : [],
+			'keywords'        => [
+				'primary_keyword' => (string) $row['primary_keyword'],
+				'subkeywords'     => is_array( $row['subkeywords'] ?? null ) ? array_values( $row['subkeywords'] ) : [],
+			],
+			'generated_at'    => \current_time( 'mysql', true ),
+			'preserved'       => true,
+		];
+
+		return [
+			'entry'          => $entry,
+			'landing_key'    => (string) $row['landing_key'],
+			'prior_payloads' => [],
+		];
+	}
+
+	/**
+	 * Strip keyword-governed priors so reusable/canonical generation stays neutral.
+	 *
+	 * @param array<int,array<string,mixed>> $priors
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function filter_neutral_priors( array $priors ): array {
+		$neutral = [];
+
+		foreach ( $priors as $prior ) {
+			if ( ! is_array( $prior ) ) {
+				continue;
+			}
+
+			$layout = $this->normalize_layout( (string) ( $prior['layout'] ?? '' ) );
+
+			if ( '' === $layout || $this->harness->is_keyword_layout( $layout ) ) {
+				continue;
+			}
+
+			$neutral[] = $prior;
+		}
+
+		return $neutral;
+	}
+
+	/**
+	 * Compare meaningful persisted landing state (not only identity fields).
+	 *
+	 * Used when save_state() returns false so identical-but-unordered or
+	 * stale/partial snapshots are not treated as successful persistence.
+	 *
+	 * @param array<int,array<string,mixed>> $left
+	 * @param array<int,array<string,mixed>> $right
+	 */
+	private function landing_pages_equivalent( array $left, array $right ): bool {
+		if ( count( $left ) !== count( $right ) ) {
+			return false;
+		}
+
+		$normalize = function ( array $rows ): array {
+			$map = [];
+
+			foreach ( $rows as $row ) {
+				if ( ! is_array( $row ) ) {
+					continue;
+				}
+
+				$key = \sanitize_key( (string) ( $row['landing_key'] ?? '' ) );
+
+				if ( '' === $key ) {
+					$key = 'id_' . (int) ( $row['id'] ?? 0 );
+				}
+
+				$keywords       = is_array( $row['keywords'] ?? null ) ? $row['keywords'] : [];
+				$primary        = (string) ( $row['primary_keyword'] ?? ( $keywords['primary_keyword'] ?? '' ) );
+				$subkeywords    = is_array( $row['subkeywords'] ?? null )
+					? $row['subkeywords']
+					: ( is_array( $keywords['subkeywords'] ?? null ) ? $keywords['subkeywords'] : [] );
+				$subkeywords    = array_values(
+					array_filter(
+						array_map(
+							static function ( $value ): string {
+								return \sanitize_text_field( (string) $value );
+							},
+							$subkeywords
+						),
+						static function ( string $value ): bool {
+							return '' !== $value;
+						}
+					)
+				);
+				// Order-insensitive keyword bag — payload order is not meaningful state.
+				sort( $subkeywords, SORT_STRING );
+
+				$map[ $key ] = [
+					'id'              => (int) ( $row['id'] ?? 0 ),
+					'landing_key'     => \sanitize_key( (string) ( $row['landing_key'] ?? '' ) ),
+					'title'           => \sanitize_text_field( (string) ( $row['title'] ?? '' ) ),
+					'slug'            => \sanitize_title( (string) ( $row['slug'] ?? '' ) ),
+					'landing_type'    => \sanitize_key( (string) ( $row['landing_type'] ?? '' ) ),
+					'menu_eligible'   => ! empty( $row['menu_eligible'] ),
+					'primary_keyword' => \sanitize_text_field( $primary ),
+					'subkeywords'     => $subkeywords,
+					'generated_at'    => \sanitize_text_field( (string) ( $row['generated_at'] ?? '' ) ),
+					'preserved'       => ! empty( $row['preserved'] ),
+				];
+			}
+
+			ksort( $map );
+
+			return $map;
+		};
+
+		return $normalize( $left ) === $normalize( $right );
+	}
+
+	/**
+	 * Best-effort post ID recovery when build_page throws after create/update.
+	 */
+	private function recover_build_page_post_id( int $existing_id, string $slug ): int {
+		if ( $existing_id > 0 ) {
+			return $existing_id;
+		}
+
+		$slug = \sanitize_title( $slug );
+
+		if ( '' === $slug ) {
+			return 0;
+		}
+
+		$page = \get_page_by_path( $slug, OBJECT, 'page' );
+
+		if ( $page instanceof \WP_Post ) {
+			return (int) $page->ID;
+		}
+
+		return 0;
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $landings
+	 *
+	 * @return int[]
+	 */
+	private function collect_landing_post_ids( array $landings ): array {
+		$ids = [];
+
+		foreach ( $landings as $landing ) {
+			if ( ! is_array( $landing ) ) {
+				continue;
+			}
+
+			$id = (int) ( $landing['id'] ?? 0 );
+
+			if ( $id > 0 ) {
+				$ids[] = $id;
+			}
+		}
+
+		return $ids;
+	}
+}
+

--- a/inc/wizard/class-step-landing-page-builder.php
+++ b/inc/wizard/class-step-landing-page-builder.php
@@ -12,12 +12,8 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Builds N SEO/Ads landing pages from canonical reusable sections + keyword copy.
  *
- * Phase 2 backend scope: identity preflight, lazy canonical bootstrap, page upsert
- * with template/type meta, and state persistence. Menu/Yoast/noindex final-state
- * sync remains Phase 3.
- *
- * PR2 safety: class is implemented but NOT active in REQUIRED_STEPS / DISPATCHABLE_STEPS
- * until Phase 3 wires UI + Ads noindex/menu final-state sync.
+ * Includes identity preflight, lazy canonical bootstrap, page upsert with
+ * template/type meta, Yoast/noindex final-state sync, and menu reconciliation.
  */
 class Step_Landing_Page_Builder {
 	private const STEP     = 'landing-page-builder';
@@ -46,6 +42,8 @@ class Step_Landing_Page_Builder {
 	private $harness;
 	private $reviewer;
 	private $canonical_store;
+	private $menu_builder;
+	private $yoast_meta_writer;
 
 	public function __construct(
 		?Logger $logger = null,
@@ -54,7 +52,9 @@ class Step_Landing_Page_Builder {
 		?Flexible_Content_Layouts $layout_repository = null,
 		?AI_Content_Harness $harness = null,
 		?AI_Content_Reviewer $reviewer = null,
-		?Canonical_Section_Store $canonical_store = null
+		?Canonical_Section_Store $canonical_store = null,
+		?Menu_Builder $menu_builder = null,
+		?Yoast_Meta_Writer $yoast_meta_writer = null
 	) {
 		$this->logger            = $logger ?? new Logger();
 		$this->state_manager     = $state_manager ?? new State_Manager();
@@ -63,6 +63,8 @@ class Step_Landing_Page_Builder {
 		$this->harness           = $harness ?? new AI_Content_Harness();
 		$this->reviewer          = $reviewer;
 		$this->canonical_store   = $canonical_store ?? new Canonical_Section_Store();
+		$this->menu_builder      = $menu_builder ?? new Menu_Builder( $this->logger );
+		$this->yoast_meta_writer = $yoast_meta_writer ?? new Yoast_Meta_Writer( $this->logger );
 	}
 
 	/**
@@ -74,6 +76,69 @@ class Step_Landing_Page_Builder {
 	 */
 	public function run( array $payload ) {
 		if ( $this->truthy( $payload['skip_all'] ?? false ) ) {
+			$state             = $this->state_manager->get_state();
+			$existing_landings = $this->normalize_state_landings(
+				is_array( $state['landing_pages'] ?? null ) ? $state['landing_pages'] : []
+			);
+
+			// Existing landings must still receive final-state robots/menu reconciliation.
+			// No existing landings → skip-all is a pure no-op complete.
+			if ( [] !== $existing_landings ) {
+				foreach ( $existing_landings as $landing_key => $row ) {
+					if ( ! is_array( $row ) ) {
+						continue;
+					}
+
+					$post_id     = (int) ( $row['id'] ?? 0 );
+					$slug        = (string) ( $row['slug'] ?? '' );
+					$log_context = [
+						'landing_key' => (string) ( $row['landing_key'] ?? $landing_key ),
+						'slug'        => $slug,
+						'skip_all'    => true,
+					];
+
+					if ( $post_id <= 0 || 'page' !== \get_post_type( $post_id ) ) {
+						$post_id = $this->recover_build_page_post_id( $post_id, $slug );
+					}
+
+					if ( $post_id <= 0 || 'page' !== \get_post_type( $post_id ) ) {
+						$this->mark_step_status( 'failed' );
+
+						return new \WP_Error(
+							'rms_wizard_landing_skip_all_missing_post',
+							sprintf(
+								/* translators: %s: landing key or slug. */
+								\__( 'Skip-all could not reconcile landing "%s": page not found.', 'simple-rms-theme' ),
+								'' !== (string) ( $row['landing_key'] ?? '' )
+									? (string) $row['landing_key']
+									: ( '' !== $slug ? $slug : (string) $landing_key )
+							),
+							array_merge( [ 'status' => 500 ], $log_context )
+						);
+					}
+
+					$final_state = $this->sync_landing_final_state( $post_id, $row, $log_context );
+
+					if ( \is_wp_error( $final_state ) ) {
+						$this->mark_step_status( 'failed' );
+						$this->logger->log(
+							'error',
+							'Skip-all final-state sync failed; step not marked complete.',
+							array_merge(
+								$log_context,
+								[
+									'post_id'       => $post_id,
+									'error_code'    => $final_state->get_error_code(),
+									'error_message' => $final_state->get_error_message(),
+								]
+							)
+						);
+
+						return $final_state;
+					}
+				}
+			}
+
 			if ( ! $this->mark_step_status( 'complete' ) ) {
 				return new \WP_Error(
 					'rms_wizard_landing_status_persist_failed',
@@ -863,6 +928,11 @@ class Step_Landing_Page_Builder {
 				)
 			);
 
+			// Ads may already be published — best-effort noindex/menu cleanup before failing.
+			if ( $recovered_id > 0 ) {
+				$this->protect_ads_final_state_best_effort( $recovered_id, $row, $log_context );
+			}
+
 			$error_data = array_merge(
 				[
 					'status'          => 500,
@@ -888,13 +958,37 @@ class Step_Landing_Page_Builder {
 		}
 
 		if ( $post_id <= 0 ) {
-			return new \WP_Error( 'rms_wizard_landing_save_failed', \__( 'Landing page could not be saved.', 'simple-rms-theme' ), array_merge( [ 'status' => 500 ], $log_context ) );
+			$recovered_id = $this->recover_build_page_post_id( $existing_id, (string) $row['slug'] );
+
+			if ( $recovered_id > 0 ) {
+				$this->protect_ads_final_state_best_effort( $recovered_id, $row, $log_context );
+			}
+
+			return new \WP_Error(
+				'rms_wizard_landing_save_failed',
+				\__( 'Landing page could not be saved.', 'simple-rms-theme' ),
+				array_merge(
+					[ 'status' => 500 ],
+					$log_context,
+					$recovered_id > 0 ? [ 'post_id' => $recovered_id ] : []
+				)
+			);
 		}
 
 		$meta_ok = $this->ensure_landing_meta( $post_id, (string) $row['landing_type'], $log_context );
 
 		if ( \is_wp_error( $meta_ok ) ) {
+			// Published page without verified meta — protect Ads before surfacing failure.
+			$this->protect_ads_final_state_best_effort( $post_id, $row, $log_context );
+
 			return $meta_ok;
+		}
+
+		// Final-state Yoast + robots + menu reconciliation (every create/update).
+		$final_state = $this->sync_landing_final_state( $post_id, $row, $log_context );
+
+		if ( \is_wp_error( $final_state ) ) {
+			return $final_state;
 		}
 
 		$entry = [
@@ -918,6 +1012,247 @@ class Step_Landing_Page_Builder {
 			'landing_key'    => (string) $row['landing_key'],
 			'prior_payloads' => $local_priors,
 		];
+	}
+
+	/**
+	 * Apply final-state menu + robots + Yoast title/metadesc for one landing.
+	 *
+	 * SEO: clear noindex; append to configured menus idempotently when eligible.
+	 * Ads: write noindex + read-back (fail closed); remove from configured menus.
+	 *
+	 * @param array<string,mixed> $row
+	 * @param array<string,mixed> $log_context
+	 *
+	 * @return true|\WP_Error
+	 */
+	private function sync_landing_final_state( int $post_id, array $row, array $log_context ) {
+		$landing_type    = \sanitize_key( (string) ( $row['landing_type'] ?? 'seo' ) );
+		$landing_type    = in_array( $landing_type, [ 'seo', 'ads' ], true ) ? $landing_type : 'seo';
+		$primary_keyword = (string) ( $row['primary_keyword'] ?? '' );
+		$title           = (string) ( $row['title'] ?? '' );
+		$menu_eligible   = array_key_exists( 'menu_eligible', $row )
+			? (bool) $row['menu_eligible']
+			: ( 'seo' === $landing_type );
+
+		// Optional Yoast title/metadesc (skip+log when Yoast absent — never fails the step).
+		$this->yoast_meta_writer->write_landing_seo( $post_id, $primary_keyword, $landing_type, $title );
+
+		// Robots final state.
+		if ( 'ads' === $landing_type ) {
+			$noindex = $this->yoast_meta_writer->set_noindex( $post_id, true );
+
+			if ( \is_wp_error( $noindex ) ) {
+				return $noindex;
+			}
+		} else {
+			$clear = $this->yoast_meta_writer->set_noindex( $post_id, false );
+
+			if ( \is_wp_error( $clear ) ) {
+				return $clear;
+			}
+		}
+
+		// Menu final state against currently configured theme menus.
+		$menu_ids = $this->configured_menu_ids();
+
+		if ( [] === $menu_ids ) {
+			$this->logger->log(
+				'info',
+				'Landing final-state menu sync skipped; no configured menus yet.',
+				array_merge( [ 'post_id' => $post_id, 'landing_type' => $landing_type ], $log_context )
+			);
+
+			return true;
+		}
+
+		$seo_append_failed = [];
+
+		if ( 'seo' === $landing_type && $menu_eligible ) {
+			// SEO menu append is best-effort: log failures with detail, do not fail-close.
+			// Ads menu removal below remains fail-closed.
+			foreach ( $menu_ids as $menu_id ) {
+				$append = $this->menu_builder->append_page_items( $menu_id, [ $post_id ] );
+
+				if ( empty( $append['verified'] ) ) {
+					$failed = is_array( $append['failed_page_ids'] ?? null )
+						? array_values( $append['failed_page_ids'] )
+						: [ $post_id ];
+					$seo_append_failed[] = [
+						'menu_id'         => $menu_id,
+						'failed_page_ids' => $failed,
+						'created'         => is_array( $append['created'] ?? null ) ? $append['created'] : [],
+						'already_present' => is_array( $append['already_present'] ?? null ) ? $append['already_present'] : [],
+					];
+
+					$this->logger->log(
+						'warning',
+						'Landing final-state SEO menu append failed (best-effort; step continues). Ads removal remains fail-closed.',
+						array_merge(
+							[
+								'post_id'          => $post_id,
+								'menu_id'          => $menu_id,
+								'landing_type'     => $landing_type,
+								'failed_page_ids'  => $failed,
+								'created'          => $append['created'] ?? [],
+								'already_present'  => $append['already_present'] ?? [],
+							],
+							$log_context
+						)
+					);
+				}
+			}
+		} else {
+			// Ads / ineligible: fail-closed if menu removal cannot be verified.
+			foreach ( $menu_ids as $menu_id ) {
+				$removal = $this->menu_builder->remove_page_items( $menu_id, [ $post_id ] );
+
+				if ( empty( $removal['verified'] ) ) {
+					$failed = is_array( $removal['failed_page_ids'] ?? null )
+						? array_values( $removal['failed_page_ids'] )
+						: [ $post_id ];
+
+					$this->logger->log(
+						'error',
+						'Landing final-state menu removal failed verification.',
+						array_merge(
+							[
+								'post_id'          => $post_id,
+								'menu_id'          => $menu_id,
+								'landing_type'     => $landing_type,
+								'failed_page_ids'  => $failed,
+							],
+							$log_context
+						)
+					);
+
+					return new \WP_Error(
+						'rms_wizard_landing_menu_remove_failed',
+						sprintf(
+							/* translators: %s: landing title or slug. */
+							\__( 'Landing "%s" could not be removed from menus. Final state was not applied.', 'simple-rms-theme' ),
+							'' !== $title ? $title : (string) ( $row['slug'] ?? $post_id )
+						),
+						array_merge(
+							[
+								'status'          => 500,
+								'post_id'         => $post_id,
+								'menu_id'         => $menu_id,
+								'failed_page_ids' => $failed,
+							],
+							$log_context
+						)
+					);
+				}
+			}
+		}
+
+		$this->logger->log(
+			'info',
+			'Landing final-state menu/robots sync applied.',
+			array_merge(
+				[
+					'post_id'            => $post_id,
+					'landing_type'       => $landing_type,
+					'menu_eligible'      => $menu_eligible,
+					'menu_ids'           => $menu_ids,
+					'seo_append_best_effort' => 'seo' === $landing_type && $menu_eligible,
+					'seo_append_failed'  => $seo_append_failed,
+				],
+				$log_context
+			)
+		);
+
+		return true;
+	}
+
+	/**
+	 * Best-effort Ads final-state protection after a post-publish failure.
+	 *
+	 * Does not change the caller's failure outcome — only attempts noindex + menu
+	 * removal when landing_type is ads and a post ID is known. Logs success/failure.
+	 *
+	 * @param array<string,mixed> $row
+	 * @param array<string,mixed> $log_context
+	 */
+	private function protect_ads_final_state_best_effort( int $post_id, array $row, array $log_context ): void {
+		$post_id      = \absint( $post_id );
+		$landing_type = \sanitize_key( (string) ( $row['landing_type'] ?? 'seo' ) );
+		$landing_type = in_array( $landing_type, [ 'seo', 'ads' ], true ) ? $landing_type : 'seo';
+		$landing_key  = (string) ( $row['landing_key'] ?? ( $log_context['landing_key'] ?? '' ) );
+		$slug         = (string) ( $row['slug'] ?? ( $log_context['slug'] ?? '' ) );
+
+		if ( $post_id <= 0 || 'ads' !== $landing_type ) {
+			return;
+		}
+
+		// Ensure Ads path in sync (menu_eligible false).
+		$protection_row                   = $row;
+		$protection_row['landing_type']   = 'ads';
+		$protection_row['menu_eligible']  = false;
+
+		$protection = $this->sync_landing_final_state( $post_id, $protection_row, $log_context );
+		$ok         = ! \is_wp_error( $protection );
+
+		$this->logger->log(
+			$ok ? 'info' : 'error',
+			$ok
+				? 'Ads best-effort final-state protection succeeded after build failure.'
+				: 'Ads best-effort final-state protection failed after build failure.',
+			array_merge(
+				[
+					'post_id'           => $post_id,
+					'landing_key'       => $landing_key,
+					'slug'              => $slug,
+					'protection_ok'     => $ok,
+					'protection_error'  => $ok ? null : $protection->get_error_code(),
+					'protection_message'=> $ok ? null : $protection->get_error_message(),
+				],
+				$log_context
+			)
+		);
+	}
+
+	/**
+	 * Menu term IDs currently assigned to theme locations / stored menu_config.
+	 *
+	 * @return array<int,int>
+	 */
+	private function configured_menu_ids(): array {
+		$ids   = [];
+		$state = $this->state_manager->get_state();
+		$config = is_array( $state['menu_config'] ?? null ) ? $state['menu_config'] : [];
+
+		foreach ( [ 'primary_menu_id', 'mobile_menu_id' ] as $key ) {
+			$id = \absint( $config[ $key ] ?? 0 );
+
+			if ( $id > 0 ) {
+				$ids[] = $id;
+			}
+		}
+
+		if ( is_array( $config['locations'] ?? null ) ) {
+			foreach ( $config['locations'] as $menu_id ) {
+				$id = \absint( $menu_id );
+
+				if ( $id > 0 ) {
+					$ids[] = $id;
+				}
+			}
+		}
+
+		$locations = \get_theme_mod( 'nav_menu_locations', [] );
+
+		if ( is_array( $locations ) ) {
+			foreach ( $locations as $menu_id ) {
+				$id = \absint( $menu_id );
+
+				if ( $id > 0 ) {
+					$ids[] = $id;
+				}
+			}
+		}
+
+		return array_values( array_unique( array_filter( $ids ) ) );
 	}
 
 	/**
@@ -1857,6 +2192,9 @@ class Step_Landing_Page_Builder {
 				)
 			);
 
+			// Best-effort Ads protection before returning the original preserve failure.
+			$this->protect_ads_final_state_best_effort( $existing_id, $row, $log_context );
+
 			return new \WP_Error(
 				'rms_wizard_landing_preserve_failed',
 				\__( 'Keyword generation failed and the existing landing page could not be preserved.', 'simple-rms-theme' ),
@@ -1884,6 +2222,9 @@ class Step_Landing_Page_Builder {
 					]
 				)
 			);
+
+			// Best-effort Ads protection before returning the original preserve failure.
+			$this->protect_ads_final_state_best_effort( $existing_id, $row, $log_context );
 
 			return new \WP_Error(
 				'rms_wizard_landing_preserve_failed',
@@ -1915,7 +2256,17 @@ class Step_Landing_Page_Builder {
 				)
 			);
 
+			// Best-effort Ads protection before returning the original meta failure.
+			$this->protect_ads_final_state_best_effort( $existing_id, $row, $log_context );
+
 			return $meta_ok;
+		}
+
+		// Type flips / robots / menu still reconcile even when sections are preserved.
+		$final_state = $this->sync_landing_final_state( $existing_id, $row, $log_context );
+
+		if ( \is_wp_error( $final_state ) ) {
+			return $final_state;
 		}
 
 		$entry = [

--- a/inc/wizard/class-step-menu-setup.php
+++ b/inc/wizard/class-step-menu-setup.php
@@ -35,8 +35,14 @@ class Step_Menu_Setup {
 	public function run( array $payload ) {
 		$state           = $this->state_manager->get_state();
 		$generated_pages = is_array( $state['generated_pages'] ?? null ) ? $state['generated_pages'] : [];
+		$landing_pages   = is_array( $state['landing_pages'] ?? null ) ? $state['landing_pages'] : [];
 
-		if ( [] === $generated_pages ) {
+		// Pool may come from generated_pages and/or menu-eligible SEO landings.
+		// Do not fail solely because generated_pages is empty when landings exist.
+		// Ads remain excluded from the pool.
+		$page_pool = $this->build_page_pool( $generated_pages, $landing_pages );
+
+		if ( [] === $page_pool ) {
 			$this->state_manager->set_step_status( self::STEP, 'failed' );
 
 			return new \WP_Error( 'rms_wizard_no_generated_pages', \__( 'No pages found. Please complete the Generate Pages step first', 'simple-rms-theme' ), [ 'status' => 400 ] );
@@ -44,8 +50,8 @@ class Step_Menu_Setup {
 
 		$primary_input    = is_array( $payload['primary'] ?? null ) ? $payload['primary'] : ( is_array( $payload['primary_page_ids'] ?? null ) ? $payload['primary_page_ids'] : [] );
 		$mobile_input     = is_array( $payload['mobile'] ?? null ) ? $payload['mobile'] : ( is_array( $payload['mobile_page_ids'] ?? null ) ? $payload['mobile_page_ids'] : [] );
-		$primary_page_ids = $this->resolve_page_ids( $primary_input, $generated_pages );
-		$mobile_page_ids  = $this->resolve_page_ids( $mobile_input, $generated_pages );
+		$primary_page_ids = $this->resolve_page_ids( $primary_input, $page_pool );
+		$mobile_page_ids  = $this->resolve_page_ids( $mobile_input, $page_pool );
 
 		if ( [] === $primary_page_ids ) {
 			$this->state_manager->set_step_status( self::STEP, 'failed' );
@@ -89,11 +95,70 @@ class Step_Menu_Setup {
 
 		$this->menu_builder->assign_location( 'mobile', $mobile_menu_id );
 
+		// Mandatory safety net after destructive replace: eligible SEO present, Ads removed.
+		$configured_menu_ids = array_values(
+			array_unique(
+				array_filter(
+					[
+						$primary_menu_id,
+						$mobile_menu_id,
+					]
+				)
+			)
+		);
+		$landing_reconcile = $this->menu_builder->reconcile_landing_menu_items( $configured_menu_ids, $landing_pages );
+
+		// Fail-closed when Ads / ineligible landings could not be verified removed.
+		if ( empty( $landing_reconcile['verified'] ) ) {
+			$failed = is_array( $landing_reconcile['removal_failed_page_ids'] ?? null )
+				? array_values( $landing_reconcile['removal_failed_page_ids'] )
+				: [];
+
+			$this->state_manager->set_step_status( self::STEP, 'failed' );
+			$this->logger->log(
+				'error',
+				'Menu setup landing reconciliation failed Ads/ineligible removal verification.',
+				[
+					'menu_ids'                 => $configured_menu_ids,
+					'removal_failed_page_ids'  => $failed,
+					'landing_reconcile'        => $landing_reconcile,
+				]
+			);
+
+			return new \WP_Error(
+				'rms_wizard_menu_ads_removal_failed',
+				\__( 'Menu setup could not verify removal of Ads or ineligible landing pages from menus.', 'simple-rms-theme' ),
+				[
+					'status'                  => 500,
+					'removal_failed_page_ids' => $failed,
+					'landing_reconcile'       => $landing_reconcile,
+				]
+			);
+		}
+
+		// SEO append is best-effort: surface incomplete appends without failing the step.
+		$append_failed = is_array( $landing_reconcile['append_failed_page_ids'] ?? null )
+			? array_values( $landing_reconcile['append_failed_page_ids'] )
+			: [];
+
+		if ( [] !== $append_failed ) {
+			$this->logger->log(
+				'warning',
+				'Menu setup SEO landing menu append incomplete (best-effort; Ads removal verified).',
+				[
+					'menu_ids'               => $configured_menu_ids,
+					'append_failed_page_ids' => $append_failed,
+					'landing_reconcile'      => $landing_reconcile,
+				]
+			);
+		}
+
 		$menu_config = [
-			'primary_menu_id'  => $primary_menu_id,
-			'mobile_menu_id'   => $mobile_menu_id,
-			'locations'        => [ 'primary' => $primary_menu_id, 'mobile' => $mobile_menu_id ],
-			'deleted_menu_ids' => $deleted_menu_ids,
+			'primary_menu_id'    => $primary_menu_id,
+			'mobile_menu_id'     => $mobile_menu_id,
+			'locations'          => [ 'primary' => $primary_menu_id, 'mobile' => $mobile_menu_id ],
+			'deleted_menu_ids'   => $deleted_menu_ids,
+			'landing_reconcile'  => $landing_reconcile,
 		];
 
 		$state['menu_config'] = $menu_config;
@@ -104,8 +169,18 @@ class Step_Menu_Setup {
 		return $menu_config;
 	}
 
-	private function resolve_page_ids( array $selected, array $generated_pages ): array {
-		$generated = [];
+	/**
+	 * Build id/slug lookup from generated pages + menu-eligible SEO landings.
+	 *
+	 * Ads / menu_eligible=false landings are never added to the pool.
+	 *
+	 * @param array<int,array<string,mixed>> $generated_pages
+	 * @param array<int,array<string,mixed>> $landing_pages
+	 *
+	 * @return array<string,int>
+	 */
+	private function build_page_pool( array $generated_pages, array $landing_pages ): array {
+		$pool = [];
 
 		foreach ( $generated_pages as $page ) {
 			if ( ! is_array( $page ) || empty( $page['id'] ) ) {
@@ -118,20 +193,57 @@ class Step_Menu_Setup {
 				continue;
 			}
 
-			$generated[ (string) $id ] = $id;
+			$pool[ (string) $id ] = $id;
 
 			if ( ! empty( $page['slug'] ) ) {
-				$generated[ \sanitize_title( (string) $page['slug'] ) ] = $id;
+				$pool[ \sanitize_title( (string) $page['slug'] ) ] = $id;
 			}
 		}
 
+		foreach ( $landing_pages as $landing ) {
+			if ( ! is_array( $landing ) || empty( $landing['id'] ) ) {
+				continue;
+			}
+
+			$id   = \absint( $landing['id'] );
+			$type = \sanitize_key( (string) ( $landing['landing_type'] ?? '' ) );
+			$eligible = array_key_exists( 'menu_eligible', $landing )
+				? (bool) $landing['menu_eligible']
+				: ( 'seo' === $type );
+
+			// Ads and ineligible landings must never join the menu pool.
+			if ( $id <= 0 || 'seo' !== $type || ! $eligible ) {
+				continue;
+			}
+
+			if ( 'page' !== \get_post_type( $id ) ) {
+				continue;
+			}
+
+			$pool[ (string) $id ] = $id;
+
+			if ( ! empty( $landing['slug'] ) ) {
+				$pool[ \sanitize_title( (string) $landing['slug'] ) ] = $id;
+			}
+		}
+
+		return $pool;
+	}
+
+	/**
+	 * @param array<int|string,mixed> $selected
+	 * @param array<string,int>       $pool
+	 *
+	 * @return array<int,int>
+	 */
+	private function resolve_page_ids( array $selected, array $pool ): array {
 		$page_ids = [];
 
 		foreach ( $selected as $item ) {
 			$key = is_numeric( $item ) ? (string) \absint( $item ) : \sanitize_title( (string) $item );
 
-			if ( isset( $generated[ $key ] ) && ! in_array( $generated[ $key ], $page_ids, true ) ) {
-				$page_ids[] = $generated[ $key ];
+			if ( isset( $pool[ $key ] ) && ! in_array( $pool[ $key ], $page_ids, true ) ) {
+				$page_ids[] = $pool[ $key ];
 			}
 		}
 

--- a/inc/wizard/class-wizard-unlock-controller.php
+++ b/inc/wizard/class-wizard-unlock-controller.php
@@ -22,9 +22,9 @@ class Wizard_Unlock_Controller {
 	/**
 	 * Whether user-facing controlled unlock is enabled.
 	 *
-	 * TODO(Phase 2 task 2.6): set true when the generate-pages landing deletion guard ships.
+	 * Enabled together with the generate-pages landing deletion guard (Phase 2 task 2.6).
 	 */
-	public const CONTROLLED_UNLOCK_ENABLED = false;
+	public const CONTROLLED_UNLOCK_ENABLED = true;
 
 	private $state_manager;
 	private $logger;

--- a/inc/wizard/class-yoast-meta-writer.php
+++ b/inc/wizard/class-yoast-meta-writer.php
@@ -10,16 +10,46 @@ namespace Inc\Wizard;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Writes Yoast SEO title and description meta to generated pages.
+ * Writes Yoast SEO title, description, and robots meta for wizard pages.
  */
 class Yoast_Meta_Writer {
 	public const TITLE_KEY       = '_yoast_wpseo_title';
 	public const DESCRIPTION_KEY = '_yoast_wpseo_metadesc';
+	public const NOINDEX_KEY     = '_yoast_wpseo_meta-robots-noindex';
+
+	/** Common SERP-friendly max length for SEO titles. */
+	public const TITLE_MAX_LENGTH = 60;
+
+	/** Common SERP-friendly max length for meta descriptions. */
+	public const DESCRIPTION_MAX_LENGTH = 155;
 
 	private $logger;
 
+	/** @var bool Whether missing-Yoast was already logged this request. */
+	private static $missing_yoast_logged = false;
+
 	public function __construct( ?Logger $logger = null ) {
 		$this->logger = $logger ?? new Logger();
+	}
+
+	/**
+	 * Whether Yoast SEO appears active for optional title/metadesc writes.
+	 */
+	public static function is_yoast_active(): bool {
+		if ( defined( 'WPSEO_VERSION' ) ) {
+			return true;
+		}
+
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			$plugin_php = \ABSPATH . 'wp-admin/includes/plugin.php';
+
+			if ( is_readable( $plugin_php ) ) {
+				require_once $plugin_php;
+			}
+		}
+
+		// Yoast package slug is wordpress-seo/wp-seo.php.
+		return function_exists( 'is_plugin_active' ) && \is_plugin_active( 'wordpress-seo/wp-seo.php' );
 	}
 
 	/**
@@ -48,5 +78,174 @@ class Yoast_Meta_Writer {
 		$this->logger->log( $written ? 'info' : 'warning', $written ? 'Yoast metadata written.' : 'No Yoast metadata values supplied.', [ 'post_id' => $post_id ] );
 
 		return $written;
+	}
+
+	/**
+	 * Write per-landing Yoast title/metadesc from keyword + type when Yoast is active.
+	 *
+	 * When Yoast is absent, skips title/metadesc writes and logs once per request.
+	 *
+	 * @param int    $post_id         Landing page ID.
+	 * @param string $primary_keyword Primary keyword.
+	 * @param string $landing_type    seo|ads.
+	 * @param string $title           Optional page title for fallback copy.
+	 *
+	 * @return bool True when title/metadesc were written.
+	 */
+	public function write_landing_seo( int $post_id, string $primary_keyword, string $landing_type, string $title = '' ): bool {
+		$post_id         = \absint( $post_id );
+		$primary_keyword = \sanitize_text_field( $primary_keyword );
+		$landing_type    = in_array( $landing_type, [ 'seo', 'ads' ], true ) ? $landing_type : 'seo';
+		$title           = \sanitize_text_field( $title );
+
+		if ( $post_id <= 0 || '' === $primary_keyword ) {
+			return false;
+		}
+
+		if ( ! self::is_yoast_active() ) {
+			if ( ! self::$missing_yoast_logged ) {
+				$this->logger->log(
+					'info',
+					'Yoast SEO is not active; skipping landing title/metadesc writes.',
+					[ 'post_id' => $post_id ]
+				);
+				self::$missing_yoast_logged = true;
+			}
+
+			return false;
+		}
+
+		$company = '';
+
+		if ( function_exists( 'get_field' ) ) {
+			$company = \sanitize_text_field( (string) \get_field( 'company_name', 'option' ) );
+		}
+
+		if ( '' === $company ) {
+			$company = \sanitize_text_field( (string) \get_bloginfo( 'name' ) );
+		}
+
+		$suffix = 'ads' === $landing_type
+			? \__( 'Get a free estimate', 'simple-rms-theme' )
+			: \__( 'Trusted local experts', 'simple-rms-theme' );
+
+		$meta_title = trim(
+			sprintf(
+				/* translators: 1: primary keyword, 2: company or site name. */
+				\__( '%1$s | %2$s', 'simple-rms-theme' ),
+				$primary_keyword,
+				'' !== $company ? $company : ( '' !== $title ? $title : \get_bloginfo( 'name' ) )
+			)
+		);
+
+		$meta_desc = trim(
+			sprintf(
+				/* translators: 1: primary keyword, 2: short CTA/trust phrase, 3: company name. */
+				\__( 'Learn about %1$s. %2$s%3$s', 'simple-rms-theme' ),
+				$primary_keyword,
+				$suffix,
+				'' !== $company ? ' — ' . $company : ''
+			)
+		);
+
+		// Keep within common SERP-friendly bounds.
+		if ( function_exists( 'mb_substr' ) ) {
+			$meta_title = \mb_substr( $meta_title, 0, self::TITLE_MAX_LENGTH );
+			$meta_desc  = \mb_substr( $meta_desc, 0, self::DESCRIPTION_MAX_LENGTH );
+		} else {
+			$meta_title = substr( $meta_title, 0, self::TITLE_MAX_LENGTH );
+			$meta_desc  = substr( $meta_desc, 0, self::DESCRIPTION_MAX_LENGTH );
+		}
+
+		return $this->write(
+			$post_id,
+			[
+				'title'       => $meta_title,
+				'description' => $meta_desc,
+			]
+		);
+	}
+
+	/**
+	 * Set or clear Ads noindex meta and verify read-back.
+	 *
+	 * Always writes the Yoast noindex post meta key (storage), independent of Yoast being active.
+	 * wp_robots in wizard-init.php provides the second protection layer for Ads landings.
+	 *
+	 * @param int  $post_id  Landing page ID.
+	 * @param bool $noindex  True to force noindex=1, false to clear.
+	 *
+	 * @return true|\WP_Error
+	 */
+	public function set_noindex( int $post_id, bool $noindex ) {
+		$post_id = \absint( $post_id );
+
+		if ( $post_id <= 0 ) {
+			return new \WP_Error(
+				'rms_wizard_noindex_invalid_post',
+				\__( 'Invalid landing page for noindex sync.', 'simple-rms-theme' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		if ( $noindex ) {
+			\update_post_meta( $post_id, self::NOINDEX_KEY, '1' );
+			$read_back = (string) \get_post_meta( $post_id, self::NOINDEX_KEY, true );
+
+			if ( '1' !== $read_back ) {
+				$this->logger->log(
+					'error',
+					'Ads landing noindex meta failed read-back.',
+					[
+						'post_id'   => $post_id,
+						'read_back' => $read_back,
+					]
+				);
+
+				return new \WP_Error(
+					'rms_wizard_ads_noindex_failed',
+					\__( 'Ads landing noindex meta could not be verified. The landing was not marked complete.', 'simple-rms-theme' ),
+					[
+						'status'  => 500,
+						'post_id' => $post_id,
+					]
+				);
+			}
+
+			$this->logger->log( 'info', 'Ads landing noindex meta written and verified.', [ 'post_id' => $post_id ] );
+
+			return true;
+		}
+
+		\delete_post_meta( $post_id, self::NOINDEX_KEY );
+		$read_back = (string) \get_post_meta( $post_id, self::NOINDEX_KEY, true );
+
+		if ( '1' === $read_back ) {
+			$this->logger->log(
+				'error',
+				'SEO landing noindex meta could not be cleared.',
+				[ 'post_id' => $post_id ]
+			);
+
+			return new \WP_Error(
+				'rms_wizard_seo_noindex_clear_failed',
+				\__( 'SEO landing noindex meta could not be cleared.', 'simple-rms-theme' ),
+				[
+					'status'  => 500,
+					'post_id' => $post_id,
+				]
+			);
+		}
+
+		$this->logger->log( 'info', 'SEO landing noindex meta cleared.', [ 'post_id' => $post_id ] );
+
+		return true;
+	}
+
+	/**
+	 * Read whether noindex meta is currently set to 1.
+	 */
+	public function has_noindex( int $post_id ): bool {
+		return '1' === (string) \get_post_meta( \absint( $post_id ), self::NOINDEX_KEY, true );
 	}
 }

--- a/inc/wizard/wizard-init.php
+++ b/inc/wizard/wizard-init.php
@@ -101,6 +101,161 @@ if ( Inc\Wizard\Wizard_Unlock_Controller::is_controlled_unlock_enabled() ) {
 }
 add_action( 'admin_post_' . Inc\Wizard\Wizard_Unlock_Controller::RELOCK_ACTION, 'rms_wizard_handle_relock_action' );
 
+// Always-loaded Ads landing robots + sitemap protections (front-end + sitemaps).
+add_filter( 'wp_robots', 'rms_wizard_ads_landing_wp_robots' );
+add_filter( 'wp_sitemaps_posts_query_args', 'rms_wizard_exclude_ads_landings_from_wp_sitemap', 10, 2 );
+add_filter( 'wpseo_exclude_from_sitemap_by_post_ids', 'rms_wizard_exclude_ads_landings_from_yoast_sitemap' );
+add_filter( 'wpseo_sitemap_entry', 'rms_wizard_filter_yoast_sitemap_entry', 10, 3 );
+
+/**
+ * Force noindex for Ads landings on the landing template (second protection layer).
+ *
+ * Requires ALL of: is_page(), valid queried ID, template pages/landing-page.php,
+ * and rms_landing_type === ads. SEO landings on the same template are untouched.
+ *
+ * @param array<string,bool|string> $robots Robots directives.
+ *
+ * @return array<string,bool|string>
+ */
+function rms_wizard_ads_landing_wp_robots( array $robots ): array {
+	if ( ! is_page() ) {
+		return $robots;
+	}
+
+	$post_id = (int) get_queried_object_id();
+
+	if ( $post_id <= 0 ) {
+		return $robots;
+	}
+
+	$template = (string) get_page_template_slug( $post_id );
+
+	if ( 'pages/landing-page.php' !== $template ) {
+		return $robots;
+	}
+
+	$landing_type = sanitize_key( (string) get_post_meta( $post_id, 'rms_landing_type', true ) );
+
+	if ( 'ads' !== $landing_type ) {
+		return $robots;
+	}
+
+	$robots['noindex']  = true;
+	$robots['nofollow'] = true;
+
+	return $robots;
+}
+
+/**
+ * Exclude Ads landings from the core WordPress XML sitemap query.
+ *
+ * @param array<string,mixed> $args      Query args.
+ * @param string              $post_type Post type.
+ *
+ * @return array<string,mixed>
+ */
+function rms_wizard_exclude_ads_landings_from_wp_sitemap( array $args, string $post_type ): array {
+	if ( 'page' !== $post_type ) {
+		return $args;
+	}
+
+	$meta_query = isset( $args['meta_query'] ) && is_array( $args['meta_query'] ) ? $args['meta_query'] : [];
+
+	$meta_query[] = [
+		'relation' => 'OR',
+		[
+			'key'     => 'rms_landing_type',
+			'compare' => 'NOT EXISTS',
+		],
+		[
+			'key'     => 'rms_landing_type',
+			'value'   => 'ads',
+			'compare' => '!=',
+		],
+	];
+
+	$args['meta_query'] = $meta_query;
+
+	return $args;
+}
+
+/**
+ * Collect Ads landing page IDs for Yoast sitemap exclusion.
+ *
+ * @return array<int,int>
+ */
+function rms_wizard_ads_landing_page_ids(): array {
+	static $ids = null;
+
+	if ( null !== $ids ) {
+		return $ids;
+	}
+
+	$query = new WP_Query(
+		[
+			'post_type'              => 'page',
+			'post_status'            => 'publish',
+			'posts_per_page'         => -1,
+			'fields'                 => 'ids',
+			'no_found_rows'          => true,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+			'meta_key'               => 'rms_landing_type',
+			'meta_value'             => 'ads',
+		]
+	);
+
+	$ids = array_map( 'absint', is_array( $query->posts ) ? $query->posts : [] );
+
+	return $ids;
+}
+
+/**
+ * Exclude Ads landings from Yoast sitemaps when the API is available.
+ *
+ * @param array<int,int> $excluded_ids Existing excluded post IDs.
+ *
+ * @return array<int,int>
+ */
+function rms_wizard_exclude_ads_landings_from_yoast_sitemap( $excluded_ids ): array {
+	$excluded_ids = is_array( $excluded_ids ) ? $excluded_ids : [];
+	$ads_ids      = rms_wizard_ads_landing_page_ids();
+
+	if ( [] === $ads_ids ) {
+		return $excluded_ids;
+	}
+
+	return array_values( array_unique( array_merge( array_map( 'absint', $excluded_ids ), $ads_ids ) ) );
+}
+
+/**
+ * Defense-in-depth: drop Ads landings from Yoast sitemap entries.
+ *
+ * @param array<string,mixed>|false $url    Sitemap entry.
+ * @param string                    $type   Object type.
+ * @param object|null               $object Post-like object.
+ *
+ * @return array<string,mixed>|false
+ */
+function rms_wizard_filter_yoast_sitemap_entry( $url, $type, $object ) {
+	if ( false === $url || ! is_object( $object ) || empty( $object->ID ) ) {
+		return $url;
+	}
+
+	if ( 'post' !== $type && 'page' !== $type ) {
+		// Yoast uses 'post' for pages in some versions; also check post_type.
+		if ( empty( $object->post_type ) || 'page' !== $object->post_type ) {
+			return $url;
+		}
+	}
+
+	if ( 'ads' === sanitize_key( (string) get_post_meta( (int) $object->ID, 'rms_landing_type', true ) ) ) {
+		return false;
+	}
+
+	return $url;
+}
+
 /**
  * Handle controlled unlock form posts from the Setup Wizard admin notice.
  *
@@ -197,23 +352,25 @@ function rms_wizard_render_admin_page(): void {
 	$force_unlocked     = ! empty( $state['force_unlocked'] );
 	$unlock_ui_enabled  = ! empty( $state['controlled_unlock_ui'] );
 	$steps              = [
-		'dependencies'      => __( 'Dependencies', 'simple-rms-theme' ),
-		'acf-import'        => __( 'ACF Import', 'simple-rms-theme' ),
-		'client-data'       => __( 'Client Data', 'simple-rms-theme' ),
-		'generate-pages'    => __( 'Generate Pages', 'simple-rms-theme' ),
-		'menu-setup'        => __( 'Menu Setup', 'simple-rms-theme' ),
-		'ia-generation'     => __( 'IA Generation', 'simple-rms-theme' ),
-		'home-page-builder' => __( 'Home Page Builder', 'simple-rms-theme' ),
+		'dependencies'         => __( 'Dependencies', 'simple-rms-theme' ),
+		'acf-import'           => __( 'ACF Import', 'simple-rms-theme' ),
+		'client-data'          => __( 'Client Data', 'simple-rms-theme' ),
+		'generate-pages'       => __( 'Generate Pages', 'simple-rms-theme' ),
+		'menu-setup'           => __( 'Menu Setup', 'simple-rms-theme' ),
+		'ia-generation'        => __( 'IA Generation', 'simple-rms-theme' ),
+		'home-page-builder'    => __( 'Home Page Builder', 'simple-rms-theme' ),
+		'landing-page-builder' => __( 'Landing Page Builder', 'simple-rms-theme' ),
 	];
 	$step_slugs = array_keys( $steps );
 	$descriptions = [
-		'dependencies'      => __( 'Check and install the required WordPress plugins before continuing.', 'simple-rms-theme' ),
-		'acf-import'        => __( 'Import ACF JSON field groups from the theme acf-json directory.', 'simple-rms-theme' ),
-		'client-data'       => __( 'Save contractor business information into the theme options.', 'simple-rms-theme' ),
-		'generate-pages'    => __( 'Add the site pages to create, then assign the Home and optional Blog roles.', 'simple-rms-theme' ),
-		'menu-setup'        => __( 'Choose generated pages for the primary and mobile menus.', 'simple-rms-theme' ),
-		'ia-generation'     => __( 'Configure the AI provider, model, and encrypted credentials for later content generation.', 'simple-rms-theme' ),
-		'home-page-builder' => __( 'Choose Home page sections and build them from the saved client data.', 'simple-rms-theme' ),
+		'dependencies'         => __( 'Check and install the required WordPress plugins before continuing.', 'simple-rms-theme' ),
+		'acf-import'           => __( 'Import ACF JSON field groups from the theme acf-json directory.', 'simple-rms-theme' ),
+		'client-data'          => __( 'Save contractor business information into the theme options.', 'simple-rms-theme' ),
+		'generate-pages'       => __( 'Add the site pages to create, then assign the Home and optional Blog roles.', 'simple-rms-theme' ),
+		'menu-setup'           => __( 'Choose generated pages for the primary and mobile menus.', 'simple-rms-theme' ),
+		'ia-generation'        => __( 'Configure the AI provider, model, and encrypted credentials for later content generation.', 'simple-rms-theme' ),
+		'home-page-builder'    => __( 'Choose Home page sections and build them from the saved client data.', 'simple-rms-theme' ),
+		'landing-page-builder' => __( 'Create SEO and Ads landing pages with keywords, reusable sections, and noindex controls.', 'simple-rms-theme' ),
 	];
 	?>
 	<div
@@ -280,7 +437,7 @@ function rms_wizard_render_admin_page(): void {
 					<?php esc_html_e( 'The setup wizard has already been completed and is read-only.', 'simple-rms-theme' ); ?>
 				</p>
 				<p class="description">
-					<?php esc_html_e( 'Controlled unlock will be available after landing page protection ships. Developers may define RMS_WIZARD_FORCE as true to bypass the lock in local environments.', 'simple-rms-theme' ); ?>
+					<?php esc_html_e( 'Developers may define RMS_WIZARD_FORCE as true to bypass the lock in local environments.', 'simple-rms-theme' ); ?>
 				</p>
 			</div>
 		<?php endif; ?>
@@ -361,6 +518,8 @@ function rms_wizard_render_admin_page(): void {
 							<?php rms_wizard_render_ia_generation_form(); ?>
 						<?php elseif ( 'home-page-builder' === $slug ) : ?>
 							<?php rms_wizard_render_home_page_builder_form(); ?>
+						<?php elseif ( 'landing-page-builder' === $slug ) : ?>
+							<?php rms_wizard_render_landing_page_builder_form(); ?>
 						<?php endif; ?>
 
 						<div class="rms-wizard-actions rms-wizard-step-actions">
@@ -489,7 +648,7 @@ function rms_wizard_render_menu_setup_form(): void {
 	<form class="rms-wizard-fields rms-wizard-guided-form" data-wizard-menu-form>
 		<div class="rms-wizard-guided-panel">
 			<p class="rms-wizard-fields__intro">
-				<?php esc_html_e( 'Menus are built only from pages created by the Generate Pages step. Refresh the state after generating pages if this list is empty.', 'simple-rms-theme' ); ?>
+				<?php esc_html_e( 'Menus are built from Generate Pages results plus menu-eligible SEO landings. Ads landings are excluded automatically. Refresh the state after generating pages or landings if this list is empty.', 'simple-rms-theme' ); ?>
 			</p>
 
 			<div class="notice notice-warning inline rms-wizard-menu-empty" data-wizard-menu-empty hidden>
@@ -675,6 +834,133 @@ function rms_wizard_render_home_page_builder_form(): void {
 					</div>
 					<button type="button" class="button-link-delete rms-wizard-home-section-row__remove" data-wizard-remove-home-section><?php esc_html_e( 'Remove', 'simple-rms-theme' ); ?></button>
 				</article>
+			</template>
+		</div>
+	</form>
+	<?php
+}
+
+/**
+ * Render the guided Landing Page Builder form.
+ *
+ * @return void
+ */
+function rms_wizard_render_landing_page_builder_form(): void {
+	$sections        = rms_wizard_home_section_choices();
+	$default_layouts = [
+		'hero',
+		'seo-content',
+		'vision-mission-v1',
+		'badges',
+		'portfolio-v1',
+		'seo-content',
+		'testimonials-v1',
+		'seo-content',
+	];
+	$section_options = array_values(
+		array_map(
+			static function ( array $section ) use ( $default_layouts ): array {
+				$layout = (string) $section['name'];
+
+				return [
+					'layout'              => $layout,
+					'label'               => $section['label'],
+					'description'         => $section['description'],
+					'is_keyword_layout'   => in_array( $layout, [ 'hero', 'seo-content' ], true ),
+					'is_default'          => in_array( $layout, $default_layouts, true ),
+					'default_item_count'  => rms_wizard_home_section_default_item_count( $layout ),
+					'has_fillable_fields' => rms_wizard_home_section_has_fillable_fields( $layout ),
+				];
+			},
+			$sections
+		)
+	);
+	?>
+	<form class="rms-wizard-fields rms-wizard-guided-form" data-wizard-landing-page-builder-form>
+		<div class="rms-wizard-guided-panel">
+			<p class="rms-wizard-fields__intro">
+				<?php esc_html_e( 'Create one or more SEO or Ads landing pages. Only Hero and SEO Content receive keywords; reusable sections stay neutral and pull from the canonical store. Ads landings are noindex and never auto-added to menus.', 'simple-rms-theme' ); ?>
+			</p>
+
+			<label class="rms-wizard-landing-skip-all">
+				<input type="checkbox" name="skip_all" value="1" data-wizard-landing-skip-all>
+				<span><?php esc_html_e( 'Skip landing pages for now (complete this step with zero landings)', 'simple-rms-theme' ); ?></span>
+			</label>
+
+			<script type="application/json" data-wizard-landing-sections><?php echo wp_json_encode( $section_options, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT ); ?></script>
+			<script type="application/json" data-wizard-landing-default-layouts><?php echo wp_json_encode( $default_layouts, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT ); ?></script>
+
+			<div class="rms-wizard-landing-toolbar">
+				<button type="button" class="button button-secondary" data-wizard-add-landing><?php esc_html_e( 'Add landing', 'simple-rms-theme' ); ?></button>
+				<p class="rms-wizard-field__instructions"><?php esc_html_e( 'Duplicate a row to start a new landing with a fresh identity. Existing landings hydrate from wizard state on load.', 'simple-rms-theme' ); ?></p>
+			</div>
+
+			<div class="rms-wizard-landing-builder" data-wizard-landing-builder>
+				<div class="rms-wizard-landing-rows" role="list" data-wizard-landing-rows></div>
+				<p class="rms-wizard-landing-builder__empty" data-wizard-landing-empty><?php esc_html_e( 'No landings added yet. Add a landing or skip this step.', 'simple-rms-theme' ); ?></p>
+			</div>
+
+			<div class="rms-wizard-landing-replace-panel" data-wizard-landing-replace-panel>
+				<strong><?php esc_html_e( 'Replace canonical reusable sections', 'simple-rms-theme' ); ?></strong>
+				<p class="rms-wizard-field__instructions"><?php esc_html_e( 'Optional. Mark reusable layouts to regenerate and overwrite the shared canonical store. Requires confirmation when running the step.', 'simple-rms-theme' ); ?></p>
+				<div class="rms-wizard-landing-replace-list" data-wizard-landing-replace-list></div>
+			</div>
+
+			<template data-wizard-landing-row-template>
+				<article class="rms-wizard-landing-row" role="listitem" data-wizard-landing-row>
+					<input type="hidden" name="landings[__INDEX__][id]" value="" data-wizard-landing-id>
+					<input type="hidden" name="landings[__INDEX__][landing_key]" value="" data-wizard-landing-key>
+					<header class="rms-wizard-landing-row__header">
+						<strong data-wizard-landing-heading><?php esc_html_e( 'Landing', 'simple-rms-theme' ); ?></strong>
+						<div class="rms-wizard-landing-row__actions">
+							<button type="button" class="button-link" data-wizard-duplicate-landing><?php esc_html_e( 'Duplicate', 'simple-rms-theme' ); ?></button>
+							<button type="button" class="button-link-delete" data-wizard-remove-landing><?php esc_html_e( 'Remove', 'simple-rms-theme' ); ?></button>
+						</div>
+					</header>
+					<div class="rms-wizard-landing-row__grid">
+						<div class="rms-wizard-field">
+							<label for="rms-wizard-landing-title-__INDEX__"><?php esc_html_e( 'Title', 'simple-rms-theme' ); ?></label>
+							<input id="rms-wizard-landing-title-__INDEX__" type="text" name="landings[__INDEX__][title]" data-wizard-landing-title placeholder="<?php esc_attr_e( 'Kitchen Remodel Landing', 'simple-rms-theme' ); ?>">
+						</div>
+						<div class="rms-wizard-field">
+							<label for="rms-wizard-landing-slug-__INDEX__"><?php esc_html_e( 'Slug', 'simple-rms-theme' ); ?></label>
+							<input id="rms-wizard-landing-slug-__INDEX__" type="text" name="landings[__INDEX__][slug]" data-wizard-landing-slug data-wizard-slug-auto="1" placeholder="<?php esc_attr_e( 'kitchen-remodel', 'simple-rms-theme' ); ?>">
+						</div>
+						<div class="rms-wizard-field">
+							<label for="rms-wizard-landing-type-__INDEX__"><?php esc_html_e( 'Landing type', 'simple-rms-theme' ); ?></label>
+							<select id="rms-wizard-landing-type-__INDEX__" name="landings[__INDEX__][landing_type]" data-wizard-landing-type>
+								<option value="seo"><?php esc_html_e( 'SEO (indexable, menu-eligible)', 'simple-rms-theme' ); ?></option>
+								<option value="ads"><?php esc_html_e( 'Ads (noindex, orphan)', 'simple-rms-theme' ); ?></option>
+							</select>
+						</div>
+						<div class="rms-wizard-field">
+							<label for="rms-wizard-landing-keyword-__INDEX__"><?php esc_html_e( 'Primary keyword', 'simple-rms-theme' ); ?></label>
+							<input id="rms-wizard-landing-keyword-__INDEX__" type="text" name="landings[__INDEX__][primary_keyword]" data-wizard-landing-primary-keyword placeholder="<?php esc_attr_e( 'kitchen remodel near me', 'simple-rms-theme' ); ?>">
+						</div>
+						<div class="rms-wizard-field rms-wizard-landing-row__subkeywords">
+							<label for="rms-wizard-landing-subkeywords-__INDEX__"><?php esc_html_e( 'Subkeywords (comma-separated, max 10)', 'simple-rms-theme' ); ?></label>
+							<input id="rms-wizard-landing-subkeywords-__INDEX__" type="text" name="landings[__INDEX__][subkeywords]" data-wizard-landing-subkeywords placeholder="<?php esc_attr_e( 'cabinet refinishing, countertop install', 'simple-rms-theme' ); ?>">
+						</div>
+					</div>
+					<div class="rms-wizard-landing-sections" data-wizard-landing-sections-list>
+						<div class="rms-wizard-landing-sections__header">
+							<strong><?php esc_html_e( 'Sections', 'simple-rms-theme' ); ?></strong>
+							<button type="button" class="button-link" data-wizard-add-landing-section><?php esc_html_e( 'Add section', 'simple-rms-theme' ); ?></button>
+						</div>
+						<div class="rms-wizard-landing-section-rows" data-wizard-landing-section-rows></div>
+					</div>
+				</article>
+			</template>
+
+			<template data-wizard-landing-section-row-template>
+				<div class="rms-wizard-landing-section-row" data-wizard-landing-section-row>
+					<select name="landings[__LINDEX__][sections][__SINDEX__][layout]" data-wizard-landing-section-layout></select>
+					<label class="rms-wizard-landing-section-override">
+						<input type="checkbox" name="landings[__LINDEX__][sections][__SINDEX__][override_canonical]" value="1" data-wizard-landing-section-override>
+						<span><?php esc_html_e( 'Override canonical (neutral regen, does not write store)', 'simple-rms-theme' ); ?></span>
+					</label>
+					<button type="button" class="button-link-delete" data-wizard-remove-landing-section><?php esc_html_e( 'Remove', 'simple-rms-theme' ); ?></button>
+				</div>
 			</template>
 		</div>
 	</form>

--- a/openspec/changes/wizard-landing-page-builder/apply-progress.md
+++ b/openspec/changes/wizard-landing-page-builder/apply-progress.md
@@ -1,9 +1,9 @@
 # Apply Progress: wizard-landing-page-builder
 
 **Mode**: Standard  
-**Batch**: Phase 2 Backend Landing Slice (PR2) + PR2 review-blocker fixes + remaining PR2 reliability follow-up + equivalence/`build_page` reliability  
-**Date**: 2026-07-21  
-**Branch**: `feat/wizard-landing-backend` (feature-branch-chain, base = PR1 foundation)
+**Batch**: PR3 remaining risk blockers + SEO append feedback  
+**Date**: 2026-07-22  
+**Branch**: `feat/wizard-landing-ui` (feature-branch-chain, base = PR2 `feat/wizard-landing-backend`)
 
 ## Completed Tasks (cumulative)
 
@@ -21,118 +21,85 @@
 - [x] 2.5 `Content_Builder` whitelist `meta_input` (`_wp_page_template`, `rms_landing_type`)
 - [x] 2.6 `delete_unselected_pages()` landing guard + controlled unlock enabled
 
-### Phase 2 PR2 review-blocker follow-up
-- [x] Deactivate live required/dispatch for `landing-page-builder` until Phase 3 UI+noindex
+### Phase 2 PR2 review-blocker / reliability follow-up
+- [x] Deactivate live required/dispatch until Phase 3 (then re-activated in 3.7)
 - [x] Identity cross-pair validation + stricter slug collisions
-- [x] Keyword AI failure → `WP_Error` (or preserve existing landing); no placeholder publish
-- [x] Multi-landing partial-failure state persistence before failed status
-- [x] Critical persistence post-state checks (state, status, meta, canonical write)
-- [x] Reviewer/JSON observability + neutral priors for reusable/canonical paths
+- [x] Keyword AI failure → `WP_Error` (or preserve existing landing)
+- [x] Multi-landing partial-failure state persistence
+- [x] Critical persistence post-state checks
+- [x] Reviewer/JSON observability + neutral priors
+- [x] generate-pages residual landing exclusion (fail-closed)
+- [x] build_one_landing exception → WP_Error + partial path
+- [x] try_preserve checks update/meta results
+- [x] landing_pages_equivalent expanded
+- [x] Local try/catch around `build_page()`
 
-### Phase 2 PR2 remaining reliability follow-up
-- [x] `generate-pages` excludes residual SEO/Ads landings from select/update/Home-Blog assignment (fail-closed `WP_Error`); deletion guard retained
-- [x] `build_one_landing()` thrown exceptions converted to `WP_Error` + partial persistence path
-- [x] `try_preserve_existing_landing()` checks `wp_update_post()` / meta results (no false preserve success)
-- [x] Document duplicated Home/Landing helper families + extraction plan after PR3/before archive
-- [x] `landing_pages_equivalent()` expanded beyond id/key/slug/type (title, keywords, menu_eligible, generated_at, preserved)
-- [x] Local try/catch around `Content_Builder::build_page()` with post-ID recovery + contextual `WP_Error` (outer partial recovery unchanged)
+### Phase 3
+- [x] 3.1 `Menu_Builder`: idempotent `append_page_items()`, `remove_page_items()`, `reconcile_landing_menu_items()`
+- [x] 3.2 `Step_Menu_Setup`: merge eligible SEO landings, exclude Ads, post-replace reconciliation
+- [x] 3.3 Yoast title/metadesc + noindex write/read-back; `wp_robots`; WP/Yoast sitemap Ads exclusion
+- [x] 3.4 Admin TS: landing collector, keyword validation, skip-all, identity hydration, duplicate reset, unlock-aware lock UI, replace-canonical modal
+- [x] 3.5 Admin SCSS: landing + unlock states
+- [x] 3.6 `pages/landing-page.php`: flexible `page_sections` + breadcrumb once after first Hero
+- [x] 3.7 Atomic activation: `landing-page-builder` in `REQUIRED_STEPS` + `DISPATCHABLE_STEPS` with visible UI + final-state sync
 
-Phase 3/4 tasks remain incomplete (including 3.7 activation).
+### PR3 review-blocker / high-value warning fixes (prior batch)
+- [x] BLOCKER: `skip_all` reconciles final-state (noindex/menu) for existing landings before complete; fails closed on sync error; no-op when none exist
+- [x] BLOCKER: post-publish failure path best-effort Ads final-state protection (recover post_id → noindex + menu remove); logs success/fail; still returns original error
+- [x] WARNING: `remove_page_items` read-back verification; Ads/ineligible removal fail-closed in landing final-state + Menu Setup reconcile
+- [x] WARNING: Menu Setup builds pool from eligible landings even when `generated_pages` empty; Ads still excluded
+- [x] WARNING: `landing-page.php` guards ACF helpers with `function_exists` before flexible loop
+- [x] Docs: JSDoc on `getGeneratedPages()`; breadcrumb behavior documented; blank lines cleaned; no-runner limitation kept
 
-## Phase 1 Review Follow-up Fixes (preserved)
+### PR3 remaining risk blockers (this batch)
+- [x] BLOCKER: `landing-page.php` ACF-missing path no longer loads template parts that call `get_sub_field()`; minimal title/content fallback when ACF absent; hardcoded section order preserved when ACF present but `page_sections` empty; flexible path unchanged when rows exist
+- [x] BLOCKER: `try_preserve_existing_landing()` early failures (`wp_update_post` error, invalid update result, `ensure_landing_meta` failure) call `protect_ads_final_state_best_effort()` before returning original error (logs post_id/landing_key/slug via protection helper)
+- [x] WARNING: SEO menu append returns structured result + read-back; failures logged as warning (best-effort). Ads menu removal remains fail-closed. Reconcile exposes `append_failed_page_ids` without flipping removal `verified`
+- [x] Minor: JSDoc on `getMenuEligibleLandings()`; Yoast title/description max lengths as named constants
 
-| Finding | Severity | Fix |
-|---------|----------|-----|
-| `landing-page-builder` required before runtime | BLOCKER | Removed from active `REQUIRED_STEPS` in Phase 1 |
-| Canonical store nondeterministic persistence | WARNING | Cache mutates only after successful `update_option()` or verified equal full post-state entry |
-| Unlock/relock nondeterministic persistence | WARNING | Post-state option equality checks |
-| Premature `landing_page_builder` alias pollutes state | WARNING | Unknown-step reject before status writes |
-| Stale unlock marker bypasses lock | BLOCKER | `has_unlock_marker()` vs effective `is_unlocked()` |
-| Completion flag SoT | WARNING | `State_Manager::has_completion_flag()` only |
+Phase 4 verification tasks remain incomplete (manual WP Admin scenarios).
 
-## Phase 2 PR2 Review Blocker Fixes
-
-| Finding | Severity | Fix |
-|---------|----------|-----|
-| Live backend can publish Ads indexable before Phase 3 noindex | BLOCKER | Safer smaller fix: keep `Step_Landing_Page_Builder` implemented but remove `landing-page-builder` from `REQUIRED_STEPS` + `DISPATCHABLE_STEPS`. Dispatch case + alias retained for Phase 3 atomic activation (task 3.7). Existing 7-step UI completion unchanged. |
-| UI/required mismatch (7-step UI vs 8th required) | BLOCKER | Same deactivation; completion stays 7 required steps until UI can send payload/`skip_all`. |
-| Identity mismatch id+key | BLOCKER | `match_existing_landing()` rejects stale cross-pair when both non-empty id and landing_key disagree; order id → key → slug; slug collisions reject other pages (landing or not) when id already matched. |
-| Keyword AI failure publishes placeholders | BLOCKER | `generate_section_copy(..., require_ai=true)` returns `WP_Error` on AI/decode/review/empty-validation failure for hero/seo-content. Updates may preserve existing valid page_sections instead of placeholders. Logs include landing_key/slug/layout. |
-| Multi-landing partial failure diverges state | HIGH | On failure after N-1 successes, `persist_partial_landing_progress()` saves `landing_pages` + canonical summary first, logs counts/post IDs, then marks step failed (logs if status write fails). No delete of updated existing landings. |
-| Persistence checks | HIGH | `persist_wizard_state` / `mark_step_status` re-read post-state; meta safety-net verifies template+type; canonical `replace`/`set_if_empty` failures logged and fall back when possible. Critical full-run state/status failures return `WP_Error`. |
-| Reviewer/JSON observability + keyword priors | HIGH | Reviewer throwables and invalid JSON-on-success logged with context. Reusable/canonical paths use `filter_neutral_priors()` so keyword sections do not pollute neutral generation/review. |
-| `generate-pages` can publish/assign residual landings | BLOCKER | Fail-closed: selected slugs resolving to `rms_landing_type` `seo`/`ads` return `WP_Error` (`rms_wizard_page_slug_is_landing`) before cleanup/update; loop + `assign_reading_pages()` refuse landing Home/Blog assignment; deletion guard kept. |
-| Partial recovery misses thrown exceptions | WARNING | Each `build_one_landing()` call wrapped in try/catch; `\Throwable` → contextual `WP_Error` then existing `persist_partial_landing_progress()`. |
-| `try_preserve_existing_landing()` ignores update result | WARNING | Capture `wp_update_post(..., true)`; on `WP_Error`/invalid result or meta failure log and return `WP_Error` (no false preserved success). |
-| `landing_pages_equivalent()` too narrow | WARNING | Normalize/compare id, landing_key, title, slug, landing_type, menu_eligible, primary_keyword, order-insensitive subkeywords, generated_at, preserved — reject stale/partial state as “saved”. |
-| `build_page()` throwable after create/update bypasses recovery | WARNING | Local try/catch around `build_page()` → contextual `WP_Error` (`landing_key`/`slug`/`title`, recovered `post_id` when known); outer loop still runs `persist_partial_landing_progress()` for prior successes. |
-| Readability/size (shared helper extraction) | WARNING | **Deliberate duplication retained** with Home Builder. See Known limitations for named helper families + extraction plan after PR3/before archive. |
-
-## Files Changed (Phase 2 batch + review fixes)
+## Files Changed (this batch)
 
 | File | Action | What Was Done |
 |------|--------|---------------|
-| `inc/wizard/class-ai-content-harness.php` | Modified | Distinct `PAGE_LANDING` Layer 2; keyword inject only hero/seo-content |
-| `inc/wizard/class-step-home-page-builder.php` | Modified | After success, `set_if_empty` reusable prepared rows |
-| `inc/wizard/class-step-landing-page-builder.php` | Created + hardened | Full backend + PR2 safety: identity, keyword fail-closed, partial persist, persistence checks, observability, neutral priors, richer state equivalence, local `build_page()` exception boundary |
-| `inc/wizard/class-content-builder.php` | Modified | Whitelist-only `meta_input` |
-| `inc/wizard/class-step-generate-pages.php` | Modified | Landing deletion guard + select/update/reading-assignment exclusion (fail-closed) |
-| `inc/wizard/class-wizard-unlock-controller.php` | Modified | `CONTROLLED_UNLOCK_ENABLED = true` |
-| `inc/wizard/class-step-controller.php` | Modified | PR2: required/dispatch remain 7 steps; dispatch case + alias kept dormant with Phase 3 activation comments |
-| `openspec/changes/wizard-landing-page-builder/tasks.md` | Modified | Phase 2 complete + compatibility notes + task 3.7 activation |
-| `openspec/changes/wizard-landing-page-builder/apply-progress.md` | Modified | This cumulative progress note + helper-duplication known limitations |
+| `pages/landing-page.php` | Modified | Split ACF-missing vs ACF-empty fallbacks; safe markup without `get_sub_field` |
+| `inc/wizard/class-step-landing-page-builder.php` | Modified | Ads protect on preserve early fails; SEO append feedback logs |
+| `inc/wizard/class-menu-builder.php` | Modified | Structured `append_page_items` + verify; reconcile reports append failures |
+| `inc/wizard/class-step-menu-setup.php` | Modified | Warning log when SEO append incomplete after Ads removal OK |
+| `inc/wizard/class-yoast-meta-writer.php` | Modified | `TITLE_MAX_LENGTH` / `DESCRIPTION_MAX_LENGTH` constants |
+| `src/ts/admin/wizard.ts` | Modified | JSDoc for `getMenuEligibleLandings` |
+| `openspec/changes/wizard-landing-page-builder/apply-progress.md` | Modified | This cumulative progress note |
 
-## Intentionally not changed (Phase 3+)
+## Design notes
 
-- Menu append/remove / Menu Setup landing merge
-- Yoast title/metadesc/noindex + `wp_robots` + ads sitemap
-- Admin TS/SCSS landing UI
-- `pages/landing-page.php` flexible loop / breadcrumb
-- Shared Home/Landing section-assembly extraction (documented follow-up)
-- Local docs: `Wizard ai harness prompt guide.md`, `wizard-prd.html`
-- No commit/push
-
-## Design notes (Phase 2 + PR2 safety)
-
-- Landing **runtime code** is present; **activation** is Phase 3 (required + dispatchable + UI + noindex/menu).
-- Controlled unlock enabled only because 2.6 deletion guard shipped in the same backend slice.
-- Ads noindex/menu final-state sync deferred to Phase 3 (by design; PR2 cannot go live without it).
-- Keyword scope strict: only `hero` / `seo-content` receive keywords; overrides stay neutral (`PAGE_HOME`).
-- Canonical first-write only; overrides never write store; replace requires `replace_canonical` + confirm flag.
-- Bootstrap failure returns actionable `WP_Error` (`rms_wizard_canonical_bootstrap_failed`).
-
-## Known limitations
-
-1. Step is not callable via REST until Phase 3 activation — intentional PR2 safety.
-2. **Deliberate Home Builder / Landing Builder helper duplication** (readability debt, not a runtime bug). Duplicated helper families today:
-   - Section assembly / section row preparation (`section_data`, service row contracts, image fallbacks orchestration)
-   - Placeholder copy builders (`placeholder_copy`, `placeholder_repeater_rows`, `placeholder_field_value`)
-   - Item-count defaults / clamp (`item_count` and the shared max section item limit **`12`**)
-   - Reviewer/config helpers (`reviewer()`, `is_review_enabled()`, review wiring around AI decode)
-   - Text/HTML/JSON helpers (`text`, `html`, `section_value`, `decode_json_content`, `truthy`)
-   - Completion helper (`maybe_mark_completed` against `Step_Controller::get_required_steps()`)
-   - **Follow-up plan**: extract a shared section-assembly / content-helper collaborator **after PR3 lands or before archive** — not in this PR2 reliability patch. Also extract the repeated max item limit `12` to a named constant during that cleanup.
-3. No automated behavioral tests / no test runner (`strict_tdd: false`). Reliability is verified via `php -l` + code review only — do not claim automated behavior coverage.
-4. Preserve-on-keyword-failure path updates title/slug/meta only; does not rewrite sections.
-5. Partial-failure recovery does not roll back newly created posts (prefers state persistence over destructive delete). Thrown exceptions (including local `build_page()` catch) convert to `WP_Error` and use the same partial persistence path as returned errors. Recovered orphan post IDs are logged/error-data only — not auto-added to successful `landing_pages`.
+- **Breadcrumb (flexible path)**: injected **once after the first Hero row only**. If flexible `page_sections` has no Hero layout, **no breadcrumb** is rendered in that path.
+- **Breadcrumb (fallback path, ACF present)**: hardcoded order still includes Hero then `breadcrumb-slim`.
+- **ACF missing**: minimal `the_title` / `the_content` fallback only — never load section template parts.
+- **Menu policy asymmetry**: SEO append = **best-effort** (warn + continue). Ads removal / noindex = **fail-closed**.
+- **No automated behavioral tests**: Mode Standard (`strict_tdd: false`, no test runner). Verification is `php -l`, `tsc --noEmit`, and `npm run build` only.
 
 ## Verification
 
 ```
+php -l pages/landing-page.php
 php -l inc/wizard/class-step-landing-page-builder.php
+php -l inc/wizard/class-menu-builder.php
+php -l inc/wizard/class-step-menu-setup.php
+php -l inc/wizard/class-yoast-meta-writer.php
+npx tsc --noEmit
+npm run build
 ```
 
-(Plus prior Phase 2 `php -l` on generate-pages/controller/harness/content-builder/unlock/home-builder.)
-
-Mode: **Standard** (`openspec/config.yaml` → `strict_tdd: false`, no test runner). No automated behavior tests exist for these reliability paths.
+Mode: **Standard** (`strict_tdd: false`, no test runner). Manual WP Admin scenarios remain for Phase 4.
 
 ## Workload / PR Boundary
 
 - Mode: chained PR slice (feature-branch-chain)
-- Current work unit: PR2 Backend Landing + remaining reliability follow-up (equivalence + build_page boundary)
-- Boundary: Phase 2 tasks 2.1–2.6 hardened for standalone PR safety; no Phase 3 UI/menu/template
-- Estimated review budget impact: small incremental reliability patch on PR2 surface
+- Current work unit: PR3 remaining risk blockers only
+- Boundary: no archive, no commit/push
+- Estimated review budget impact: small focused delta
 
 ## Status
 
-Phase 1 + Phase 2 complete with PR2 remaining reliability warnings addressed (10/19 tasks incl. new 3.7). Ready for PR2 re-review / next batch Phase 3 UI/menu/SEO/template + activation.
+17/19 tasks complete (Phase 1–3) + PR3 remaining risk blockers addressed. Ready for re-review / Phase 4 verification. No commit performed.

--- a/openspec/changes/wizard-landing-page-builder/apply-progress.md
+++ b/openspec/changes/wizard-landing-page-builder/apply-progress.md
@@ -1,69 +1,138 @@
 # Apply Progress: wizard-landing-page-builder
 
 **Mode**: Standard  
-**Batch**: Phase 1 final cleanup before PR prep  
-**Date**: 2026-07-20
+**Batch**: Phase 2 Backend Landing Slice (PR2) + PR2 review-blocker fixes + remaining PR2 reliability follow-up + equivalence/`build_page` reliability  
+**Date**: 2026-07-21  
+**Branch**: `feat/wizard-landing-backend` (feature-branch-chain, base = PR1 foundation)
 
 ## Completed Tasks (cumulative)
 
+### Phase 1
 - [x] 1.1 Canonical section store
 - [x] 1.2 State manager + step controller foundation
 - [x] 1.3 Unlock controller + admin wiring
 - [x] 1.4 Completed-gate allowlist for unlock/relock only
 
-Phase 2+ tasks remain incomplete and were not started in this batch.
+### Phase 2
+- [x] 2.1 AI harness `PAGE_LANDING` Layer 2 + Layer 3 keywords (`hero` / `seo-content` only)
+- [x] 2.2 Home Builder first-write reusable rows to `Canonical_Section_Store`
+- [x] 2.3 `Step_Landing_Page_Builder` payload validation, identity preflight, renames, skip-all
+- [x] 2.4 Lazy canonical bootstrap (`state.home_sections` → Home `page_sections` → neutral gen)
+- [x] 2.5 `Content_Builder` whitelist `meta_input` (`_wp_page_template`, `rms_landing_type`)
+- [x] 2.6 `delete_unselected_pages()` landing guard + controlled unlock enabled
 
-## Review Follow-up Fixes (cumulative)
+### Phase 2 PR2 review-blocker follow-up
+- [x] Deactivate live required/dispatch for `landing-page-builder` until Phase 3 UI+noindex
+- [x] Identity cross-pair validation + stricter slug collisions
+- [x] Keyword AI failure → `WP_Error` (or preserve existing landing); no placeholder publish
+- [x] Multi-landing partial-failure state persistence before failed status
+- [x] Critical persistence post-state checks (state, status, meta, canonical write)
+- [x] Reviewer/JSON observability + neutral priors for reusable/canonical paths
+
+### Phase 2 PR2 remaining reliability follow-up
+- [x] `generate-pages` excludes residual SEO/Ads landings from select/update/Home-Blog assignment (fail-closed `WP_Error`); deletion guard retained
+- [x] `build_one_landing()` thrown exceptions converted to `WP_Error` + partial persistence path
+- [x] `try_preserve_existing_landing()` checks `wp_update_post()` / meta results (no false preserve success)
+- [x] Document duplicated Home/Landing helper families + extraction plan after PR3/before archive
+- [x] `landing_pages_equivalent()` expanded beyond id/key/slug/type (title, keywords, menu_eligible, generated_at, preserved)
+- [x] Local try/catch around `Content_Builder::build_page()` with post-ID recovery + contextual `WP_Error` (outer partial recovery unchanged)
+
+Phase 3/4 tasks remain incomplete (including 3.7 activation).
+
+## Phase 1 Review Follow-up Fixes (preserved)
 
 | Finding | Severity | Fix |
 |---------|----------|-----|
-| `landing-page-builder` required before runtime | BLOCKER | Removed from active `REQUIRED_STEPS`; 7-step completion remains valid via shared `get_required_steps()` |
+| `landing-page-builder` required before runtime | BLOCKER | Removed from active `REQUIRED_STEPS` in Phase 1 |
 | Canonical store nondeterministic persistence | WARNING | Cache mutates only after successful `update_option()` or verified equal full post-state entry |
-| Unlock/relock nondeterministic persistence | WARNING | Post-state option equality checks; fail + rollback on unlock; fail if still unlocked after relock |
-| Phase 1 unlock exposes destructive reruns | WARNING | `CONTROLLED_UNLOCK_ENABLED = false`; no unlock admin-post registration until Phase 2 deletion guard; REST unlock returns 503; relock kept for stale cleanup |
-| `RMS_WIZARD_FORCE` UI ambiguity | WARNING | Explicit force-unlocked notice; suppress unlock messaging under force mode |
-| Premature `landing_page_builder` alias pollutes state | WARNING | Removed Phase 1 alias; `is_dispatchable_step()` rejects unknown/unimplemented steps **before** status writes |
-| Stale unlock marker bypasses lock | BLOCKER | `has_unlock_marker()` vs effective `is_unlocked()`; lock ignores markers while controlled unlock disabled |
-| View duplicates unlock source of truth | WARNING | `wizard-init.php` trusts only `$state` from `get_resume_state()` |
-| Untracked local docs risk commit | WARNING | `.gitignore` entries for local docs |
-| Step status stuck `running` on throw | WARNING | catch marks progress steps `failed`; logs if failed-status write itself fails |
-| Dead `assert_required_steps_parity()` | WARNING | Removed; shared `get_required_steps()` is the single list |
-| Duplicate completion-flag helper | WARNING | Removed `Wizard_Unlock_Controller::has_completion_flag()`; use `State_Manager::has_completion_flag()` |
-| Tautological unlock `$at_ok`/`$by_ok` | WARNING | Simplified to post-state equality only |
-| Canonical success ignored `generated_at` | WARNING | Full entry compare (payload + generated_at) after reload |
-| Unlock/relock failures silent | WARNING | Logger records persist failures + residual rollback markers |
-| Duplicate execute_step success shape | INFO | Single success return path after dispatch |
+| Unlock/relock nondeterministic persistence | WARNING | Post-state option equality checks |
+| Premature `landing_page_builder` alias pollutes state | WARNING | Unknown-step reject before status writes |
+| Stale unlock marker bypasses lock | BLOCKER | `has_unlock_marker()` vs effective `is_unlocked()` |
+| Completion flag SoT | WARNING | `State_Manager::has_completion_flag()` only |
 
-## Files Changed (this batch)
+## Phase 2 PR2 Review Blocker Fixes
+
+| Finding | Severity | Fix |
+|---------|----------|-----|
+| Live backend can publish Ads indexable before Phase 3 noindex | BLOCKER | Safer smaller fix: keep `Step_Landing_Page_Builder` implemented but remove `landing-page-builder` from `REQUIRED_STEPS` + `DISPATCHABLE_STEPS`. Dispatch case + alias retained for Phase 3 atomic activation (task 3.7). Existing 7-step UI completion unchanged. |
+| UI/required mismatch (7-step UI vs 8th required) | BLOCKER | Same deactivation; completion stays 7 required steps until UI can send payload/`skip_all`. |
+| Identity mismatch id+key | BLOCKER | `match_existing_landing()` rejects stale cross-pair when both non-empty id and landing_key disagree; order id → key → slug; slug collisions reject other pages (landing or not) when id already matched. |
+| Keyword AI failure publishes placeholders | BLOCKER | `generate_section_copy(..., require_ai=true)` returns `WP_Error` on AI/decode/review/empty-validation failure for hero/seo-content. Updates may preserve existing valid page_sections instead of placeholders. Logs include landing_key/slug/layout. |
+| Multi-landing partial failure diverges state | HIGH | On failure after N-1 successes, `persist_partial_landing_progress()` saves `landing_pages` + canonical summary first, logs counts/post IDs, then marks step failed (logs if status write fails). No delete of updated existing landings. |
+| Persistence checks | HIGH | `persist_wizard_state` / `mark_step_status` re-read post-state; meta safety-net verifies template+type; canonical `replace`/`set_if_empty` failures logged and fall back when possible. Critical full-run state/status failures return `WP_Error`. |
+| Reviewer/JSON observability + keyword priors | HIGH | Reviewer throwables and invalid JSON-on-success logged with context. Reusable/canonical paths use `filter_neutral_priors()` so keyword sections do not pollute neutral generation/review. |
+| `generate-pages` can publish/assign residual landings | BLOCKER | Fail-closed: selected slugs resolving to `rms_landing_type` `seo`/`ads` return `WP_Error` (`rms_wizard_page_slug_is_landing`) before cleanup/update; loop + `assign_reading_pages()` refuse landing Home/Blog assignment; deletion guard kept. |
+| Partial recovery misses thrown exceptions | WARNING | Each `build_one_landing()` call wrapped in try/catch; `\Throwable` → contextual `WP_Error` then existing `persist_partial_landing_progress()`. |
+| `try_preserve_existing_landing()` ignores update result | WARNING | Capture `wp_update_post(..., true)`; on `WP_Error`/invalid result or meta failure log and return `WP_Error` (no false preserved success). |
+| `landing_pages_equivalent()` too narrow | WARNING | Normalize/compare id, landing_key, title, slug, landing_type, menu_eligible, primary_keyword, order-insensitive subkeywords, generated_at, preserved — reject stale/partial state as “saved”. |
+| `build_page()` throwable after create/update bypasses recovery | WARNING | Local try/catch around `build_page()` → contextual `WP_Error` (`landing_key`/`slug`/`title`, recovered `post_id` when known); outer loop still runs `persist_partial_landing_progress()` for prior successes. |
+| Readability/size (shared helper extraction) | WARNING | **Deliberate duplication retained** with Home Builder. See Known limitations for named helper families + extraction plan after PR3/before archive. |
+
+## Files Changed (Phase 2 batch + review fixes)
 
 | File | Action | What Was Done |
 |------|--------|---------------|
-| `inc/wizard/class-wizard-unlock-controller.php` | Modified | SoT completion flag; simplified post-state checks; failure/rollback logging |
-| `inc/wizard/class-canonical-section-store.php` | Modified | Full-entry post-state verification including `generated_at` |
-| `inc/wizard/class-step-controller.php` | Modified | Deduped success return; log failed-status write failure on throw |
-| `inc/wizard/wizard-init.php` | Modified | Register unlock admin-post only when enabled; relock notice always; keep gated unlock UI for Phase 2 |
-| `openspec/changes/wizard-landing-page-builder/apply-progress.md` | Modified | This progress note |
+| `inc/wizard/class-ai-content-harness.php` | Modified | Distinct `PAGE_LANDING` Layer 2; keyword inject only hero/seo-content |
+| `inc/wizard/class-step-home-page-builder.php` | Modified | After success, `set_if_empty` reusable prepared rows |
+| `inc/wizard/class-step-landing-page-builder.php` | Created + hardened | Full backend + PR2 safety: identity, keyword fail-closed, partial persist, persistence checks, observability, neutral priors, richer state equivalence, local `build_page()` exception boundary |
+| `inc/wizard/class-content-builder.php` | Modified | Whitelist-only `meta_input` |
+| `inc/wizard/class-step-generate-pages.php` | Modified | Landing deletion guard + select/update/reading-assignment exclusion (fail-closed) |
+| `inc/wizard/class-wizard-unlock-controller.php` | Modified | `CONTROLLED_UNLOCK_ENABLED = true` |
+| `inc/wizard/class-step-controller.php` | Modified | PR2: required/dispatch remain 7 steps; dispatch case + alias kept dormant with Phase 3 activation comments |
+| `openspec/changes/wizard-landing-page-builder/tasks.md` | Modified | Phase 2 complete + compatibility notes + task 3.7 activation |
+| `openspec/changes/wizard-landing-page-builder/apply-progress.md` | Modified | This cumulative progress note + helper-duplication known limitations |
 
-## Intentionally not changed
+## Intentionally not changed (Phase 3+)
 
-- **Unlock UI branch behind `$unlock_ui_enabled`**: left in place (dead in Phase 1) so Phase 2 task 2.6 can flip `CONTROLLED_UNLOCK_ENABLED` without reintroducing the form. Risk of removing it outweighs PR-size gain.
-- **REST `/steps/unlock/run` route**: still dispatchable, but `unlock()` hard-gates with 503 while disabled — keeps a clear unavailable contract instead of pretending the step is unknown.
-- **Phase 2/3/4 landing runtime / TS / template**: out of Phase 1 scope.
-- **No commit/push**: per apply instructions.
+- Menu append/remove / Menu Setup landing merge
+- Yoast title/metadesc/noindex + `wp_robots` + ads sitemap
+- Admin TS/SCSS landing UI
+- `pages/landing-page.php` flexible loop / breadcrumb
+- Shared Home/Landing section-assembly extraction (documented follow-up)
+- Local docs: `Wizard ai harness prompt guide.md`, `wizard-prd.html`
+- No commit/push
+
+## Design notes (Phase 2 + PR2 safety)
+
+- Landing **runtime code** is present; **activation** is Phase 3 (required + dispatchable + UI + noindex/menu).
+- Controlled unlock enabled only because 2.6 deletion guard shipped in the same backend slice.
+- Ads noindex/menu final-state sync deferred to Phase 3 (by design; PR2 cannot go live without it).
+- Keyword scope strict: only `hero` / `seo-content` receive keywords; overrides stay neutral (`PAGE_HOME`).
+- Canonical first-write only; overrides never write store; replace requires `replace_canonical` + confirm flag.
+- Bootstrap failure returns actionable `WP_Error` (`rms_wizard_canonical_bootstrap_failed`).
+
+## Known limitations
+
+1. Step is not callable via REST until Phase 3 activation — intentional PR2 safety.
+2. **Deliberate Home Builder / Landing Builder helper duplication** (readability debt, not a runtime bug). Duplicated helper families today:
+   - Section assembly / section row preparation (`section_data`, service row contracts, image fallbacks orchestration)
+   - Placeholder copy builders (`placeholder_copy`, `placeholder_repeater_rows`, `placeholder_field_value`)
+   - Item-count defaults / clamp (`item_count` and the shared max section item limit **`12`**)
+   - Reviewer/config helpers (`reviewer()`, `is_review_enabled()`, review wiring around AI decode)
+   - Text/HTML/JSON helpers (`text`, `html`, `section_value`, `decode_json_content`, `truthy`)
+   - Completion helper (`maybe_mark_completed` against `Step_Controller::get_required_steps()`)
+   - **Follow-up plan**: extract a shared section-assembly / content-helper collaborator **after PR3 lands or before archive** — not in this PR2 reliability patch. Also extract the repeated max item limit `12` to a named constant during that cleanup.
+3. No automated behavioral tests / no test runner (`strict_tdd: false`). Reliability is verified via `php -l` + code review only — do not claim automated behavior coverage.
+4. Preserve-on-keyword-failure path updates title/slug/meta only; does not rewrite sections.
+5. Partial-failure recovery does not roll back newly created posts (prefers state persistence over destructive delete). Thrown exceptions (including local `build_page()` catch) convert to `WP_Error` and use the same partial persistence path as returned errors. Recovered orphan post IDs are logged/error-data only — not auto-added to successful `landing_pages`.
 
 ## Verification
 
-Automated behavioral tests are **unavailable** by project config (`openspec/config.yaml`: `strict_tdd: false`, testing section unavailable).  
-Phase 1 relies on **PHP syntax (`php -l`) + 4R fresh review + later manual runtime verification (Phase 4)**. Do not pretend unit/integration tests exist.
+```
+php -l inc/wizard/class-step-landing-page-builder.php
+```
 
-```
-php -l inc/wizard/class-wizard-unlock-controller.php
-php -l inc/wizard/class-canonical-section-store.php
-php -l inc/wizard/class-step-controller.php
-php -l inc/wizard/wizard-init.php
-```
+(Plus prior Phase 2 `php -l` on generate-pages/controller/harness/content-builder/unlock/home-builder.)
+
+Mode: **Standard** (`openspec/config.yaml` → `strict_tdd: false`, no test runner). No automated behavior tests exist for these reliability paths.
+
+## Workload / PR Boundary
+
+- Mode: chained PR slice (feature-branch-chain)
+- Current work unit: PR2 Backend Landing + remaining reliability follow-up (equivalence + build_page boundary)
+- Boundary: Phase 2 tasks 2.1–2.6 hardened for standalone PR safety; no Phase 3 UI/menu/template
+- Estimated review budget impact: small incremental reliability patch on PR2 surface
 
 ## Status
 
-Phase 1 final cleanup complete. Ready for PR prep / re-verify of Phase 1 slice.  
-Do **not** mark Phase 2 tasks complete. Do not start Phase 2 in this batch.
+Phase 1 + Phase 2 complete with PR2 remaining reliability warnings addressed (10/19 tasks incl. new 3.7). Ready for PR2 re-review / next batch Phase 3 UI/menu/SEO/template + activation.

--- a/openspec/changes/wizard-landing-page-builder/tasks.md
+++ b/openspec/changes/wizard-landing-page-builder/tasks.md
@@ -66,13 +66,13 @@ Chain strategy: feature-branch-chain
 
 ## Phase 3: Menu, SEO, UI, Template Slice
 
-- [ ] 3.1 Modify `inc/wizard/class-menu-builder.php` with idempotent `append_page_items()`, `remove_page_items()`, and shared landing reconciliation.
-- [ ] 3.2 Modify `inc/wizard/class-step-menu-setup.php` to merge eligible SEO landings, exclude Ads, and reconcile after destructive menu replacement.
-- [ ] 3.3 Modify `inc/wizard/class-yoast-meta-writer.php` and `inc/wizard/wizard-init.php` for Yoast meta, noindex read-back, `wp_robots`, and Ads sitemap exclusion.
-- [ ] 3.4 Modify `src/ts/admin/wizard.ts` for landing collection, keyword validation, skip-all, identity hydration, duplicate reset, unlock/relock, and replace modal.
-- [ ] 3.5 Modify `src/scss/admin/wizard.scss` for landing and unlock admin states only.
-- [ ] 3.6 Modify `pages/landing-page.php` to render flexible `page_sections` and inject `breadcrumb-slim` once after the first Hero.
-- [ ] 3.7 **Activate** `landing-page-builder` atomically: add to `REQUIRED_STEPS` + `DISPATCHABLE_STEPS` (alias + dispatch case already present) together with UI + noindex/menu final-state sync. Do not activate required/dispatch without the visible skip/payload path.
+- [x] 3.1 Modify `inc/wizard/class-menu-builder.php` with idempotent `append_page_items()`, `remove_page_items()`, and shared landing reconciliation.
+- [x] 3.2 Modify `inc/wizard/class-step-menu-setup.php` to merge eligible SEO landings, exclude Ads, and reconcile after destructive menu replacement.
+- [x] 3.3 Modify `inc/wizard/class-yoast-meta-writer.php` and `inc/wizard/wizard-init.php` for Yoast meta, noindex read-back, `wp_robots`, and Ads sitemap exclusion.
+- [x] 3.4 Modify `src/ts/admin/wizard.ts` for landing collection, keyword validation, skip-all, identity hydration, duplicate reset, unlock/relock, and replace modal.
+- [x] 3.5 Modify `src/scss/admin/wizard.scss` for landing and unlock admin states only.
+- [x] 3.6 Modify `pages/landing-page.php` to render flexible `page_sections` and inject `breadcrumb-slim` once after the first Hero.
+- [x] 3.7 **Activate** `landing-page-builder` atomically: add to `REQUIRED_STEPS` + `DISPATCHABLE_STEPS` (alias + dispatch case already present) together with UI + noindex/menu final-state sync. Do not activate required/dispatch without the visible skip/payload path.
 
 ## Phase 4: Verification
 

--- a/openspec/changes/wizard-landing-page-builder/tasks.md
+++ b/openspec/changes/wizard-landing-page-builder/tasks.md
@@ -45,12 +45,24 @@ Chain strategy: feature-branch-chain
 
 ## Phase 2: Backend Landing Slice
 
-- [ ] 2.1 Modify `inc/wizard/class-ai-content-harness.php` with `PAGE_LANDING` Layer 2 and Layer 3 keywords only for `hero` / `seo-content`.
-- [ ] 2.2 Modify `inc/wizard/class-step-home-page-builder.php` to first-write reusable prepared rows to `Canonical_Section_Store`, excluding `hero` / `seo-content`.
-- [ ] 2.3 Create `inc/wizard/class-step-landing-page-builder.php` with payload validation, id/key/slug matching, duplicate/collision rejection, renames, and skip-all completion.
-- [ ] 2.4 Add lazy bootstrap in `inc/wizard/class-step-landing-page-builder.php`: `state.home_sections` → Home `page_sections` → neutral generation; block with actionable error if missing.
-- [ ] 2.5 Modify `inc/wizard/class-content-builder.php` to whitelist `meta_input` for `_wp_page_template` and `rms_landing_type` only.
-- [ ] 2.6 Modify `inc/wizard/class-step-generate-pages.php` so `delete_unselected_pages()` excludes pages with `rms_landing_type` meta.
+- [x] 2.1 Modify `inc/wizard/class-ai-content-harness.php` with `PAGE_LANDING` Layer 2 and Layer 3 keywords only for `hero` / `seo-content`.
+- [x] 2.2 Modify `inc/wizard/class-step-home-page-builder.php` to first-write reusable prepared rows to `Canonical_Section_Store`, excluding `hero` / `seo-content`.
+- [x] 2.3 Create `inc/wizard/class-step-landing-page-builder.php` with payload validation, id/key/slug matching, duplicate/collision rejection, renames, and skip-all completion.
+- [x] 2.4 Add lazy bootstrap in `inc/wizard/class-step-landing-page-builder.php`: `state.home_sections` → Home `page_sections` → neutral generation; block with actionable error if missing.
+- [x] 2.5 Modify `inc/wizard/class-content-builder.php` to whitelist `meta_input` for `_wp_page_template` and `rms_landing_type` only.
+- [x] 2.6 Modify `inc/wizard/class-step-generate-pages.php` so `delete_unselected_pages()` excludes pages with `rms_landing_type` meta.
+
+### Phase 2 compatibility notes (PR2 review follow-up)
+
+- **Backend class exists; activation deferred to Phase 3.** `Step_Landing_Page_Builder` is fully implemented (tasks 2.3–2.4), but `landing-page-builder` is **not** in active `REQUIRED_STEPS` or `DISPATCHABLE_STEPS` until Phase 3 wires admin UI + Ads noindex/menu final-state sync. Dispatch `case` + `landing_page_builder` alias remain in code for that activation; alias alone is safe (unknown-step reject before status writes).
+- Existing 7-step UI completion stays valid. Do **not** require the 8th step while UI cannot send payload/`skip_all` visibly.
+- Identity preflight: non-empty `id` + `landing_key` must refer to the same state row; reject duplicate ids/keys, non-landing and other-landing slug collisions, and stale cross-pair identity. Match order is deterministic: id → key → slug.
+- Keyword sections (`hero` / `seo-content`): AI generation/decode/review/empty-validation failures return `WP_Error` (no placeholder publish) unless a valid existing landing payload can be preserved.
+- Multi-landing partial failure: successful `landing_pages` are persisted before marking the step failed; counts/post IDs logged; status write failures logged.
+- Critical persistence (`save_state`, `set_step_status`, meta safety-net, canonical `replace`/`set_if_empty`) verified via post-state checks and logged/`WP_Error` on failure.
+- Reviewer throwables and invalid JSON-on-success are logged with landing key/slug/layout. Reusable/canonical generation/review filters out keyword-driven priors.
+- Shared section-assembly helper extraction deferred (deliberate duplication with Home builder) — extract after PR3 or before archive.
+- Controlled unlock remains enabled with the 2.6 deletion guard (unchanged by this follow-up).
 
 ## Phase 3: Menu, SEO, UI, Template Slice
 
@@ -60,6 +72,7 @@ Chain strategy: feature-branch-chain
 - [ ] 3.4 Modify `src/ts/admin/wizard.ts` for landing collection, keyword validation, skip-all, identity hydration, duplicate reset, unlock/relock, and replace modal.
 - [ ] 3.5 Modify `src/scss/admin/wizard.scss` for landing and unlock admin states only.
 - [ ] 3.6 Modify `pages/landing-page.php` to render flexible `page_sections` and inject `breadcrumb-slim` once after the first Hero.
+- [ ] 3.7 **Activate** `landing-page-builder` atomically: add to `REQUIRED_STEPS` + `DISPATCHABLE_STEPS` (alias + dispatch case already present) together with UI + noindex/menu final-state sync. Do not activate required/dispatch without the visible skip/payload path.
 
 ## Phase 4: Verification
 

--- a/pages/landing-page.php
+++ b/pages/landing-page.php
@@ -1,18 +1,79 @@
 <?php
 /**
  * Template Name: SEO Landing Page
+ *
+ * Renders wizard-generated flexible `page_sections` when present.
+ * Injects `breadcrumb-slim` once after the first Hero row only.
+ * Falls back to the hardcoded section order when ACF is available but empty.
+ * When ACF functions are missing, renders a minimal safe title/content fallback
+ * (template parts call `get_sub_field()` and would fatal without ACF).
+ *
+ * @package Simple_RMS_Theme
  */
 
 get_header();
 
-get_template_part('templates/hero');
-get_template_part('templates/breadcrumb-slim');
-get_template_part('templates/seo-content');
-get_template_part('templates/vision-mission-v1');
-get_template_part('templates/badges');
-get_template_part('templates/portfolio-v1');
-get_template_part('templates/seo-content');
-get_template_part('templates/testimonials-v1');
-get_template_part('templates/seo-content');
+// ACF flexible helpers required for both generated rows and hardcoded parts.
+$acf_available = function_exists( 'have_rows' )
+	&& function_exists( 'the_row' )
+	&& function_exists( 'get_row_layout' )
+	&& function_exists( 'get_sub_field' );
+
+$has_flexible_sections = $acf_available && have_rows( 'page_sections' );
+
+if ( $has_flexible_sections ) :
+	$breadcrumb_injected = false;
+
+	while ( have_rows( 'page_sections' ) ) :
+		the_row();
+		$layout = get_row_layout();
+
+		if ( ! is_string( $layout ) || '' === $layout ) {
+			continue;
+		}
+
+		get_template_part( 'templates/' . $layout );
+
+		// Inject breadcrumb once after the first Hero row only (not an ACF layout).
+		// No Hero in flexible content ⇒ no breadcrumb in this path.
+		if ( ! $breadcrumb_injected && 'hero' === $layout ) {
+			get_template_part( 'templates/breadcrumb-slim' );
+			$breadcrumb_injected = true;
+		}
+	endwhile;
+elseif ( $acf_available ) :
+	// ACF present but empty flexible content — legacy hardcoded section order.
+	// Template parts may call get_sub_field(); safe only when ACF is loaded.
+	get_template_part( 'templates/hero' );
+	get_template_part( 'templates/breadcrumb-slim' );
+	get_template_part( 'templates/seo-content' );
+	get_template_part( 'templates/vision-mission-v1' );
+	get_template_part( 'templates/badges' );
+	get_template_part( 'templates/portfolio-v1' );
+	get_template_part( 'templates/seo-content' );
+	get_template_part( 'templates/testimonials-v1' );
+	get_template_part( 'templates/seo-content' );
+else :
+	// ACF missing/degraded — do not load template parts that call get_sub_field().
+	?>
+	<main id="main" class="landing-page landing-page--acf-missing">
+		<?php
+		while ( have_posts() ) :
+			the_post();
+			?>
+			<article <?php post_class( 'landing-page__article' ); ?>>
+				<header class="landing-page__header">
+					<h1 class="landing-page__title"><?php echo esc_html( get_the_title() ); ?></h1>
+				</header>
+				<div class="landing-page__content entry-content">
+					<?php the_content(); ?>
+				</div>
+			</article>
+			<?php
+		endwhile;
+		?>
+	</main>
+	<?php
+endif;
 
 get_footer();

--- a/src/scss/admin/wizard.scss
+++ b/src/scss/admin/wizard.scss
@@ -846,6 +846,196 @@
   background: var(--rms-wizard-success);
 }
 
+/* Landing Page Builder + unlock admin states */
+.rms-setup-wizard.is-locked .rms-wizard-step-panel {
+  opacity: 0.92;
+}
+
+.rms-setup-wizard.is-unlocked .rms-wizard-step-nav.is-complete {
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--rms-wizard-warning), #fff 40%);
+}
+
+.rms-wizard-controlled-unlock__form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  margin-top: 10px;
+}
+
+.rms-wizard-landing-skip-all {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 12px 14px;
+  margin: 0 0 14px;
+  font-weight: 600;
+  background: #f0f6fc;
+  border: 1px solid #c3d9ed;
+  border-radius: 10px;
+}
+
+.rms-wizard-landing-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.rms-wizard-landing-toolbar .rms-wizard-field__instructions {
+  flex-basis: 100%;
+  margin: 0;
+}
+
+.rms-wizard-landing-builder {
+  display: grid;
+  gap: 12px;
+}
+
+.rms-wizard-landing-rows {
+  display: grid;
+  gap: 14px;
+}
+
+.rms-wizard-landing-row {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+  background: #fff;
+  border: 1px solid var(--rms-wizard-border);
+  border-radius: 12px;
+  box-shadow: 0 1px 1px rgb(0 0 0 / 0.03);
+}
+
+.rms-wizard-landing-row.is-ads {
+  border-color: color-mix(in srgb, var(--rms-wizard-warning), #fff 35%);
+  background: #fffdf8;
+}
+
+.rms-wizard-landing-row__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.rms-wizard-landing-row__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.rms-wizard-landing-row__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.rms-wizard-landing-row__subkeywords {
+  grid-column: 1 / -1;
+}
+
+.rms-wizard-landing-sections {
+  display: grid;
+  gap: 10px;
+  padding-top: 4px;
+  border-top: 1px dashed var(--rms-wizard-border);
+}
+
+.rms-wizard-landing-sections__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.rms-wizard-landing-section-rows {
+  display: grid;
+  gap: 8px;
+}
+
+.rms-wizard-landing-section-row {
+  display: grid;
+  grid-template-columns: minmax(180px, 1.2fr) minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 12px;
+  background: #f8fafc;
+  border: 1px solid #edf0f2;
+  border-radius: 10px;
+}
+
+.rms-wizard-landing-section-override {
+  display: inline-flex;
+  gap: 8px;
+  align-items: flex-start;
+  margin: 0;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--rms-wizard-muted);
+}
+
+.rms-wizard-landing-section-override[hidden] {
+  display: none;
+}
+
+.rms-wizard-landing-builder__empty {
+  padding: 16px;
+  margin: 0;
+  color: var(--rms-wizard-muted);
+  text-align: center;
+  background: #fff;
+  border: 1px dashed var(--rms-wizard-border);
+  border-radius: 12px;
+}
+
+.rms-wizard-landing-replace-panel {
+  display: grid;
+  gap: 8px;
+  margin-top: 16px;
+  padding: 14px;
+  background: #fff8e5;
+  border: 1px solid color-mix(in srgb, var(--rms-wizard-warning), #fff 55%);
+  border-left: 4px solid var(--rms-wizard-warning);
+  border-radius: 10px;
+}
+
+.rms-wizard-landing-replace-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 8px;
+}
+
+.rms-wizard-landing-replace-option {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  margin: 0;
+  padding: 8px 10px;
+  background: #fff;
+  border: 1px solid #f0e2b8;
+  border-radius: 8px;
+  font-size: 13px;
+}
+
+.rms-wizard-fields.is-skip-all .rms-wizard-landing-builder,
+.rms-wizard-fields.is-skip-all .rms-wizard-landing-toolbar,
+.rms-wizard-fields.is-skip-all .rms-wizard-landing-replace-panel {
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+@media (max-width: 782px) {
+  .rms-wizard-landing-row__grid,
+  .rms-wizard-landing-section-row {
+    grid-template-columns: 1fr;
+  }
+}
+
 .rms-wizard-next-step.is-ready:hover,
 .rms-wizard-next-step.is-ready:focus-visible {
   filter: brightness(0.95);

--- a/src/ts/admin/wizard.ts
+++ b/src/ts/admin/wizard.ts
@@ -20,6 +20,21 @@ interface GeneratedPage {
   role?: string;
 }
 
+interface LandingPageState {
+  id?: number | string;
+  landing_key?: string;
+  title?: string;
+  slug?: string;
+  landing_type?: 'seo' | 'ads' | string;
+  menu_eligible?: boolean;
+  primary_keyword?: string;
+  subkeywords?: string[];
+  keywords?: {
+    primary_keyword?: string;
+    subkeywords?: string[];
+  };
+}
+
 interface WizardPageTemplate {
   title?: string;
   slug?: string;
@@ -36,9 +51,35 @@ interface HomeSectionTemplate {
   default_item_count?: number;
 }
 
+interface LandingSectionOption {
+  layout?: string;
+  label?: string;
+  description?: string;
+  is_keyword_layout?: boolean;
+  is_default?: boolean;
+  default_item_count?: number;
+  has_fillable_fields?: boolean;
+}
+
 interface HomeSectionPayload {
   layout: string;
   item_count: number;
+}
+
+interface LandingSectionPayload {
+  layout: string;
+  override_canonical: boolean;
+}
+
+interface LandingPayloadItem {
+  id: number | null;
+  landing_key: string;
+  title: string;
+  slug: string;
+  landing_type: 'seo' | 'ads';
+  primary_keyword: string;
+  subkeywords: string[];
+  sections: LandingSectionPayload[];
 }
 
 interface PagePayloadItem {
@@ -64,7 +105,13 @@ interface WizardState {
     configured_at?: string;
   };
   generated_pages?: GeneratedPage[];
+  landing_pages?: LandingPageState[];
   locked?: boolean;
+  unlocked?: boolean;
+  completed_flag?: boolean;
+  force_unlocked?: boolean;
+  controlled_unlock_ui?: boolean;
+  has_unlock_marker?: boolean;
   logs?: WizardLogEntry[];
 }
 
@@ -164,6 +211,7 @@ declare global {
     { slug: 'menu-setup', label: 'Menu Setup' },
     { slug: 'ia-generation', label: 'IA Generation' },
     { slug: 'home-page-builder', label: 'Home Page Builder' },
+    { slug: 'landing-page-builder', label: 'Landing Page Builder' },
   ];
 
   const destructiveWarnings: Record<string, { message: string; checkboxMessage: string }> = {
@@ -174,6 +222,10 @@ declare global {
     'menu-setup': {
       message: 'Existing menus and location assignments will be removed and replaced. This cannot be undone.',
       checkboxMessage: 'Confirm that existing menus and location assignments can be replaced before continuing.',
+    },
+    'landing-page-builder': {
+      message: 'Replacing canonical reusable sections overwrites shared copy used by future landings. This cannot be undone.',
+      checkboxMessage: 'Confirm replace canonical before overwriting shared reusable sections.',
     },
   };
 
@@ -278,9 +330,15 @@ declare global {
     }).join('');
   };
 
+  const isWizardLocked = (): boolean => Boolean(state.locked) && !state.unlocked && !state.force_unlocked;
+
   const updateButtons = (): void => {
-    const isLocked = Boolean(state.locked);
+    const isLocked = isWizardLocked();
     const isHydrating = root.classList.contains('is-hydrating');
+
+    root.classList.toggle('is-unlocked', Boolean(state.unlocked) && !state.force_unlocked);
+    root.classList.toggle('is-force-unlocked', Boolean(state.force_unlocked));
+    root.classList.toggle('is-locked', isLocked);
 
     navButtons.forEach((button) => {
       button.disabled = isHydrating || runningStep !== null;
@@ -316,6 +374,8 @@ declare global {
       const allComplete = steps.every((step) => statusFor(step.slug) === 'complete');
       completeButton.disabled = isHydrating || isLocked || runningStep !== null || !allComplete;
     }
+
+    syncLandingSkipAllUi();
   };
 
   const render = (): void => {
@@ -325,6 +385,8 @@ declare global {
 
     renderGeneratedPageControls();
     hydrateIaGenerationForm();
+    hydrateLandingRowsFromState();
+    renderLandingReplaceOptions();
     syncGuidedControlState();
     setActiveStep(nextStep);
     updateNav();
@@ -332,8 +394,10 @@ declare global {
     updateLogs();
     updateButtons();
 
-    if (state.locked) {
-      setNotice('The setup wizard is complete and locked. Define RMS_WIZARD_FORCE as true for development reruns.', 'success');
+    if (isWizardLocked()) {
+      setNotice('The setup wizard is complete and locked. Unlock it for editing or define RMS_WIZARD_FORCE as true for development reruns.', 'success');
+    } else if (state.unlocked && !state.force_unlocked) {
+      setNotice('The setup wizard is unlocked for editing. Completion state is preserved.', 'info');
     }
   };
 
@@ -501,6 +565,10 @@ declare global {
       return collectHomePageBuilderPayload(form);
     }
 
+    if (step === 'landing-page-builder') {
+      return collectLandingPageBuilderPayload(form);
+    }
+
     return collectFormPayload(form);
   };
 
@@ -645,6 +713,24 @@ declare global {
   };
 
   const ensureDestructiveConfirmation = async (step: string, payload: StepPayload): Promise<boolean> => {
+    if (step === 'landing-page-builder') {
+      const replaceMap = (payload.replace_canonical ?? {}) as Record<string, boolean>;
+      const needsReplaceConfirm = Object.values(replaceMap).some(Boolean);
+
+      if (!needsReplaceConfirm) {
+        return true;
+      }
+
+      const warning = destructiveWarnings[step];
+      const confirmed = await openConfirmationModal(warning.message);
+
+      if (confirmed) {
+        payload.confirm_replace_canonical = true;
+      }
+
+      return confirmed;
+    }
+
     const warning = destructiveWarnings[step];
 
     if (!warning) {
@@ -665,6 +751,121 @@ declare global {
     }
 
     return confirmed;
+  };
+
+  const collectLandingPageBuilderPayload = (form: HTMLFormElement): StepPayload => {
+    const skipAll = Boolean(form.querySelector<HTMLInputElement>('[data-wizard-landing-skip-all]')?.checked);
+
+    if (skipAll) {
+      return { skip_all: true, landings: [] };
+    }
+
+    const landings: LandingPayloadItem[] = [];
+    const seenSlugs = new Set<string>();
+    const seenKeys = new Set<string>();
+    const seenIds = new Set<number>();
+
+    form.querySelectorAll<HTMLElement>('[data-wizard-landing-row]').forEach((row, index) => {
+      const title = row.querySelector<HTMLInputElement>('[data-wizard-landing-title]')?.value.trim() ?? '';
+      const slugInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-slug]')?.value.trim() ?? '';
+      const slug = sanitizeSlug(slugInput || title);
+      const landingTypeRaw = row.querySelector<HTMLSelectElement>('[data-wizard-landing-type]')?.value ?? 'seo';
+      const landingType: 'seo' | 'ads' = landingTypeRaw === 'ads' ? 'ads' : 'seo';
+      const primaryKeyword = row.querySelector<HTMLInputElement>('[data-wizard-landing-primary-keyword]')?.value.trim() ?? '';
+      const subkeywordsRaw = row.querySelector<HTMLInputElement>('[data-wizard-landing-subkeywords]')?.value ?? '';
+      const idRaw = row.querySelector<HTMLInputElement>('[data-wizard-landing-id]')?.value.trim() ?? '';
+      const landingKey = row.querySelector<HTMLInputElement>('[data-wizard-landing-key]')?.value.trim() || mintLandingKey();
+      const id = idRaw ? Number.parseInt(idRaw, 10) : null;
+
+      if (!title && !slug && !primaryKeyword) {
+        return;
+      }
+
+      if (!title) {
+        throw new Error(`Landing ${index + 1} needs a title.`);
+      }
+
+      if (!slug) {
+        throw new Error(`Landing "${title}" needs a valid slug.`);
+      }
+
+      if (!primaryKeyword) {
+        throw new Error(`Landing "${title}" requires a primary keyword.`);
+      }
+
+      if (seenSlugs.has(slug)) {
+        throw new Error(`Landing slugs must be unique. "${slug}" is already used.`);
+      }
+
+      if (landingKey && seenKeys.has(landingKey)) {
+        throw new Error('Duplicate landing keys are not allowed in one run.');
+      }
+
+      if (id && Number.isFinite(id) && id > 0) {
+        if (seenIds.has(id)) {
+          throw new Error('Duplicate landing ids are not allowed in one run.');
+        }
+
+        seenIds.add(id);
+      }
+
+      seenSlugs.add(slug);
+      seenKeys.add(landingKey);
+
+      const subkeywords = subkeywordsRaw
+        .split(',')
+        .map((value) => value.trim())
+        .filter(Boolean)
+        .slice(0, 10);
+
+      const sections: LandingSectionPayload[] = [];
+
+      row.querySelectorAll<HTMLElement>('[data-wizard-landing-section-row]').forEach((sectionRow) => {
+        const layout = sectionRow.querySelector<HTMLSelectElement>('[data-wizard-landing-section-layout]')?.value.trim() ?? '';
+        const override = Boolean(sectionRow.querySelector<HTMLInputElement>('[data-wizard-landing-section-override]')?.checked);
+
+        if (!layout) {
+          return;
+        }
+
+        sections.push({ layout, override_canonical: override });
+      });
+
+      if (sections.length === 0) {
+        throw new Error(`Landing "${title}" needs at least one section.`);
+      }
+
+      landings.push({
+        id: id && Number.isFinite(id) && id > 0 ? id : null,
+        landing_key: landingKey,
+        title,
+        slug,
+        landing_type: landingType,
+        primary_keyword: primaryKeyword,
+        subkeywords,
+        sections,
+      });
+    });
+
+    if (landings.length === 0) {
+      throw new Error('Add at least one landing page or enable skip-all to complete without landings.');
+    }
+
+    const replaceCanonical: Record<string, boolean> = {};
+
+    form.querySelectorAll<HTMLInputElement>('[data-wizard-landing-replace-layout]:checked').forEach((input) => {
+      const layout = input.value.trim();
+
+      if (layout) {
+        replaceCanonical[layout] = true;
+      }
+    });
+
+    return {
+      landings,
+      replace_canonical: replaceCanonical,
+      skip_all: false,
+    };
   };
 
   const openConfirmationModal = (message: string): Promise<boolean> => {
@@ -783,14 +984,449 @@ declare global {
     });
   };
 
-  const getGeneratedPages = (): GeneratedPage[] => (
-    Array.isArray(state.generated_pages) ? state.generated_pages.filter((page) => Boolean(generatedPageValue(page))) : []
-  );
+  /**
+   * Pages available to the Menu Setup UI.
+   *
+   * Merges standard `state.generated_pages` with menu-eligible SEO landings
+   * from `state.landing_pages`. Ads and `menu_eligible=false` landings are
+   * excluded via `getMenuEligibleLandings()` so they never appear as menu options.
+   */
+  const getGeneratedPages = (): GeneratedPage[] => {
+    const standard = Array.isArray(state.generated_pages)
+      ? state.generated_pages.filter((page) => Boolean(generatedPageValue(page)))
+      : [];
+    const landings = getMenuEligibleLandings().map((landing) => ({
+      id: landing.id,
+      title: landing.title,
+      slug: landing.slug,
+      role: landing.landing_type === 'seo' ? 'landing-seo' : 'landing',
+    }));
 
-  const generatedPageValue = (page: GeneratedPage): string => {
+    const seen = new Set<string>();
+    const merged: GeneratedPage[] = [];
+
+    [...standard, ...landings].forEach((page) => {
+      const value = generatedPageValue(page);
+
+      if (!value || seen.has(value)) {
+        return;
+      }
+
+      seen.add(value);
+      merged.push(page);
+    });
+
+    return merged;
+  };
+
+  /**
+   * SEO landings that may appear in Menu Setup.
+   *
+   * Filters `state.landing_pages` to `landing_type=seo` with `menu_eligible`
+   * true (default true for SEO when the flag is absent). Ads and ineligible
+   * rows are always excluded. Requires a resolvable id/slug via
+   * `generatedPageValue()`.
+   */
+  const getMenuEligibleLandings = (): LandingPageState[] => {
+    if (!Array.isArray(state.landing_pages)) {
+      return [];
+    }
+
+    return state.landing_pages.filter((landing) => {
+      const type = landing.landing_type === 'ads' ? 'ads' : 'seo';
+      const eligible = typeof landing.menu_eligible === 'boolean' ? landing.menu_eligible : type === 'seo';
+
+      return type === 'seo' && eligible && Boolean(generatedPageValue(landing));
+    });
+  };
+
+  const generatedPageValue = (page: GeneratedPage | LandingPageState): string => {
     const id = typeof page.id === 'number' || typeof page.id === 'string' ? String(page.id) : '';
 
     return id || sanitizeSlug(page.slug ?? '');
+  };
+
+  const mintLandingKey = (): string => {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return `lp_${crypto.randomUUID().replace(/-/g, '').slice(0, 12)}`;
+    }
+
+    return `lp_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+  };
+
+  const readLandingSectionOptions = (): LandingSectionOption[] => {
+    const source = root.querySelector<HTMLScriptElement>('script[data-wizard-landing-sections]');
+
+    if (!source?.textContent) {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(source.textContent) as unknown;
+
+      return Array.isArray(parsed)
+        ? parsed.filter((item): item is LandingSectionOption => typeof item === 'object' && item !== null)
+        : [];
+    } catch (_error) {
+      return [];
+    }
+  };
+
+  const readLandingDefaultLayouts = (): string[] => {
+    const source = root.querySelector<HTMLScriptElement>('script[data-wizard-landing-default-layouts]');
+
+    if (!source?.textContent) {
+      return ['hero', 'seo-content', 'vision-mission-v1', 'badges', 'portfolio-v1', 'seo-content', 'testimonials-v1', 'seo-content'];
+    }
+
+    try {
+      const parsed = JSON.parse(source.textContent) as unknown;
+
+      return Array.isArray(parsed) ? parsed.map(String).filter(Boolean) : [];
+    } catch (_error) {
+      return ['hero', 'seo-content'];
+    }
+  };
+
+  const getLandingRowsContainer = (): HTMLElement | null => root.querySelector<HTMLElement>('[data-wizard-landing-rows]');
+
+  const getLandingRowTemplate = (): HTMLTemplateElement | null => root.querySelector<HTMLTemplateElement>('template[data-wizard-landing-row-template]');
+
+  const getLandingSectionRowTemplate = (): HTMLTemplateElement | null => root.querySelector<HTMLTemplateElement>('template[data-wizard-landing-section-row-template]');
+
+  const hydrateLandingRowsFromState = (): void => {
+    const rows = getLandingRowsContainer();
+
+    if (!rows) {
+      return;
+    }
+
+    // Never clobber in-progress edits; only seed when the builder is empty.
+    if (rows.querySelector('[data-wizard-landing-row]')) {
+      syncLandingBuilderEmptyState();
+      return;
+    }
+
+    const landings = Array.isArray(state.landing_pages) ? state.landing_pages : [];
+
+    if (landings.length === 0) {
+      syncLandingBuilderEmptyState();
+      return;
+    }
+
+    landings.forEach((landing) => {
+      const rawId = landing.id;
+      const parsedId = typeof rawId === 'number'
+        ? rawId
+        : (typeof rawId === 'string' ? Number.parseInt(rawId, 10) : NaN);
+
+      addLandingRow({
+        id: Number.isFinite(parsedId) && parsedId > 0 ? parsedId : null,
+        landing_key: landing.landing_key || mintLandingKey(),
+        title: landing.title || '',
+        slug: landing.slug || '',
+        landing_type: landing.landing_type === 'ads' ? 'ads' : 'seo',
+        primary_keyword: landing.primary_keyword || landing.keywords?.primary_keyword || '',
+        subkeywords: landing.subkeywords || landing.keywords?.subkeywords || [],
+      });
+    });
+  };
+
+  const addLandingRow = (data: Partial<LandingPayloadItem> = {}): HTMLElement | null => {
+    const rows = getLandingRowsContainer();
+    const template = getLandingRowTemplate();
+
+    if (!rows || !template) {
+      return null;
+    }
+
+    const index = rows.querySelectorAll('[data-wizard-landing-row]').length;
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = template.innerHTML.replaceAll('__INDEX__', String(index)).trim();
+    const row = wrapper.firstElementChild instanceof HTMLElement ? wrapper.firstElementChild : null;
+
+    if (!row) {
+      return null;
+    }
+
+    const idInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-id]');
+    const keyInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-key]');
+    const titleInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-title]');
+    const slugInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-slug]');
+    const typeSelect = row.querySelector<HTMLSelectElement>('[data-wizard-landing-type]');
+    const keywordInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-primary-keyword]');
+    const subkeywordsInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-subkeywords]');
+    const heading = row.querySelector<HTMLElement>('[data-wizard-landing-heading]');
+
+    if (idInput) {
+      idInput.value = data.id && Number(data.id) > 0 ? String(data.id) : '';
+    }
+
+    if (keyInput) {
+      keyInput.value = data.landing_key || mintLandingKey();
+    }
+
+    if (titleInput) {
+      titleInput.value = data.title || '';
+    }
+
+    if (slugInput) {
+      slugInput.value = sanitizeSlug(data.slug || data.title || '');
+      slugInput.dataset.wizardSlugAuto = data.slug ? '0' : '1';
+    }
+
+    if (typeSelect) {
+      typeSelect.value = data.landing_type === 'ads' ? 'ads' : 'seo';
+    }
+
+    if (keywordInput) {
+      keywordInput.value = data.primary_keyword || '';
+    }
+
+    if (subkeywordsInput) {
+      subkeywordsInput.value = (data.subkeywords || []).join(', ');
+    }
+
+    if (heading) {
+      heading.textContent = data.title || `Landing ${index + 1}`;
+    }
+
+    rows.append(row);
+    row.classList.toggle('is-ads', typeSelect?.value === 'ads');
+
+    const sectionLayouts = (data.sections && data.sections.length > 0)
+      ? data.sections.map((section) => section.layout)
+      : readLandingDefaultLayouts();
+
+    sectionLayouts.forEach((layout, sectionIndex) => {
+      const override = Boolean(data.sections?.[sectionIndex]?.override_canonical);
+      addLandingSectionRow(row, layout, override);
+    });
+
+    reindexLandingRows();
+    syncLandingBuilderEmptyState();
+    syncLandingSkipAllUi();
+    titleInput?.focus();
+
+    return row;
+  };
+
+  const addLandingSectionRow = (landingRow: HTMLElement, layout = '', override = false): void => {
+    const container = landingRow.querySelector<HTMLElement>('[data-wizard-landing-section-rows]');
+    const template = getLandingSectionRowTemplate();
+
+    if (!container || !template) {
+      return;
+    }
+
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = template.innerHTML
+      .replaceAll('__LINDEX__', '0')
+      .replaceAll('__SINDEX__', String(container.querySelectorAll('[data-wizard-landing-section-row]').length))
+      .trim();
+    const sectionRow = wrapper.firstElementChild instanceof HTMLElement ? wrapper.firstElementChild : null;
+
+    if (!sectionRow) {
+      return;
+    }
+
+    const select = sectionRow.querySelector<HTMLSelectElement>('[data-wizard-landing-section-layout]');
+    const overrideInput = sectionRow.querySelector<HTMLInputElement>('[data-wizard-landing-section-override]');
+    const options = readLandingSectionOptions();
+
+    if (select) {
+      select.replaceChildren();
+      options.forEach((option) => {
+        if (!option.layout) {
+          return;
+        }
+
+        const opt = new Option(
+          option.label ? `${option.label} (${option.layout})` : option.layout,
+          option.layout
+        );
+        select.append(opt);
+      });
+
+      if (layout) {
+        select.value = layout;
+      } else if (options[0]?.layout) {
+        select.value = options[0].layout;
+      }
+
+      syncLandingSectionOverrideVisibility(sectionRow);
+    }
+
+    if (overrideInput) {
+      overrideInput.checked = override;
+    }
+
+    container.append(sectionRow);
+    reindexLandingRows();
+  };
+
+  const syncLandingSectionOverrideVisibility = (sectionRow: HTMLElement): void => {
+    const layout = sectionRow.querySelector<HTMLSelectElement>('[data-wizard-landing-section-layout]')?.value ?? '';
+    const overrideLabel = sectionRow.querySelector<HTMLElement>('.rms-wizard-landing-section-override');
+    const isKeyword = layout === 'hero' || layout === 'seo-content';
+
+    if (overrideLabel) {
+      overrideLabel.hidden = isKeyword;
+    }
+
+    if (isKeyword) {
+      const overrideInput = sectionRow.querySelector<HTMLInputElement>('[data-wizard-landing-section-override]');
+
+      if (overrideInput) {
+        overrideInput.checked = false;
+      }
+    }
+  };
+
+  const duplicateLandingRow = (button: HTMLButtonElement): void => {
+    const source = button.closest<HTMLElement>('[data-wizard-landing-row]');
+
+    if (!source) {
+      return;
+    }
+
+    const title = source.querySelector<HTMLInputElement>('[data-wizard-landing-title]')?.value.trim() ?? '';
+    const slug = source.querySelector<HTMLInputElement>('[data-wizard-landing-slug]')?.value.trim() ?? '';
+    const landingType = source.querySelector<HTMLSelectElement>('[data-wizard-landing-type]')?.value === 'ads' ? 'ads' : 'seo';
+    const primaryKeyword = source.querySelector<HTMLInputElement>('[data-wizard-landing-primary-keyword]')?.value.trim() ?? '';
+    const subkeywords = (source.querySelector<HTMLInputElement>('[data-wizard-landing-subkeywords]')?.value ?? '')
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean);
+    const sections: LandingSectionPayload[] = Array.from(source.querySelectorAll<HTMLElement>('[data-wizard-landing-section-row]')).map((sectionRow) => ({
+      layout: sectionRow.querySelector<HTMLSelectElement>('[data-wizard-landing-section-layout]')?.value.trim() ?? '',
+      override_canonical: Boolean(sectionRow.querySelector<HTMLInputElement>('[data-wizard-landing-section-override]')?.checked),
+    })).filter((section) => section.layout);
+
+    // Duplicate must clear id and mint a new landing_key.
+    addLandingRow({
+      id: null,
+      landing_key: mintLandingKey(),
+      title: title ? `${title} copy` : '',
+      slug: slug ? `${slug}-copy` : '',
+      landing_type: landingType,
+      primary_keyword: primaryKeyword,
+      subkeywords,
+      sections,
+    });
+  };
+
+  const removeLandingRow = (button: HTMLButtonElement): void => {
+    button.closest<HTMLElement>('[data-wizard-landing-row]')?.remove();
+    reindexLandingRows();
+    syncLandingBuilderEmptyState();
+  };
+
+  const reindexLandingRows = (): void => {
+    const rows = Array.from(root.querySelectorAll<HTMLElement>('[data-wizard-landing-row]'));
+
+    rows.forEach((row, index) => {
+      row.dataset.wizardLandingIndex = String(index);
+
+      const heading = row.querySelector<HTMLElement>('[data-wizard-landing-heading]');
+      const title = row.querySelector<HTMLInputElement>('[data-wizard-landing-title]')?.value.trim() ?? '';
+
+      if (heading) {
+        heading.textContent = title || `Landing ${index + 1}`;
+      }
+
+      row.classList.toggle('is-ads', row.querySelector<HTMLSelectElement>('[data-wizard-landing-type]')?.value === 'ads');
+
+      row.querySelectorAll<FieldElement>('[name]').forEach((field) => {
+        field.name = field.name
+          .replace(/landings\[\d+\]/g, `landings[${index}]`)
+          .replace(/landings\[__INDEX__\]/g, `landings[${index}]`);
+      });
+
+      row.querySelectorAll<HTMLElement>('[id]').forEach((element) => {
+        element.id = element.id.replace(/rms-wizard-landing-([a-z-]+)-\d+/g, `rms-wizard-landing-$1-${index}`);
+      });
+
+      row.querySelectorAll<HTMLLabelElement>('label[for]').forEach((label) => {
+        label.htmlFor = label.htmlFor.replace(/rms-wizard-landing-([a-z-]+)-\d+/g, `rms-wizard-landing-$1-${index}`);
+      });
+
+      Array.from(row.querySelectorAll<HTMLElement>('[data-wizard-landing-section-row]')).forEach((sectionRow, sectionIndex) => {
+        sectionRow.querySelectorAll<FieldElement>('[name]').forEach((field) => {
+          field.name = field.name
+            .replace(/landings\[\d+\]/g, `landings[${index}]`)
+            .replace(/sections\[\d+\]/g, `sections[${sectionIndex}]`)
+            .replace(/__LINDEX__/g, String(index))
+            .replace(/__SINDEX__/g, String(sectionIndex));
+        });
+      });
+    });
+  };
+
+  const syncLandingBuilderEmptyState = (): void => {
+    const hasRows = Boolean(root.querySelector('[data-wizard-landing-row]'));
+    const emptyMessage = root.querySelector<HTMLElement>('[data-wizard-landing-empty]');
+
+    if (emptyMessage) {
+      emptyMessage.hidden = hasRows;
+    }
+  };
+
+  const syncLandingSkipAllUi = (): void => {
+    const form = root.querySelector<HTMLFormElement>('[data-wizard-landing-page-builder-form]');
+    const skip = form?.querySelector<HTMLInputElement>('[data-wizard-landing-skip-all]');
+    const builder = form?.querySelector<HTMLElement>('[data-wizard-landing-builder]');
+    const toolbar = form?.querySelector<HTMLElement>('.rms-wizard-landing-toolbar');
+    const replacePanel = form?.querySelector<HTMLElement>('[data-wizard-landing-replace-panel]');
+    const skipped = Boolean(skip?.checked);
+
+    if (builder) {
+      builder.hidden = skipped;
+    }
+
+    if (toolbar) {
+      toolbar.hidden = skipped;
+    }
+
+    if (replacePanel) {
+      replacePanel.hidden = skipped;
+    }
+
+    form?.classList.toggle('is-skip-all', skipped);
+  };
+
+  const renderLandingReplaceOptions = (): void => {
+    const list = root.querySelector<HTMLElement>('[data-wizard-landing-replace-list]');
+
+    if (!list || list.dataset.wizardRendered === '1') {
+      return;
+    }
+
+    const options = readLandingSectionOptions().filter((option) => option.layout && !option.is_keyword_layout);
+    list.replaceChildren();
+
+    options.forEach((option) => {
+      if (!option.layout) {
+        return;
+      }
+
+      const label = document.createElement('label');
+      label.className = 'rms-wizard-landing-replace-option';
+
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      input.value = option.layout;
+      input.dataset.wizardLandingReplaceLayout = '1';
+      input.name = `replace_canonical[${option.layout}]`;
+
+      const text = document.createElement('span');
+      text.textContent = option.label ? `${option.label} (${option.layout})` : option.layout;
+
+      label.append(input, text);
+      list.append(label);
+    });
+
+    list.dataset.wizardRendered = '1';
   };
 
   const syncGuidedControlState = (): void => {
@@ -1669,6 +2305,52 @@ declare global {
       if (removePageButton) {
         event.preventDefault();
         removePageRow(removePageButton);
+        return;
+      }
+
+      const addLandingButton = target.closest<HTMLButtonElement>('[data-wizard-add-landing]');
+
+      if (addLandingButton) {
+        event.preventDefault();
+        addLandingRow();
+        return;
+      }
+
+      const duplicateLandingButton = target.closest<HTMLButtonElement>('[data-wizard-duplicate-landing]');
+
+      if (duplicateLandingButton) {
+        event.preventDefault();
+        duplicateLandingRow(duplicateLandingButton);
+        return;
+      }
+
+      const removeLandingButton = target.closest<HTMLButtonElement>('[data-wizard-remove-landing]');
+
+      if (removeLandingButton) {
+        event.preventDefault();
+        removeLandingRow(removeLandingButton);
+        return;
+      }
+
+      const addLandingSectionButton = target.closest<HTMLButtonElement>('[data-wizard-add-landing-section]');
+
+      if (addLandingSectionButton) {
+        event.preventDefault();
+        const landingRow = addLandingSectionButton.closest<HTMLElement>('[data-wizard-landing-row]');
+
+        if (landingRow) {
+          addLandingSectionRow(landingRow);
+        }
+
+        return;
+      }
+
+      const removeLandingSectionButton = target.closest<HTMLButtonElement>('[data-wizard-remove-landing-section]');
+
+      if (removeLandingSectionButton) {
+        event.preventDefault();
+        removeLandingSectionButton.closest<HTMLElement>('[data-wizard-landing-section-row]')?.remove();
+        reindexLandingRows();
       }
     });
 
@@ -1682,6 +2364,24 @@ declare global {
       if (target instanceof HTMLInputElement && target.matches('[data-wizard-page-slug]')) {
         updatePageRowFromSlug(target);
       }
+
+      if (target instanceof HTMLInputElement && target.matches('[data-wizard-landing-title]')) {
+        const row = target.closest<HTMLElement>('[data-wizard-landing-row]');
+        const slugInput = row?.querySelector<HTMLInputElement>('[data-wizard-landing-slug]');
+        const heading = row?.querySelector<HTMLElement>('[data-wizard-landing-heading]');
+
+        if (slugInput && slugInput.dataset.wizardSlugAuto !== '0') {
+          slugInput.value = sanitizeSlug(target.value);
+        }
+
+        if (heading) {
+          heading.textContent = target.value.trim() || 'Landing';
+        }
+      }
+
+      if (target instanceof HTMLInputElement && target.matches('[data-wizard-landing-slug]')) {
+        target.dataset.wizardSlugAuto = '0';
+      }
     });
 
     root.addEventListener('blur', (event) => {
@@ -1689,6 +2389,11 @@ declare global {
 
       if (target instanceof HTMLInputElement && target.matches('[data-wizard-page-slug]')) {
         updatePageRowFromSlug(target, true);
+      }
+
+      if (target instanceof HTMLInputElement && target.matches('[data-wizard-landing-slug]')) {
+        target.value = sanitizeSlug(target.value);
+        target.dataset.wizardSlugAuto = '0';
       }
     }, true);
 
@@ -1711,6 +2416,26 @@ declare global {
 
       if (target instanceof HTMLSelectElement && target.matches('[data-wizard-home-section-select]')) {
         syncGuidedControlState();
+        return;
+      }
+
+      if (target instanceof HTMLInputElement && target.matches('[data-wizard-landing-skip-all]')) {
+        syncLandingSkipAllUi();
+        return;
+      }
+
+      if (target instanceof HTMLSelectElement && target.matches('[data-wizard-landing-type]')) {
+        const row = target.closest<HTMLElement>('[data-wizard-landing-row]');
+        row?.classList.toggle('is-ads', target.value === 'ads');
+        return;
+      }
+
+      if (target instanceof HTMLSelectElement && target.matches('[data-wizard-landing-section-layout]')) {
+        const sectionRow = target.closest<HTMLElement>('[data-wizard-landing-section-row]');
+
+        if (sectionRow) {
+          syncLandingSectionOverrideVisibility(sectionRow);
+        }
       }
     });
 


### PR DESCRIPTION
Closes #16

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds the backend landing builder implementation: PAGE_LANDING prompts, canonical first-write from Home Builder, dormant Step_Landing_Page_Builder, meta whitelist, and generate-pages landing safety guards.
- Keeps `landing-page-builder` dormant until PR3 wires UI, noindex/menu final-state sync, and template rendering.
- Enables controlled unlock only after the landing deletion guard is present.

## Chain Context

Strategy: feature-branch-chain

```text
feature/wizard-setup
└── PR 1: feat/wizard-landing-foundation
    └── 📍 PR 2: feat/wizard-landing-backend
        └── PR 3: menu/SEO/UI/template verification (next)
```

Current PR boundary: backend landing slice only. The landing step class exists but is intentionally not active in `REQUIRED_STEPS` or `DISPATCHABLE_STEPS` until PR3 activation.

## Changes

| File | Change |
|------|--------|
| `inc/wizard/class-ai-content-harness.php` | Adds landing page context and keyword-gated Layer 3 behavior. |
| `inc/wizard/class-step-home-page-builder.php` | First-writes reusable prepared sections into the canonical store. |
| `inc/wizard/class-step-landing-page-builder.php` | Adds dormant backend runtime for landing validation, canonical bootstrap, page build/update, identity, fail-closed keyword sections, and partial recovery. |
| `inc/wizard/class-content-builder.php` | Adds whitelist-only `meta_input` support for `_wp_page_template` and `rms_landing_type`. |
| `inc/wizard/class-step-generate-pages.php` | Prevents generated-pages from updating/deleting/assigning landing pages. |
| `inc/wizard/class-step-controller.php` | Adds dormant landing alias/dispatch comments without activating the step. |
| `inc/wizard/class-wizard-unlock-controller.php` | Enables controlled unlock now that deletion guard exists. |
| `openspec/changes/wizard-landing-page-builder/tasks.md` | Marks Phase 2 complete and records Phase 3 activation task. |
| `openspec/changes/wizard-landing-page-builder/apply-progress.md` | Records Phase 2 progress, review fixes, known no-runner limitation, and shared-helper follow-up. |

## Test Plan

- [x] `php -l` passed on all PHP files touched/created in Phase 2.
- [x] 4R review completed: risk PASS, resilience PASS, readability PASS, reliability PASS except known no-runner limitation documented by project config.
- [x] Confirmed current 7-step wizard remains valid because `landing-page-builder` is dormant until PR3.
- [x] Confirmed generate-pages fails closed if selected slugs resolve to landing pages and protects landing pages from deletion.
- [x] Confirmed keyword-governed sections fail closed on AI/decode/review failures instead of publishing placeholders.

## Known Limitations / Follow-ups

- Automated behavioral tests are unavailable in this project (`strict_tdd: false`, no runner). Manual runtime verification remains tracked for Phase 4.
- Landing UI, Ads noindex/Yoast/sitemap sync, menu reconciliation, and template rendering are intentionally deferred to PR3.
- Landing builder duplicates helper families from Home Builder; extraction to a shared section assembler is documented for after PR3 or before archive.

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran applicable syntax checks
- [x] SDD artifacts updated
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers