### PR TITLE
feat(wizard): activate landing page builder

### DIFF
--- a/inc/wizard/class-menu-builder.php
+++ b/inc/wizard/class-menu-builder.php
@@ -154,6 +154,391 @@ class Menu_Builder {
 		return $deleted;
 	}
 
+	/**
+	 * Append page links to a menu without duplicating existing page items.
+	 *
+	 * Best-effort for SEO eligibility paths: failures are reported in the
+	 * structured result (and logged) so callers can warn without fail-closing.
+	 * Ads/ineligible removal remains fail-closed via `remove_page_items()`.
+	 *
+	 * @param int        $menu_id  Menu term ID.
+	 * @param array<int> $page_ids Page post IDs to ensure are present.
+	 *
+	 * @return array{
+	 *   created: array<int,int>,
+	 *   already_present: array<int,int>,
+	 *   failed_page_ids: array<int,int>,
+	 *   verified: bool
+	 * }
+	 */
+	public function append_page_items( int $menu_id, array $page_ids ): array {
+		$menu_id = \absint( $menu_id );
+		$empty   = [
+			'created'          => [],
+			'already_present'  => [],
+			'failed_page_ids'  => [],
+			'verified'         => true,
+		];
+
+		if ( $menu_id <= 0 ) {
+			return $empty;
+		}
+
+		$existing_page_ids = $this->menu_page_ids( $menu_id );
+		$created           = [];
+		$already_present   = [];
+		$create_failed     = [];
+		$requested         = [];
+		$position          = count( $existing_page_ids ) + 1;
+
+		foreach ( $page_ids as $page_id ) {
+			$page_id = \absint( $page_id );
+
+			if ( $page_id <= 0 || 'page' !== \get_post_type( $page_id ) ) {
+				continue;
+			}
+
+			$requested[] = $page_id;
+
+			if ( in_array( $page_id, $existing_page_ids, true ) ) {
+				$already_present[] = $page_id;
+				continue;
+			}
+
+			$item_id = \wp_update_nav_menu_item(
+				$menu_id,
+				0,
+				[
+					'menu-item-object-id' => $page_id,
+					'menu-item-object'    => 'page',
+					'menu-item-type'      => 'post_type',
+					'menu-item-status'    => 'publish',
+					'menu-item-position'  => $position,
+				]
+			);
+
+			if ( \is_wp_error( $item_id ) ) {
+				$create_failed[] = $page_id;
+				$this->logger->log(
+					'error',
+					'Wizard menu item append failed.',
+					[
+						'menu_id'       => $menu_id,
+						'page_id'       => $page_id,
+						'error_code'    => $item_id->get_error_code(),
+						'error_message' => $item_id->get_error_message(),
+					]
+				);
+				continue;
+			}
+
+			$created[]           = (int) $item_id;
+			$existing_page_ids[] = $page_id;
+			$position++;
+		}
+
+		// Bust object cache so read-back reflects freshly written items.
+		if ( function_exists( 'clean_term_cache' ) ) {
+			\clean_term_cache( $menu_id, 'nav_menu' );
+		}
+
+		$present_after = $this->menu_page_ids( $menu_id );
+		$failed        = [];
+
+		foreach ( array_values( array_unique( $requested ) ) as $page_id ) {
+			if ( ! in_array( $page_id, $present_after, true ) ) {
+				$failed[] = $page_id;
+			}
+		}
+
+		// Prefer create-time failures when read-back also missed them.
+		$failed = array_values( array_unique( array_merge( $create_failed, $failed ) ) );
+		$ok     = [] === $failed;
+
+		if ( [] !== $created ) {
+			$this->logger->log(
+				'info',
+				'Wizard menu items appended.',
+				[
+					'menu_id'    => $menu_id,
+					'item_count' => count( $created ),
+					'created'    => $created,
+				]
+			);
+		}
+
+		if ( ! $ok ) {
+			$this->logger->log(
+				'warning',
+				'Wizard menu item append incomplete after verification.',
+				[
+					'menu_id'          => $menu_id,
+					'failed_page_ids'  => $failed,
+					'already_present'  => array_values( array_unique( $already_present ) ),
+					'created'          => $created,
+					'requested'        => array_values( array_unique( $requested ) ),
+				]
+			);
+		}
+
+		return [
+			'created'         => $created,
+			'already_present' => array_values( array_unique( $already_present ) ),
+			'failed_page_ids' => $failed,
+			'verified'        => $ok,
+		];
+	}
+
+	/**
+	 * Remove nav items that point at the given page IDs.
+	 *
+	 * Verifies via read-back that target page IDs are no longer present.
+	 *
+	 * @param int        $menu_id  Menu term ID.
+	 * @param array<int> $page_ids Page post IDs to remove from the menu.
+	 *
+	 * @return array{deleted:array<int,int>,failed_page_ids:array<int,int>,verified:bool}
+	 */
+	public function remove_page_items( int $menu_id, array $page_ids ): array {
+		$menu_id  = \absint( $menu_id );
+		$page_ids = array_values(
+			array_unique(
+				array_filter(
+					array_map( 'absint', $page_ids )
+				)
+			)
+		);
+
+		$empty = [
+			'deleted'          => [],
+			'failed_page_ids'  => [],
+			'verified'         => true,
+		];
+
+		if ( $menu_id <= 0 || [] === $page_ids ) {
+			return $empty;
+		}
+
+		$items = \wp_get_nav_menu_items( $menu_id );
+
+		if ( empty( $items ) || ! is_array( $items ) ) {
+			// Nothing to remove — already verified absent.
+			return $empty;
+		}
+
+		$deleted = [];
+
+		foreach ( $items as $item ) {
+			$object_id = (int) ( $item->object_id ?? 0 );
+			$type      = (string) ( $item->type ?? '' );
+			$object    = (string) ( $item->object ?? '' );
+
+			if ( 'post_type' !== $type || 'page' !== $object ) {
+				continue;
+			}
+
+			if ( ! in_array( $object_id, $page_ids, true ) ) {
+				continue;
+			}
+
+			$item_id = (int) ( $item->ID ?? 0 );
+
+			if ( $item_id <= 0 ) {
+				continue;
+			}
+
+			$result = \wp_delete_post( $item_id, true );
+
+			if ( $result ) {
+				$deleted[] = $item_id;
+			} else {
+				$this->logger->log(
+					'error',
+					'Wizard menu item delete failed.',
+					[
+						'menu_id'  => $menu_id,
+						'item_id'  => $item_id,
+						'page_id'  => $object_id,
+					]
+				);
+			}
+		}
+
+		// Bust nav menu item cache so read-back is not stale.
+		\wp_cache_delete( $menu_id, 'nav_menu_items' );
+		if ( function_exists( 'clean_term_cache' ) ) {
+			\clean_term_cache( $menu_id, 'nav_menu' );
+		}
+
+		$still_present = array_values(
+			array_intersect( $this->menu_page_ids( $menu_id ), $page_ids )
+		);
+		$verified      = [] === $still_present;
+
+		if ( [] !== $deleted ) {
+			$this->logger->log(
+				'info',
+				'Wizard menu items removed for pages.',
+				[
+					'menu_id'    => $menu_id,
+					'page_ids'   => $page_ids,
+					'item_count' => count( $deleted ),
+					'verified'   => $verified,
+				]
+			);
+		}
+
+		if ( ! $verified ) {
+			$this->logger->log(
+				'error',
+				'Wizard menu page removal failed read-back verification.',
+				[
+					'menu_id'         => $menu_id,
+					'page_ids'        => $page_ids,
+					'failed_page_ids' => $still_present,
+					'deleted_items'   => $deleted,
+				]
+			);
+		}
+
+		return [
+			'deleted'         => $deleted,
+			'failed_page_ids' => $still_present,
+			'verified'        => $verified,
+		];
+	}
+
+	/**
+	 * Final-state landing menu reconciliation across configured menus.
+	 *
+	 * Eligible SEO landings are present idempotently; Ads / ineligible landings are removed.
+	 * Removal is verified via read-back; failures are reported in the return payload.
+	 * SEO append is best-effort: `append_failed_page_ids` is reported but does not
+	 * flip `verified` (Ads removal remains fail-closed).
+	 *
+	 * @param array<int>                        $menu_ids       Menu term IDs to reconcile.
+	 * @param array<int,array<string,mixed>>    $landing_pages  Landing state rows.
+	 *
+	 * @return array{
+	 *   appended:array<int,int>,
+	 *   removed:array<int,int>,
+	 *   removal_failed_page_ids:array<int,int>,
+	 *   append_failed_page_ids:array<int,int>,
+	 *   verified:bool
+	 * }
+	 */
+	public function reconcile_landing_menu_items( array $menu_ids, array $landing_pages ): array {
+		$eligible_ids   = [];
+		$ineligible_ids = [];
+
+		foreach ( $landing_pages as $landing ) {
+			if ( ! is_array( $landing ) ) {
+				continue;
+			}
+
+			$page_id = \absint( $landing['id'] ?? 0 );
+
+			if ( $page_id <= 0 || 'page' !== \get_post_type( $page_id ) ) {
+				continue;
+			}
+
+			$type          = \sanitize_key( (string) ( $landing['landing_type'] ?? '' ) );
+			$menu_eligible = array_key_exists( 'menu_eligible', $landing )
+				? (bool) $landing['menu_eligible']
+				: ( 'seo' === $type );
+
+			if ( 'seo' === $type && $menu_eligible ) {
+				$eligible_ids[] = $page_id;
+			} else {
+				$ineligible_ids[] = $page_id;
+			}
+		}
+
+		$eligible_ids   = array_values( array_unique( $eligible_ids ) );
+		$ineligible_ids = array_values( array_unique( $ineligible_ids ) );
+		$appended       = [];
+		$removed        = [];
+		$failed_pages   = [];
+		$append_failed  = [];
+
+		foreach ( $menu_ids as $menu_id ) {
+			$menu_id = \absint( $menu_id );
+
+			if ( $menu_id <= 0 ) {
+				continue;
+			}
+
+			if ( [] !== $ineligible_ids ) {
+				$removal      = $this->remove_page_items( $menu_id, $ineligible_ids );
+				$removed      = array_merge( $removed, is_array( $removal['deleted'] ?? null ) ? $removal['deleted'] : [] );
+				$failed       = is_array( $removal['failed_page_ids'] ?? null ) ? $removal['failed_page_ids'] : [];
+				$failed_pages = array_merge( $failed_pages, $failed );
+			}
+
+			if ( [] !== $eligible_ids ) {
+				$append_result = $this->append_page_items( $menu_id, $eligible_ids );
+				$created       = is_array( $append_result['created'] ?? null ) ? $append_result['created'] : [];
+				$failed_append = is_array( $append_result['failed_page_ids'] ?? null ) ? $append_result['failed_page_ids'] : [];
+				$appended      = array_merge( $appended, $created );
+				$append_failed = array_merge( $append_failed, $failed_append );
+			}
+		}
+
+		$failed_pages  = array_values( array_unique( array_map( 'absint', $failed_pages ) ) );
+		$append_failed = array_values( array_unique( array_map( 'absint', $append_failed ) ) );
+		// verified tracks Ads/ineligible removal only (fail-closed). SEO append is best-effort.
+		$verified = [] === $failed_pages;
+
+		if ( [] !== $append_failed ) {
+			$this->logger->log(
+				'warning',
+				'Landing menu reconciliation SEO append incomplete (best-effort; Ads removal still authoritative).',
+				[
+					'menu_ids'               => array_values( array_map( 'absint', $menu_ids ) ),
+					'append_failed_page_ids' => $append_failed,
+					'removal_failed_page_ids'=> $failed_pages,
+				]
+			);
+		}
+
+		return [
+			'appended'                 => $appended,
+			'removed'                  => $removed,
+			'removal_failed_page_ids'  => $failed_pages,
+			'append_failed_page_ids'   => $append_failed,
+			'verified'                 => $verified,
+		];
+	}
+
+	/**
+	 * Page object IDs currently linked in a menu.
+	 *
+	 * @return array<int,int>
+	 */
+	private function menu_page_ids( int $menu_id ): array {
+		$items = \wp_get_nav_menu_items( $menu_id );
+
+		if ( empty( $items ) || ! is_array( $items ) ) {
+			return [];
+		}
+
+		$page_ids = [];
+
+		foreach ( $items as $item ) {
+			if ( 'post_type' !== (string) ( $item->type ?? '' ) || 'page' !== (string) ( $item->object ?? '' ) ) {
+				continue;
+			}
+
+			$page_id = (int) ( $item->object_id ?? 0 );
+
+			if ( $page_id > 0 ) {
+				$page_ids[] = $page_id;
+			}
+		}
+
+		return array_values( array_unique( $page_ids ) );
+	}
+
 	private function delete_menu_items( int $menu_id ): void {
 		$items = \wp_get_nav_menu_items( $menu_id );
 

--- a/inc/wizard/class-step-controller.php
+++ b/inc/wizard/class-step-controller.php
@@ -30,11 +30,8 @@ class Step_Controller {
 	 * Single source of truth for currently required wizard steps.
 	 * Consumed by complete() and step services (e.g. maybe_mark_completed).
 	 *
-	 * PR2 keeps the existing 7-step completion surface. `landing-page-builder`
-	 * backend class exists, but required/dispatch/UI activation is deferred to
-	 * Phase 3 (menu/SEO/noindex + admin UI) so Ads landings cannot go live
-	 * without final-state controls and the UI cannot show 7/7 while an 8th
-	 * invisible step is required.
+	 * Phase 3 activates `landing-page-builder` atomically with admin UI +
+	 * Ads noindex/menu final-state sync (tasks 3.1–3.7).
 	 *
 	 * @var string[]
 	 */
@@ -46,15 +43,12 @@ class Step_Controller {
 		'menu-setup',
 		'ia-generation',
 		'home-page-builder',
+		'landing-page-builder',
 	];
 
 	/**
 	 * Steps that may be dispatched by execute_step() right now.
 	 * Must stay in sync with dispatch_step() cases.
-	 *
-	 * PR2: `landing-page-builder` is intentionally NOT dispatchable until
-	 * Phase 3 wires UI + noindex/menu final-state sync. The dispatch case and
-	 * `Step_Landing_Page_Builder` class remain for that activation.
 	 *
 	 * @var string[]
 	 */
@@ -66,6 +60,7 @@ class Step_Controller {
 		'menu-setup',
 		'ia-generation',
 		'home-page-builder',
+		'landing-page-builder',
 		'unlock',
 		'relock',
 	];
@@ -260,8 +255,6 @@ class Step_Controller {
 			case 'home-page-builder':
 				return ( new Step_Home_Page_Builder( $this->logger, $this->state_manager ) )->run( $payload );
 
-			// Kept for Phase 3 activation. Not reachable until REQUIRED_STEPS +
-			// DISPATCHABLE_STEPS + UI re-include `landing-page-builder` together.
 			case 'landing-page-builder':
 				return ( new Step_Landing_Page_Builder( $this->logger, $this->state_manager ) )->run( $payload );
 
@@ -367,10 +360,6 @@ class Step_Controller {
 			'generate_pages'    => 'generate-pages',
 			'menu_setup'        => 'menu-setup',
 			'home_page_builder' => 'home-page-builder',
-			// Phase 3 activation: re-enable `landing_page_builder` alias together
-			// with DISPATCHABLE_STEPS, REQUIRED_STEPS, dispatch case, and admin UI.
-			// Alias alone is safe (unknown-step reject runs before status writes)
-			// but must not be treated as "live" until that full activation set lands.
 			'landing_page_builder' => 'landing-page-builder',
 		];
 

--- a/inc/wizard/class-step-landing-page-builder.php
+++ b/inc/wizard/class-step-landing-page-builder.php
@@ -12,12 +12,8 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Builds N SEO/Ads landing pages from canonical reusable sections + keyword copy.
  *
- * Phase 2 backend scope: identity preflight, lazy canonical bootstrap, page upsert
- * with template/type meta, and state persistence. Menu/Yoast/noindex final-state
- * sync remains Phase 3.
- *
- * PR2 safety: class is implemented but NOT active in REQUIRED_STEPS / DISPATCHABLE_STEPS
- * until Phase 3 wires UI + Ads noindex/menu final-state sync.
+ * Includes identity preflight, lazy canonical bootstrap, page upsert with
+ * template/type meta, Yoast/noindex final-state sync, and menu reconciliation.
  */
 class Step_Landing_Page_Builder {
 	private const STEP     = 'landing-page-builder';
@@ -46,6 +42,8 @@ class Step_Landing_Page_Builder {
 	private $harness;
 	private $reviewer;
 	private $canonical_store;
+	private $menu_builder;
+	private $yoast_meta_writer;
 
 	public function __construct(
 		?Logger $logger = null,
@@ -54,7 +52,9 @@ class Step_Landing_Page_Builder {
 		?Flexible_Content_Layouts $layout_repository = null,
 		?AI_Content_Harness $harness = null,
 		?AI_Content_Reviewer $reviewer = null,
-		?Canonical_Section_Store $canonical_store = null
+		?Canonical_Section_Store $canonical_store = null,
+		?Menu_Builder $menu_builder = null,
+		?Yoast_Meta_Writer $yoast_meta_writer = null
 	) {
 		$this->logger            = $logger ?? new Logger();
 		$this->state_manager     = $state_manager ?? new State_Manager();
@@ -63,6 +63,8 @@ class Step_Landing_Page_Builder {
 		$this->harness           = $harness ?? new AI_Content_Harness();
 		$this->reviewer          = $reviewer;
 		$this->canonical_store   = $canonical_store ?? new Canonical_Section_Store();
+		$this->menu_builder      = $menu_builder ?? new Menu_Builder( $this->logger );
+		$this->yoast_meta_writer = $yoast_meta_writer ?? new Yoast_Meta_Writer( $this->logger );
 	}
 
 	/**
@@ -74,6 +76,69 @@ class Step_Landing_Page_Builder {
 	 */
 	public function run( array $payload ) {
 		if ( $this->truthy( $payload['skip_all'] ?? false ) ) {
+			$state             = $this->state_manager->get_state();
+			$existing_landings = $this->normalize_state_landings(
+				is_array( $state['landing_pages'] ?? null ) ? $state['landing_pages'] : []
+			);
+
+			// Existing landings must still receive final-state robots/menu reconciliation.
+			// No existing landings → skip-all is a pure no-op complete.
+			if ( [] !== $existing_landings ) {
+				foreach ( $existing_landings as $landing_key => $row ) {
+					if ( ! is_array( $row ) ) {
+						continue;
+					}
+
+					$post_id     = (int) ( $row['id'] ?? 0 );
+					$slug        = (string) ( $row['slug'] ?? '' );
+					$log_context = [
+						'landing_key' => (string) ( $row['landing_key'] ?? $landing_key ),
+						'slug'        => $slug,
+						'skip_all'    => true,
+					];
+
+					if ( $post_id <= 0 || 'page' !== \get_post_type( $post_id ) ) {
+						$post_id = $this->recover_build_page_post_id( $post_id, $slug );
+					}
+
+					if ( $post_id <= 0 || 'page' !== \get_post_type( $post_id ) ) {
+						$this->mark_step_status( 'failed' );
+
+						return new \WP_Error(
+							'rms_wizard_landing_skip_all_missing_post',
+							sprintf(
+								/* translators: %s: landing key or slug. */
+								\__( 'Skip-all could not reconcile landing "%s": page not found.', 'simple-rms-theme' ),
+								'' !== (string) ( $row['landing_key'] ?? '' )
+									? (string) $row['landing_key']
+									: ( '' !== $slug ? $slug : (string) $landing_key )
+							),
+							array_merge( [ 'status' => 500 ], $log_context )
+						);
+					}
+
+					$final_state = $this->sync_landing_final_state( $post_id, $row, $log_context );
+
+					if ( \is_wp_error( $final_state ) ) {
+						$this->mark_step_status( 'failed' );
+						$this->logger->log(
+							'error',
+							'Skip-all final-state sync failed; step not marked complete.',
+							array_merge(
+								$log_context,
+								[
+									'post_id'       => $post_id,
+									'error_code'    => $final_state->get_error_code(),
+									'error_message' => $final_state->get_error_message(),
+								]
+							)
+						);
+
+						return $final_state;
+					}
+				}
+			}
+
 			if ( ! $this->mark_step_status( 'complete' ) ) {
 				return new \WP_Error(
 					'rms_wizard_landing_status_persist_failed',
@@ -863,6 +928,11 @@ class Step_Landing_Page_Builder {
 				)
 			);
 
+			// Ads may already be published — best-effort noindex/menu cleanup before failing.
+			if ( $recovered_id > 0 ) {
+				$this->protect_ads_final_state_best_effort( $recovered_id, $row, $log_context );
+			}
+
 			$error_data = array_merge(
 				[
 					'status'          => 500,
@@ -888,13 +958,37 @@ class Step_Landing_Page_Builder {
 		}
 
 		if ( $post_id <= 0 ) {
-			return new \WP_Error( 'rms_wizard_landing_save_failed', \__( 'Landing page could not be saved.', 'simple-rms-theme' ), array_merge( [ 'status' => 500 ], $log_context ) );
+			$recovered_id = $this->recover_build_page_post_id( $existing_id, (string) $row['slug'] );
+
+			if ( $recovered_id > 0 ) {
+				$this->protect_ads_final_state_best_effort( $recovered_id, $row, $log_context );
+			}
+
+			return new \WP_Error(
+				'rms_wizard_landing_save_failed',
+				\__( 'Landing page could not be saved.', 'simple-rms-theme' ),
+				array_merge(
+					[ 'status' => 500 ],
+					$log_context,
+					$recovered_id > 0 ? [ 'post_id' => $recovered_id ] : []
+				)
+			);
 		}
 
 		$meta_ok = $this->ensure_landing_meta( $post_id, (string) $row['landing_type'], $log_context );
 
 		if ( \is_wp_error( $meta_ok ) ) {
+			// Published page without verified meta — protect Ads before surfacing failure.
+			$this->protect_ads_final_state_best_effort( $post_id, $row, $log_context );
+
 			return $meta_ok;
+		}
+
+		// Final-state Yoast + robots + menu reconciliation (every create/update).
+		$final_state = $this->sync_landing_final_state( $post_id, $row, $log_context );
+
+		if ( \is_wp_error( $final_state ) ) {
+			return $final_state;
 		}
 
 		$entry = [
@@ -918,6 +1012,247 @@ class Step_Landing_Page_Builder {
 			'landing_key'    => (string) $row['landing_key'],
 			'prior_payloads' => $local_priors,
 		];
+	}
+
+	/**
+	 * Apply final-state menu + robots + Yoast title/metadesc for one landing.
+	 *
+	 * SEO: clear noindex; append to configured menus idempotently when eligible.
+	 * Ads: write noindex + read-back (fail closed); remove from configured menus.
+	 *
+	 * @param array<string,mixed> $row
+	 * @param array<string,mixed> $log_context
+	 *
+	 * @return true|\WP_Error
+	 */
+	private function sync_landing_final_state( int $post_id, array $row, array $log_context ) {
+		$landing_type    = \sanitize_key( (string) ( $row['landing_type'] ?? 'seo' ) );
+		$landing_type    = in_array( $landing_type, [ 'seo', 'ads' ], true ) ? $landing_type : 'seo';
+		$primary_keyword = (string) ( $row['primary_keyword'] ?? '' );
+		$title           = (string) ( $row['title'] ?? '' );
+		$menu_eligible   = array_key_exists( 'menu_eligible', $row )
+			? (bool) $row['menu_eligible']
+			: ( 'seo' === $landing_type );
+
+		// Optional Yoast title/metadesc (skip+log when Yoast absent — never fails the step).
+		$this->yoast_meta_writer->write_landing_seo( $post_id, $primary_keyword, $landing_type, $title );
+
+		// Robots final state.
+		if ( 'ads' === $landing_type ) {
+			$noindex = $this->yoast_meta_writer->set_noindex( $post_id, true );
+
+			if ( \is_wp_error( $noindex ) ) {
+				return $noindex;
+			}
+		} else {
+			$clear = $this->yoast_meta_writer->set_noindex( $post_id, false );
+
+			if ( \is_wp_error( $clear ) ) {
+				return $clear;
+			}
+		}
+
+		// Menu final state against currently configured theme menus.
+		$menu_ids = $this->configured_menu_ids();
+
+		if ( [] === $menu_ids ) {
+			$this->logger->log(
+				'info',
+				'Landing final-state menu sync skipped; no configured menus yet.',
+				array_merge( [ 'post_id' => $post_id, 'landing_type' => $landing_type ], $log_context )
+			);
+
+			return true;
+		}
+
+		$seo_append_failed = [];
+
+		if ( 'seo' === $landing_type && $menu_eligible ) {
+			// SEO menu append is best-effort: log failures with detail, do not fail-close.
+			// Ads menu removal below remains fail-closed.
+			foreach ( $menu_ids as $menu_id ) {
+				$append = $this->menu_builder->append_page_items( $menu_id, [ $post_id ] );
+
+				if ( empty( $append['verified'] ) ) {
+					$failed = is_array( $append['failed_page_ids'] ?? null )
+						? array_values( $append['failed_page_ids'] )
+						: [ $post_id ];
+					$seo_append_failed[] = [
+						'menu_id'         => $menu_id,
+						'failed_page_ids' => $failed,
+						'created'         => is_array( $append['created'] ?? null ) ? $append['created'] : [],
+						'already_present' => is_array( $append['already_present'] ?? null ) ? $append['already_present'] : [],
+					];
+
+					$this->logger->log(
+						'warning',
+						'Landing final-state SEO menu append failed (best-effort; step continues). Ads removal remains fail-closed.',
+						array_merge(
+							[
+								'post_id'          => $post_id,
+								'menu_id'          => $menu_id,
+								'landing_type'     => $landing_type,
+								'failed_page_ids'  => $failed,
+								'created'          => $append['created'] ?? [],
+								'already_present'  => $append['already_present'] ?? [],
+							],
+							$log_context
+						)
+					);
+				}
+			}
+		} else {
+			// Ads / ineligible: fail-closed if menu removal cannot be verified.
+			foreach ( $menu_ids as $menu_id ) {
+				$removal = $this->menu_builder->remove_page_items( $menu_id, [ $post_id ] );
+
+				if ( empty( $removal['verified'] ) ) {
+					$failed = is_array( $removal['failed_page_ids'] ?? null )
+						? array_values( $removal['failed_page_ids'] )
+						: [ $post_id ];
+
+					$this->logger->log(
+						'error',
+						'Landing final-state menu removal failed verification.',
+						array_merge(
+							[
+								'post_id'          => $post_id,
+								'menu_id'          => $menu_id,
+								'landing_type'     => $landing_type,
+								'failed_page_ids'  => $failed,
+							],
+							$log_context
+						)
+					);
+
+					return new \WP_Error(
+						'rms_wizard_landing_menu_remove_failed',
+						sprintf(
+							/* translators: %s: landing title or slug. */
+							\__( 'Landing "%s" could not be removed from menus. Final state was not applied.', 'simple-rms-theme' ),
+							'' !== $title ? $title : (string) ( $row['slug'] ?? $post_id )
+						),
+						array_merge(
+							[
+								'status'          => 500,
+								'post_id'         => $post_id,
+								'menu_id'         => $menu_id,
+								'failed_page_ids' => $failed,
+							],
+							$log_context
+						)
+					);
+				}
+			}
+		}
+
+		$this->logger->log(
+			'info',
+			'Landing final-state menu/robots sync applied.',
+			array_merge(
+				[
+					'post_id'            => $post_id,
+					'landing_type'       => $landing_type,
+					'menu_eligible'      => $menu_eligible,
+					'menu_ids'           => $menu_ids,
+					'seo_append_best_effort' => 'seo' === $landing_type && $menu_eligible,
+					'seo_append_failed'  => $seo_append_failed,
+				],
+				$log_context
+			)
+		);
+
+		return true;
+	}
+
+	/**
+	 * Best-effort Ads final-state protection after a post-publish failure.
+	 *
+	 * Does not change the caller's failure outcome — only attempts noindex + menu
+	 * removal when landing_type is ads and a post ID is known. Logs success/failure.
+	 *
+	 * @param array<string,mixed> $row
+	 * @param array<string,mixed> $log_context
+	 */
+	private function protect_ads_final_state_best_effort( int $post_id, array $row, array $log_context ): void {
+		$post_id      = \absint( $post_id );
+		$landing_type = \sanitize_key( (string) ( $row['landing_type'] ?? 'seo' ) );
+		$landing_type = in_array( $landing_type, [ 'seo', 'ads' ], true ) ? $landing_type : 'seo';
+		$landing_key  = (string) ( $row['landing_key'] ?? ( $log_context['landing_key'] ?? '' ) );
+		$slug         = (string) ( $row['slug'] ?? ( $log_context['slug'] ?? '' ) );
+
+		if ( $post_id <= 0 || 'ads' !== $landing_type ) {
+			return;
+		}
+
+		// Ensure Ads path in sync (menu_eligible false).
+		$protection_row                   = $row;
+		$protection_row['landing_type']   = 'ads';
+		$protection_row['menu_eligible']  = false;
+
+		$protection = $this->sync_landing_final_state( $post_id, $protection_row, $log_context );
+		$ok         = ! \is_wp_error( $protection );
+
+		$this->logger->log(
+			$ok ? 'info' : 'error',
+			$ok
+				? 'Ads best-effort final-state protection succeeded after build failure.'
+				: 'Ads best-effort final-state protection failed after build failure.',
+			array_merge(
+				[
+					'post_id'           => $post_id,
+					'landing_key'       => $landing_key,
+					'slug'              => $slug,
+					'protection_ok'     => $ok,
+					'protection_error'  => $ok ? null : $protection->get_error_code(),
+					'protection_message'=> $ok ? null : $protection->get_error_message(),
+				],
+				$log_context
+			)
+		);
+	}
+
+	/**
+	 * Menu term IDs currently assigned to theme locations / stored menu_config.
+	 *
+	 * @return array<int,int>
+	 */
+	private function configured_menu_ids(): array {
+		$ids   = [];
+		$state = $this->state_manager->get_state();
+		$config = is_array( $state['menu_config'] ?? null ) ? $state['menu_config'] : [];
+
+		foreach ( [ 'primary_menu_id', 'mobile_menu_id' ] as $key ) {
+			$id = \absint( $config[ $key ] ?? 0 );
+
+			if ( $id > 0 ) {
+				$ids[] = $id;
+			}
+		}
+
+		if ( is_array( $config['locations'] ?? null ) ) {
+			foreach ( $config['locations'] as $menu_id ) {
+				$id = \absint( $menu_id );
+
+				if ( $id > 0 ) {
+					$ids[] = $id;
+				}
+			}
+		}
+
+		$locations = \get_theme_mod( 'nav_menu_locations', [] );
+
+		if ( is_array( $locations ) ) {
+			foreach ( $locations as $menu_id ) {
+				$id = \absint( $menu_id );
+
+				if ( $id > 0 ) {
+					$ids[] = $id;
+				}
+			}
+		}
+
+		return array_values( array_unique( array_filter( $ids ) ) );
 	}
 
 	/**
@@ -1857,6 +2192,9 @@ class Step_Landing_Page_Builder {
 				)
 			);
 
+			// Best-effort Ads protection before returning the original preserve failure.
+			$this->protect_ads_final_state_best_effort( $existing_id, $row, $log_context );
+
 			return new \WP_Error(
 				'rms_wizard_landing_preserve_failed',
 				\__( 'Keyword generation failed and the existing landing page could not be preserved.', 'simple-rms-theme' ),
@@ -1884,6 +2222,9 @@ class Step_Landing_Page_Builder {
 					]
 				)
 			);
+
+			// Best-effort Ads protection before returning the original preserve failure.
+			$this->protect_ads_final_state_best_effort( $existing_id, $row, $log_context );
 
 			return new \WP_Error(
 				'rms_wizard_landing_preserve_failed',
@@ -1915,7 +2256,17 @@ class Step_Landing_Page_Builder {
 				)
 			);
 
+			// Best-effort Ads protection before returning the original meta failure.
+			$this->protect_ads_final_state_best_effort( $existing_id, $row, $log_context );
+
 			return $meta_ok;
+		}
+
+		// Type flips / robots / menu still reconcile even when sections are preserved.
+		$final_state = $this->sync_landing_final_state( $existing_id, $row, $log_context );
+
+		if ( \is_wp_error( $final_state ) ) {
+			return $final_state;
 		}
 
 		$entry = [

--- a/inc/wizard/class-step-menu-setup.php
+++ b/inc/wizard/class-step-menu-setup.php
@@ -35,8 +35,14 @@ class Step_Menu_Setup {
 	public function run( array $payload ) {
 		$state           = $this->state_manager->get_state();
 		$generated_pages = is_array( $state['generated_pages'] ?? null ) ? $state['generated_pages'] : [];
+		$landing_pages   = is_array( $state['landing_pages'] ?? null ) ? $state['landing_pages'] : [];
 
-		if ( [] === $generated_pages ) {
+		// Pool may come from generated_pages and/or menu-eligible SEO landings.
+		// Do not fail solely because generated_pages is empty when landings exist.
+		// Ads remain excluded from the pool.
+		$page_pool = $this->build_page_pool( $generated_pages, $landing_pages );
+
+		if ( [] === $page_pool ) {
 			$this->state_manager->set_step_status( self::STEP, 'failed' );
 
 			return new \WP_Error( 'rms_wizard_no_generated_pages', \__( 'No pages found. Please complete the Generate Pages step first', 'simple-rms-theme' ), [ 'status' => 400 ] );
@@ -44,8 +50,8 @@ class Step_Menu_Setup {
 
 		$primary_input    = is_array( $payload['primary'] ?? null ) ? $payload['primary'] : ( is_array( $payload['primary_page_ids'] ?? null ) ? $payload['primary_page_ids'] : [] );
 		$mobile_input     = is_array( $payload['mobile'] ?? null ) ? $payload['mobile'] : ( is_array( $payload['mobile_page_ids'] ?? null ) ? $payload['mobile_page_ids'] : [] );
-		$primary_page_ids = $this->resolve_page_ids( $primary_input, $generated_pages );
-		$mobile_page_ids  = $this->resolve_page_ids( $mobile_input, $generated_pages );
+		$primary_page_ids = $this->resolve_page_ids( $primary_input, $page_pool );
+		$mobile_page_ids  = $this->resolve_page_ids( $mobile_input, $page_pool );
 
 		if ( [] === $primary_page_ids ) {
 			$this->state_manager->set_step_status( self::STEP, 'failed' );
@@ -89,11 +95,70 @@ class Step_Menu_Setup {
 
 		$this->menu_builder->assign_location( 'mobile', $mobile_menu_id );
 
+		// Mandatory safety net after destructive replace: eligible SEO present, Ads removed.
+		$configured_menu_ids = array_values(
+			array_unique(
+				array_filter(
+					[
+						$primary_menu_id,
+						$mobile_menu_id,
+					]
+				)
+			)
+		);
+		$landing_reconcile = $this->menu_builder->reconcile_landing_menu_items( $configured_menu_ids, $landing_pages );
+
+		// Fail-closed when Ads / ineligible landings could not be verified removed.
+		if ( empty( $landing_reconcile['verified'] ) ) {
+			$failed = is_array( $landing_reconcile['removal_failed_page_ids'] ?? null )
+				? array_values( $landing_reconcile['removal_failed_page_ids'] )
+				: [];
+
+			$this->state_manager->set_step_status( self::STEP, 'failed' );
+			$this->logger->log(
+				'error',
+				'Menu setup landing reconciliation failed Ads/ineligible removal verification.',
+				[
+					'menu_ids'                 => $configured_menu_ids,
+					'removal_failed_page_ids'  => $failed,
+					'landing_reconcile'        => $landing_reconcile,
+				]
+			);
+
+			return new \WP_Error(
+				'rms_wizard_menu_ads_removal_failed',
+				\__( 'Menu setup could not verify removal of Ads or ineligible landing pages from menus.', 'simple-rms-theme' ),
+				[
+					'status'                  => 500,
+					'removal_failed_page_ids' => $failed,
+					'landing_reconcile'       => $landing_reconcile,
+				]
+			);
+		}
+
+		// SEO append is best-effort: surface incomplete appends without failing the step.
+		$append_failed = is_array( $landing_reconcile['append_failed_page_ids'] ?? null )
+			? array_values( $landing_reconcile['append_failed_page_ids'] )
+			: [];
+
+		if ( [] !== $append_failed ) {
+			$this->logger->log(
+				'warning',
+				'Menu setup SEO landing menu append incomplete (best-effort; Ads removal verified).',
+				[
+					'menu_ids'               => $configured_menu_ids,
+					'append_failed_page_ids' => $append_failed,
+					'landing_reconcile'      => $landing_reconcile,
+				]
+			);
+		}
+
 		$menu_config = [
-			'primary_menu_id'  => $primary_menu_id,
-			'mobile_menu_id'   => $mobile_menu_id,
-			'locations'        => [ 'primary' => $primary_menu_id, 'mobile' => $mobile_menu_id ],
-			'deleted_menu_ids' => $deleted_menu_ids,
+			'primary_menu_id'    => $primary_menu_id,
+			'mobile_menu_id'     => $mobile_menu_id,
+			'locations'          => [ 'primary' => $primary_menu_id, 'mobile' => $mobile_menu_id ],
+			'deleted_menu_ids'   => $deleted_menu_ids,
+			'landing_reconcile'  => $landing_reconcile,
 		];
 
 		$state['menu_config'] = $menu_config;
@@ -104,8 +169,18 @@ class Step_Menu_Setup {
 		return $menu_config;
 	}
 
-	private function resolve_page_ids( array $selected, array $generated_pages ): array {
-		$generated = [];
+	/**
+	 * Build id/slug lookup from generated pages + menu-eligible SEO landings.
+	 *
+	 * Ads / menu_eligible=false landings are never added to the pool.
+	 *
+	 * @param array<int,array<string,mixed>> $generated_pages
+	 * @param array<int,array<string,mixed>> $landing_pages
+	 *
+	 * @return array<string,int>
+	 */
+	private function build_page_pool( array $generated_pages, array $landing_pages ): array {
+		$pool = [];
 
 		foreach ( $generated_pages as $page ) {
 			if ( ! is_array( $page ) || empty( $page['id'] ) ) {
@@ -118,20 +193,57 @@ class Step_Menu_Setup {
 				continue;
 			}
 
-			$generated[ (string) $id ] = $id;
+			$pool[ (string) $id ] = $id;
 
 			if ( ! empty( $page['slug'] ) ) {
-				$generated[ \sanitize_title( (string) $page['slug'] ) ] = $id;
+				$pool[ \sanitize_title( (string) $page['slug'] ) ] = $id;
 			}
 		}
 
+		foreach ( $landing_pages as $landing ) {
+			if ( ! is_array( $landing ) || empty( $landing['id'] ) ) {
+				continue;
+			}
+
+			$id   = \absint( $landing['id'] );
+			$type = \sanitize_key( (string) ( $landing['landing_type'] ?? '' ) );
+			$eligible = array_key_exists( 'menu_eligible', $landing )
+				? (bool) $landing['menu_eligible']
+				: ( 'seo' === $type );
+
+			// Ads and ineligible landings must never join the menu pool.
+			if ( $id <= 0 || 'seo' !== $type || ! $eligible ) {
+				continue;
+			}
+
+			if ( 'page' !== \get_post_type( $id ) ) {
+				continue;
+			}
+
+			$pool[ (string) $id ] = $id;
+
+			if ( ! empty( $landing['slug'] ) ) {
+				$pool[ \sanitize_title( (string) $landing['slug'] ) ] = $id;
+			}
+		}
+
+		return $pool;
+	}
+
+	/**
+	 * @param array<int|string,mixed> $selected
+	 * @param array<string,int>       $pool
+	 *
+	 * @return array<int,int>
+	 */
+	private function resolve_page_ids( array $selected, array $pool ): array {
 		$page_ids = [];
 
 		foreach ( $selected as $item ) {
 			$key = is_numeric( $item ) ? (string) \absint( $item ) : \sanitize_title( (string) $item );
 
-			if ( isset( $generated[ $key ] ) && ! in_array( $generated[ $key ], $page_ids, true ) ) {
-				$page_ids[] = $generated[ $key ];
+			if ( isset( $pool[ $key ] ) && ! in_array( $pool[ $key ], $page_ids, true ) ) {
+				$page_ids[] = $pool[ $key ];
 			}
 		}
 

--- a/inc/wizard/class-yoast-meta-writer.php
+++ b/inc/wizard/class-yoast-meta-writer.php
@@ -10,16 +10,46 @@ namespace Inc\Wizard;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Writes Yoast SEO title and description meta to generated pages.
+ * Writes Yoast SEO title, description, and robots meta for wizard pages.
  */
 class Yoast_Meta_Writer {
 	public const TITLE_KEY       = '_yoast_wpseo_title';
 	public const DESCRIPTION_KEY = '_yoast_wpseo_metadesc';
+	public const NOINDEX_KEY     = '_yoast_wpseo_meta-robots-noindex';
+
+	/** Common SERP-friendly max length for SEO titles. */
+	public const TITLE_MAX_LENGTH = 60;
+
+	/** Common SERP-friendly max length for meta descriptions. */
+	public const DESCRIPTION_MAX_LENGTH = 155;
 
 	private $logger;
 
+	/** @var bool Whether missing-Yoast was already logged this request. */
+	private static $missing_yoast_logged = false;
+
 	public function __construct( ?Logger $logger = null ) {
 		$this->logger = $logger ?? new Logger();
+	}
+
+	/**
+	 * Whether Yoast SEO appears active for optional title/metadesc writes.
+	 */
+	public static function is_yoast_active(): bool {
+		if ( defined( 'WPSEO_VERSION' ) ) {
+			return true;
+		}
+
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			$plugin_php = \ABSPATH . 'wp-admin/includes/plugin.php';
+
+			if ( is_readable( $plugin_php ) ) {
+				require_once $plugin_php;
+			}
+		}
+
+		// Yoast package slug is wordpress-seo/wp-seo.php.
+		return function_exists( 'is_plugin_active' ) && \is_plugin_active( 'wordpress-seo/wp-seo.php' );
 	}
 
 	/**
@@ -48,5 +78,174 @@ class Yoast_Meta_Writer {
 		$this->logger->log( $written ? 'info' : 'warning', $written ? 'Yoast metadata written.' : 'No Yoast metadata values supplied.', [ 'post_id' => $post_id ] );
 
 		return $written;
+	}
+
+	/**
+	 * Write per-landing Yoast title/metadesc from keyword + type when Yoast is active.
+	 *
+	 * When Yoast is absent, skips title/metadesc writes and logs once per request.
+	 *
+	 * @param int    $post_id         Landing page ID.
+	 * @param string $primary_keyword Primary keyword.
+	 * @param string $landing_type    seo|ads.
+	 * @param string $title           Optional page title for fallback copy.
+	 *
+	 * @return bool True when title/metadesc were written.
+	 */
+	public function write_landing_seo( int $post_id, string $primary_keyword, string $landing_type, string $title = '' ): bool {
+		$post_id         = \absint( $post_id );
+		$primary_keyword = \sanitize_text_field( $primary_keyword );
+		$landing_type    = in_array( $landing_type, [ 'seo', 'ads' ], true ) ? $landing_type : 'seo';
+		$title           = \sanitize_text_field( $title );
+
+		if ( $post_id <= 0 || '' === $primary_keyword ) {
+			return false;
+		}
+
+		if ( ! self::is_yoast_active() ) {
+			if ( ! self::$missing_yoast_logged ) {
+				$this->logger->log(
+					'info',
+					'Yoast SEO is not active; skipping landing title/metadesc writes.',
+					[ 'post_id' => $post_id ]
+				);
+				self::$missing_yoast_logged = true;
+			}
+
+			return false;
+		}
+
+		$company = '';
+
+		if ( function_exists( 'get_field' ) ) {
+			$company = \sanitize_text_field( (string) \get_field( 'company_name', 'option' ) );
+		}
+
+		if ( '' === $company ) {
+			$company = \sanitize_text_field( (string) \get_bloginfo( 'name' ) );
+		}
+
+		$suffix = 'ads' === $landing_type
+			? \__( 'Get a free estimate', 'simple-rms-theme' )
+			: \__( 'Trusted local experts', 'simple-rms-theme' );
+
+		$meta_title = trim(
+			sprintf(
+				/* translators: 1: primary keyword, 2: company or site name. */
+				\__( '%1$s | %2$s', 'simple-rms-theme' ),
+				$primary_keyword,
+				'' !== $company ? $company : ( '' !== $title ? $title : \get_bloginfo( 'name' ) )
+			)
+		);
+
+		$meta_desc = trim(
+			sprintf(
+				/* translators: 1: primary keyword, 2: short CTA/trust phrase, 3: company name. */
+				\__( 'Learn about %1$s. %2$s%3$s', 'simple-rms-theme' ),
+				$primary_keyword,
+				$suffix,
+				'' !== $company ? ' — ' . $company : ''
+			)
+		);
+
+		// Keep within common SERP-friendly bounds.
+		if ( function_exists( 'mb_substr' ) ) {
+			$meta_title = \mb_substr( $meta_title, 0, self::TITLE_MAX_LENGTH );
+			$meta_desc  = \mb_substr( $meta_desc, 0, self::DESCRIPTION_MAX_LENGTH );
+		} else {
+			$meta_title = substr( $meta_title, 0, self::TITLE_MAX_LENGTH );
+			$meta_desc  = substr( $meta_desc, 0, self::DESCRIPTION_MAX_LENGTH );
+		}
+
+		return $this->write(
+			$post_id,
+			[
+				'title'       => $meta_title,
+				'description' => $meta_desc,
+			]
+		);
+	}
+
+	/**
+	 * Set or clear Ads noindex meta and verify read-back.
+	 *
+	 * Always writes the Yoast noindex post meta key (storage), independent of Yoast being active.
+	 * wp_robots in wizard-init.php provides the second protection layer for Ads landings.
+	 *
+	 * @param int  $post_id  Landing page ID.
+	 * @param bool $noindex  True to force noindex=1, false to clear.
+	 *
+	 * @return true|\WP_Error
+	 */
+	public function set_noindex( int $post_id, bool $noindex ) {
+		$post_id = \absint( $post_id );
+
+		if ( $post_id <= 0 ) {
+			return new \WP_Error(
+				'rms_wizard_noindex_invalid_post',
+				\__( 'Invalid landing page for noindex sync.', 'simple-rms-theme' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		if ( $noindex ) {
+			\update_post_meta( $post_id, self::NOINDEX_KEY, '1' );
+			$read_back = (string) \get_post_meta( $post_id, self::NOINDEX_KEY, true );
+
+			if ( '1' !== $read_back ) {
+				$this->logger->log(
+					'error',
+					'Ads landing noindex meta failed read-back.',
+					[
+						'post_id'   => $post_id,
+						'read_back' => $read_back,
+					]
+				);
+
+				return new \WP_Error(
+					'rms_wizard_ads_noindex_failed',
+					\__( 'Ads landing noindex meta could not be verified. The landing was not marked complete.', 'simple-rms-theme' ),
+					[
+						'status'  => 500,
+						'post_id' => $post_id,
+					]
+				);
+			}
+
+			$this->logger->log( 'info', 'Ads landing noindex meta written and verified.', [ 'post_id' => $post_id ] );
+
+			return true;
+		}
+
+		\delete_post_meta( $post_id, self::NOINDEX_KEY );
+		$read_back = (string) \get_post_meta( $post_id, self::NOINDEX_KEY, true );
+
+		if ( '1' === $read_back ) {
+			$this->logger->log(
+				'error',
+				'SEO landing noindex meta could not be cleared.',
+				[ 'post_id' => $post_id ]
+			);
+
+			return new \WP_Error(
+				'rms_wizard_seo_noindex_clear_failed',
+				\__( 'SEO landing noindex meta could not be cleared.', 'simple-rms-theme' ),
+				[
+					'status'  => 500,
+					'post_id' => $post_id,
+				]
+			);
+		}
+
+		$this->logger->log( 'info', 'SEO landing noindex meta cleared.', [ 'post_id' => $post_id ] );
+
+		return true;
+	}
+
+	/**
+	 * Read whether noindex meta is currently set to 1.
+	 */
+	public function has_noindex( int $post_id ): bool {
+		return '1' === (string) \get_post_meta( \absint( $post_id ), self::NOINDEX_KEY, true );
 	}
 }

--- a/inc/wizard/wizard-init.php
+++ b/inc/wizard/wizard-init.php
@@ -101,6 +101,161 @@ if ( Inc\Wizard\Wizard_Unlock_Controller::is_controlled_unlock_enabled() ) {
 }
 add_action( 'admin_post_' . Inc\Wizard\Wizard_Unlock_Controller::RELOCK_ACTION, 'rms_wizard_handle_relock_action' );
 
+// Always-loaded Ads landing robots + sitemap protections (front-end + sitemaps).
+add_filter( 'wp_robots', 'rms_wizard_ads_landing_wp_robots' );
+add_filter( 'wp_sitemaps_posts_query_args', 'rms_wizard_exclude_ads_landings_from_wp_sitemap', 10, 2 );
+add_filter( 'wpseo_exclude_from_sitemap_by_post_ids', 'rms_wizard_exclude_ads_landings_from_yoast_sitemap' );
+add_filter( 'wpseo_sitemap_entry', 'rms_wizard_filter_yoast_sitemap_entry', 10, 3 );
+
+/**
+ * Force noindex for Ads landings on the landing template (second protection layer).
+ *
+ * Requires ALL of: is_page(), valid queried ID, template pages/landing-page.php,
+ * and rms_landing_type === ads. SEO landings on the same template are untouched.
+ *
+ * @param array<string,bool|string> $robots Robots directives.
+ *
+ * @return array<string,bool|string>
+ */
+function rms_wizard_ads_landing_wp_robots( array $robots ): array {
+	if ( ! is_page() ) {
+		return $robots;
+	}
+
+	$post_id = (int) get_queried_object_id();
+
+	if ( $post_id <= 0 ) {
+		return $robots;
+	}
+
+	$template = (string) get_page_template_slug( $post_id );
+
+	if ( 'pages/landing-page.php' !== $template ) {
+		return $robots;
+	}
+
+	$landing_type = sanitize_key( (string) get_post_meta( $post_id, 'rms_landing_type', true ) );
+
+	if ( 'ads' !== $landing_type ) {
+		return $robots;
+	}
+
+	$robots['noindex']  = true;
+	$robots['nofollow'] = true;
+
+	return $robots;
+}
+
+/**
+ * Exclude Ads landings from the core WordPress XML sitemap query.
+ *
+ * @param array<string,mixed> $args      Query args.
+ * @param string              $post_type Post type.
+ *
+ * @return array<string,mixed>
+ */
+function rms_wizard_exclude_ads_landings_from_wp_sitemap( array $args, string $post_type ): array {
+	if ( 'page' !== $post_type ) {
+		return $args;
+	}
+
+	$meta_query = isset( $args['meta_query'] ) && is_array( $args['meta_query'] ) ? $args['meta_query'] : [];
+
+	$meta_query[] = [
+		'relation' => 'OR',
+		[
+			'key'     => 'rms_landing_type',
+			'compare' => 'NOT EXISTS',
+		],
+		[
+			'key'     => 'rms_landing_type',
+			'value'   => 'ads',
+			'compare' => '!=',
+		],
+	];
+
+	$args['meta_query'] = $meta_query;
+
+	return $args;
+}
+
+/**
+ * Collect Ads landing page IDs for Yoast sitemap exclusion.
+ *
+ * @return array<int,int>
+ */
+function rms_wizard_ads_landing_page_ids(): array {
+	static $ids = null;
+
+	if ( null !== $ids ) {
+		return $ids;
+	}
+
+	$query = new WP_Query(
+		[
+			'post_type'              => 'page',
+			'post_status'            => 'publish',
+			'posts_per_page'         => -1,
+			'fields'                 => 'ids',
+			'no_found_rows'          => true,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+			'meta_key'               => 'rms_landing_type',
+			'meta_value'             => 'ads',
+		]
+	);
+
+	$ids = array_map( 'absint', is_array( $query->posts ) ? $query->posts : [] );
+
+	return $ids;
+}
+
+/**
+ * Exclude Ads landings from Yoast sitemaps when the API is available.
+ *
+ * @param array<int,int> $excluded_ids Existing excluded post IDs.
+ *
+ * @return array<int,int>
+ */
+function rms_wizard_exclude_ads_landings_from_yoast_sitemap( $excluded_ids ): array {
+	$excluded_ids = is_array( $excluded_ids ) ? $excluded_ids : [];
+	$ads_ids      = rms_wizard_ads_landing_page_ids();
+
+	if ( [] === $ads_ids ) {
+		return $excluded_ids;
+	}
+
+	return array_values( array_unique( array_merge( array_map( 'absint', $excluded_ids ), $ads_ids ) ) );
+}
+
+/**
+ * Defense-in-depth: drop Ads landings from Yoast sitemap entries.
+ *
+ * @param array<string,mixed>|false $url    Sitemap entry.
+ * @param string                    $type   Object type.
+ * @param object|null               $object Post-like object.
+ *
+ * @return array<string,mixed>|false
+ */
+function rms_wizard_filter_yoast_sitemap_entry( $url, $type, $object ) {
+	if ( false === $url || ! is_object( $object ) || empty( $object->ID ) ) {
+		return $url;
+	}
+
+	if ( 'post' !== $type && 'page' !== $type ) {
+		// Yoast uses 'post' for pages in some versions; also check post_type.
+		if ( empty( $object->post_type ) || 'page' !== $object->post_type ) {
+			return $url;
+		}
+	}
+
+	if ( 'ads' === sanitize_key( (string) get_post_meta( (int) $object->ID, 'rms_landing_type', true ) ) ) {
+		return false;
+	}
+
+	return $url;
+}
+
 /**
  * Handle controlled unlock form posts from the Setup Wizard admin notice.
  *
@@ -197,23 +352,25 @@ function rms_wizard_render_admin_page(): void {
 	$force_unlocked     = ! empty( $state['force_unlocked'] );
 	$unlock_ui_enabled  = ! empty( $state['controlled_unlock_ui'] );
 	$steps              = [
-		'dependencies'      => __( 'Dependencies', 'simple-rms-theme' ),
-		'acf-import'        => __( 'ACF Import', 'simple-rms-theme' ),
-		'client-data'       => __( 'Client Data', 'simple-rms-theme' ),
-		'generate-pages'    => __( 'Generate Pages', 'simple-rms-theme' ),
-		'menu-setup'        => __( 'Menu Setup', 'simple-rms-theme' ),
-		'ia-generation'     => __( 'IA Generation', 'simple-rms-theme' ),
-		'home-page-builder' => __( 'Home Page Builder', 'simple-rms-theme' ),
+		'dependencies'         => __( 'Dependencies', 'simple-rms-theme' ),
+		'acf-import'           => __( 'ACF Import', 'simple-rms-theme' ),
+		'client-data'          => __( 'Client Data', 'simple-rms-theme' ),
+		'generate-pages'       => __( 'Generate Pages', 'simple-rms-theme' ),
+		'menu-setup'           => __( 'Menu Setup', 'simple-rms-theme' ),
+		'ia-generation'        => __( 'IA Generation', 'simple-rms-theme' ),
+		'home-page-builder'    => __( 'Home Page Builder', 'simple-rms-theme' ),
+		'landing-page-builder' => __( 'Landing Page Builder', 'simple-rms-theme' ),
 	];
 	$step_slugs = array_keys( $steps );
 	$descriptions = [
-		'dependencies'      => __( 'Check and install the required WordPress plugins before continuing.', 'simple-rms-theme' ),
-		'acf-import'        => __( 'Import ACF JSON field groups from the theme acf-json directory.', 'simple-rms-theme' ),
-		'client-data'       => __( 'Save contractor business information into the theme options.', 'simple-rms-theme' ),
-		'generate-pages'    => __( 'Add the site pages to create, then assign the Home and optional Blog roles.', 'simple-rms-theme' ),
-		'menu-setup'        => __( 'Choose generated pages for the primary and mobile menus.', 'simple-rms-theme' ),
-		'ia-generation'     => __( 'Configure the AI provider, model, and encrypted credentials for later content generation.', 'simple-rms-theme' ),
-		'home-page-builder' => __( 'Choose Home page sections and build them from the saved client data.', 'simple-rms-theme' ),
+		'dependencies'         => __( 'Check and install the required WordPress plugins before continuing.', 'simple-rms-theme' ),
+		'acf-import'           => __( 'Import ACF JSON field groups from the theme acf-json directory.', 'simple-rms-theme' ),
+		'client-data'          => __( 'Save contractor business information into the theme options.', 'simple-rms-theme' ),
+		'generate-pages'       => __( 'Add the site pages to create, then assign the Home and optional Blog roles.', 'simple-rms-theme' ),
+		'menu-setup'           => __( 'Choose generated pages for the primary and mobile menus.', 'simple-rms-theme' ),
+		'ia-generation'        => __( 'Configure the AI provider, model, and encrypted credentials for later content generation.', 'simple-rms-theme' ),
+		'home-page-builder'    => __( 'Choose Home page sections and build them from the saved client data.', 'simple-rms-theme' ),
+		'landing-page-builder' => __( 'Create SEO and Ads landing pages with keywords, reusable sections, and noindex controls.', 'simple-rms-theme' ),
 	];
 	?>
 	<div
@@ -280,7 +437,7 @@ function rms_wizard_render_admin_page(): void {
 					<?php esc_html_e( 'The setup wizard has already been completed and is read-only.', 'simple-rms-theme' ); ?>
 				</p>
 				<p class="description">
-					<?php esc_html_e( 'Controlled unlock will be available after landing page protection ships. Developers may define RMS_WIZARD_FORCE as true to bypass the lock in local environments.', 'simple-rms-theme' ); ?>
+					<?php esc_html_e( 'Developers may define RMS_WIZARD_FORCE as true to bypass the lock in local environments.', 'simple-rms-theme' ); ?>
 				</p>
 			</div>
 		<?php endif; ?>
@@ -361,6 +518,8 @@ function rms_wizard_render_admin_page(): void {
 							<?php rms_wizard_render_ia_generation_form(); ?>
 						<?php elseif ( 'home-page-builder' === $slug ) : ?>
 							<?php rms_wizard_render_home_page_builder_form(); ?>
+						<?php elseif ( 'landing-page-builder' === $slug ) : ?>
+							<?php rms_wizard_render_landing_page_builder_form(); ?>
 						<?php endif; ?>
 
 						<div class="rms-wizard-actions rms-wizard-step-actions">
@@ -489,7 +648,7 @@ function rms_wizard_render_menu_setup_form(): void {
 	<form class="rms-wizard-fields rms-wizard-guided-form" data-wizard-menu-form>
 		<div class="rms-wizard-guided-panel">
 			<p class="rms-wizard-fields__intro">
-				<?php esc_html_e( 'Menus are built only from pages created by the Generate Pages step. Refresh the state after generating pages if this list is empty.', 'simple-rms-theme' ); ?>
+				<?php esc_html_e( 'Menus are built from Generate Pages results plus menu-eligible SEO landings. Ads landings are excluded automatically. Refresh the state after generating pages or landings if this list is empty.', 'simple-rms-theme' ); ?>
 			</p>
 
 			<div class="notice notice-warning inline rms-wizard-menu-empty" data-wizard-menu-empty hidden>
@@ -675,6 +834,133 @@ function rms_wizard_render_home_page_builder_form(): void {
 					</div>
 					<button type="button" class="button-link-delete rms-wizard-home-section-row__remove" data-wizard-remove-home-section><?php esc_html_e( 'Remove', 'simple-rms-theme' ); ?></button>
 				</article>
+			</template>
+		</div>
+	</form>
+	<?php
+}
+
+/**
+ * Render the guided Landing Page Builder form.
+ *
+ * @return void
+ */
+function rms_wizard_render_landing_page_builder_form(): void {
+	$sections        = rms_wizard_home_section_choices();
+	$default_layouts = [
+		'hero',
+		'seo-content',
+		'vision-mission-v1',
+		'badges',
+		'portfolio-v1',
+		'seo-content',
+		'testimonials-v1',
+		'seo-content',
+	];
+	$section_options = array_values(
+		array_map(
+			static function ( array $section ) use ( $default_layouts ): array {
+				$layout = (string) $section['name'];
+
+				return [
+					'layout'              => $layout,
+					'label'               => $section['label'],
+					'description'         => $section['description'],
+					'is_keyword_layout'   => in_array( $layout, [ 'hero', 'seo-content' ], true ),
+					'is_default'          => in_array( $layout, $default_layouts, true ),
+					'default_item_count'  => rms_wizard_home_section_default_item_count( $layout ),
+					'has_fillable_fields' => rms_wizard_home_section_has_fillable_fields( $layout ),
+				];
+			},
+			$sections
+		)
+	);
+	?>
+	<form class="rms-wizard-fields rms-wizard-guided-form" data-wizard-landing-page-builder-form>
+		<div class="rms-wizard-guided-panel">
+			<p class="rms-wizard-fields__intro">
+				<?php esc_html_e( 'Create one or more SEO or Ads landing pages. Only Hero and SEO Content receive keywords; reusable sections stay neutral and pull from the canonical store. Ads landings are noindex and never auto-added to menus.', 'simple-rms-theme' ); ?>
+			</p>
+
+			<label class="rms-wizard-landing-skip-all">
+				<input type="checkbox" name="skip_all" value="1" data-wizard-landing-skip-all>
+				<span><?php esc_html_e( 'Skip landing pages for now (complete this step with zero landings)', 'simple-rms-theme' ); ?></span>
+			</label>
+
+			<script type="application/json" data-wizard-landing-sections><?php echo wp_json_encode( $section_options, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT ); ?></script>
+			<script type="application/json" data-wizard-landing-default-layouts><?php echo wp_json_encode( $default_layouts, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT ); ?></script>
+
+			<div class="rms-wizard-landing-toolbar">
+				<button type="button" class="button button-secondary" data-wizard-add-landing><?php esc_html_e( 'Add landing', 'simple-rms-theme' ); ?></button>
+				<p class="rms-wizard-field__instructions"><?php esc_html_e( 'Duplicate a row to start a new landing with a fresh identity. Existing landings hydrate from wizard state on load.', 'simple-rms-theme' ); ?></p>
+			</div>
+
+			<div class="rms-wizard-landing-builder" data-wizard-landing-builder>
+				<div class="rms-wizard-landing-rows" role="list" data-wizard-landing-rows></div>
+				<p class="rms-wizard-landing-builder__empty" data-wizard-landing-empty><?php esc_html_e( 'No landings added yet. Add a landing or skip this step.', 'simple-rms-theme' ); ?></p>
+			</div>
+
+			<div class="rms-wizard-landing-replace-panel" data-wizard-landing-replace-panel>
+				<strong><?php esc_html_e( 'Replace canonical reusable sections', 'simple-rms-theme' ); ?></strong>
+				<p class="rms-wizard-field__instructions"><?php esc_html_e( 'Optional. Mark reusable layouts to regenerate and overwrite the shared canonical store. Requires confirmation when running the step.', 'simple-rms-theme' ); ?></p>
+				<div class="rms-wizard-landing-replace-list" data-wizard-landing-replace-list></div>
+			</div>
+
+			<template data-wizard-landing-row-template>
+				<article class="rms-wizard-landing-row" role="listitem" data-wizard-landing-row>
+					<input type="hidden" name="landings[__INDEX__][id]" value="" data-wizard-landing-id>
+					<input type="hidden" name="landings[__INDEX__][landing_key]" value="" data-wizard-landing-key>
+					<header class="rms-wizard-landing-row__header">
+						<strong data-wizard-landing-heading><?php esc_html_e( 'Landing', 'simple-rms-theme' ); ?></strong>
+						<div class="rms-wizard-landing-row__actions">
+							<button type="button" class="button-link" data-wizard-duplicate-landing><?php esc_html_e( 'Duplicate', 'simple-rms-theme' ); ?></button>
+							<button type="button" class="button-link-delete" data-wizard-remove-landing><?php esc_html_e( 'Remove', 'simple-rms-theme' ); ?></button>
+						</div>
+					</header>
+					<div class="rms-wizard-landing-row__grid">
+						<div class="rms-wizard-field">
+							<label for="rms-wizard-landing-title-__INDEX__"><?php esc_html_e( 'Title', 'simple-rms-theme' ); ?></label>
+							<input id="rms-wizard-landing-title-__INDEX__" type="text" name="landings[__INDEX__][title]" data-wizard-landing-title placeholder="<?php esc_attr_e( 'Kitchen Remodel Landing', 'simple-rms-theme' ); ?>">
+						</div>
+						<div class="rms-wizard-field">
+							<label for="rms-wizard-landing-slug-__INDEX__"><?php esc_html_e( 'Slug', 'simple-rms-theme' ); ?></label>
+							<input id="rms-wizard-landing-slug-__INDEX__" type="text" name="landings[__INDEX__][slug]" data-wizard-landing-slug data-wizard-slug-auto="1" placeholder="<?php esc_attr_e( 'kitchen-remodel', 'simple-rms-theme' ); ?>">
+						</div>
+						<div class="rms-wizard-field">
+							<label for="rms-wizard-landing-type-__INDEX__"><?php esc_html_e( 'Landing type', 'simple-rms-theme' ); ?></label>
+							<select id="rms-wizard-landing-type-__INDEX__" name="landings[__INDEX__][landing_type]" data-wizard-landing-type>
+								<option value="seo"><?php esc_html_e( 'SEO (indexable, menu-eligible)', 'simple-rms-theme' ); ?></option>
+								<option value="ads"><?php esc_html_e( 'Ads (noindex, orphan)', 'simple-rms-theme' ); ?></option>
+							</select>
+						</div>
+						<div class="rms-wizard-field">
+							<label for="rms-wizard-landing-keyword-__INDEX__"><?php esc_html_e( 'Primary keyword', 'simple-rms-theme' ); ?></label>
+							<input id="rms-wizard-landing-keyword-__INDEX__" type="text" name="landings[__INDEX__][primary_keyword]" data-wizard-landing-primary-keyword placeholder="<?php esc_attr_e( 'kitchen remodel near me', 'simple-rms-theme' ); ?>">
+						</div>
+						<div class="rms-wizard-field rms-wizard-landing-row__subkeywords">
+							<label for="rms-wizard-landing-subkeywords-__INDEX__"><?php esc_html_e( 'Subkeywords (comma-separated, max 10)', 'simple-rms-theme' ); ?></label>
+							<input id="rms-wizard-landing-subkeywords-__INDEX__" type="text" name="landings[__INDEX__][subkeywords]" data-wizard-landing-subkeywords placeholder="<?php esc_attr_e( 'cabinet refinishing, countertop install', 'simple-rms-theme' ); ?>">
+						</div>
+					</div>
+					<div class="rms-wizard-landing-sections" data-wizard-landing-sections-list>
+						<div class="rms-wizard-landing-sections__header">
+							<strong><?php esc_html_e( 'Sections', 'simple-rms-theme' ); ?></strong>
+							<button type="button" class="button-link" data-wizard-add-landing-section><?php esc_html_e( 'Add section', 'simple-rms-theme' ); ?></button>
+						</div>
+						<div class="rms-wizard-landing-section-rows" data-wizard-landing-section-rows></div>
+					</div>
+				</article>
+			</template>
+
+			<template data-wizard-landing-section-row-template>
+				<div class="rms-wizard-landing-section-row" data-wizard-landing-section-row>
+					<select name="landings[__LINDEX__][sections][__SINDEX__][layout]" data-wizard-landing-section-layout></select>
+					<label class="rms-wizard-landing-section-override">
+						<input type="checkbox" name="landings[__LINDEX__][sections][__SINDEX__][override_canonical]" value="1" data-wizard-landing-section-override>
+						<span><?php esc_html_e( 'Override canonical (neutral regen, does not write store)', 'simple-rms-theme' ); ?></span>
+					</label>
+					<button type="button" class="button-link-delete" data-wizard-remove-landing-section><?php esc_html_e( 'Remove', 'simple-rms-theme' ); ?></button>
+				</div>
 			</template>
 		</div>
 	</form>

--- a/openspec/changes/wizard-landing-page-builder/apply-progress.md
+++ b/openspec/changes/wizard-landing-page-builder/apply-progress.md
@@ -1,9 +1,9 @@
 # Apply Progress: wizard-landing-page-builder
 
 **Mode**: Standard  
-**Batch**: Phase 2 Backend Landing Slice (PR2) + PR2 review-blocker fixes + remaining PR2 reliability follow-up + equivalence/`build_page` reliability  
-**Date**: 2026-07-21  
-**Branch**: `feat/wizard-landing-backend` (feature-branch-chain, base = PR1 foundation)
+**Batch**: PR3 remaining risk blockers + SEO append feedback  
+**Date**: 2026-07-22  
+**Branch**: `feat/wizard-landing-ui` (feature-branch-chain, base = PR2 `feat/wizard-landing-backend`)
 
 ## Completed Tasks (cumulative)
 
@@ -21,118 +21,85 @@
 - [x] 2.5 `Content_Builder` whitelist `meta_input` (`_wp_page_template`, `rms_landing_type`)
 - [x] 2.6 `delete_unselected_pages()` landing guard + controlled unlock enabled
 
-### Phase 2 PR2 review-blocker follow-up
-- [x] Deactivate live required/dispatch for `landing-page-builder` until Phase 3 UI+noindex
+### Phase 2 PR2 review-blocker / reliability follow-up
+- [x] Deactivate live required/dispatch until Phase 3 (then re-activated in 3.7)
 - [x] Identity cross-pair validation + stricter slug collisions
-- [x] Keyword AI failure → `WP_Error` (or preserve existing landing); no placeholder publish
-- [x] Multi-landing partial-failure state persistence before failed status
-- [x] Critical persistence post-state checks (state, status, meta, canonical write)
-- [x] Reviewer/JSON observability + neutral priors for reusable/canonical paths
+- [x] Keyword AI failure → `WP_Error` (or preserve existing landing)
+- [x] Multi-landing partial-failure state persistence
+- [x] Critical persistence post-state checks
+- [x] Reviewer/JSON observability + neutral priors
+- [x] generate-pages residual landing exclusion (fail-closed)
+- [x] build_one_landing exception → WP_Error + partial path
+- [x] try_preserve checks update/meta results
+- [x] landing_pages_equivalent expanded
+- [x] Local try/catch around `build_page()`
 
-### Phase 2 PR2 remaining reliability follow-up
-- [x] `generate-pages` excludes residual SEO/Ads landings from select/update/Home-Blog assignment (fail-closed `WP_Error`); deletion guard retained
-- [x] `build_one_landing()` thrown exceptions converted to `WP_Error` + partial persistence path
-- [x] `try_preserve_existing_landing()` checks `wp_update_post()` / meta results (no false preserve success)
-- [x] Document duplicated Home/Landing helper families + extraction plan after PR3/before archive
-- [x] `landing_pages_equivalent()` expanded beyond id/key/slug/type (title, keywords, menu_eligible, generated_at, preserved)
-- [x] Local try/catch around `Content_Builder::build_page()` with post-ID recovery + contextual `WP_Error` (outer partial recovery unchanged)
+### Phase 3
+- [x] 3.1 `Menu_Builder`: idempotent `append_page_items()`, `remove_page_items()`, `reconcile_landing_menu_items()`
+- [x] 3.2 `Step_Menu_Setup`: merge eligible SEO landings, exclude Ads, post-replace reconciliation
+- [x] 3.3 Yoast title/metadesc + noindex write/read-back; `wp_robots`; WP/Yoast sitemap Ads exclusion
+- [x] 3.4 Admin TS: landing collector, keyword validation, skip-all, identity hydration, duplicate reset, unlock-aware lock UI, replace-canonical modal
+- [x] 3.5 Admin SCSS: landing + unlock states
+- [x] 3.6 `pages/landing-page.php`: flexible `page_sections` + breadcrumb once after first Hero
+- [x] 3.7 Atomic activation: `landing-page-builder` in `REQUIRED_STEPS` + `DISPATCHABLE_STEPS` with visible UI + final-state sync
 
-Phase 3/4 tasks remain incomplete (including 3.7 activation).
+### PR3 review-blocker / high-value warning fixes (prior batch)
+- [x] BLOCKER: `skip_all` reconciles final-state (noindex/menu) for existing landings before complete; fails closed on sync error; no-op when none exist
+- [x] BLOCKER: post-publish failure path best-effort Ads final-state protection (recover post_id → noindex + menu remove); logs success/fail; still returns original error
+- [x] WARNING: `remove_page_items` read-back verification; Ads/ineligible removal fail-closed in landing final-state + Menu Setup reconcile
+- [x] WARNING: Menu Setup builds pool from eligible landings even when `generated_pages` empty; Ads still excluded
+- [x] WARNING: `landing-page.php` guards ACF helpers with `function_exists` before flexible loop
+- [x] Docs: JSDoc on `getGeneratedPages()`; breadcrumb behavior documented; blank lines cleaned; no-runner limitation kept
 
-## Phase 1 Review Follow-up Fixes (preserved)
+### PR3 remaining risk blockers (this batch)
+- [x] BLOCKER: `landing-page.php` ACF-missing path no longer loads template parts that call `get_sub_field()`; minimal title/content fallback when ACF absent; hardcoded section order preserved when ACF present but `page_sections` empty; flexible path unchanged when rows exist
+- [x] BLOCKER: `try_preserve_existing_landing()` early failures (`wp_update_post` error, invalid update result, `ensure_landing_meta` failure) call `protect_ads_final_state_best_effort()` before returning original error (logs post_id/landing_key/slug via protection helper)
+- [x] WARNING: SEO menu append returns structured result + read-back; failures logged as warning (best-effort). Ads menu removal remains fail-closed. Reconcile exposes `append_failed_page_ids` without flipping removal `verified`
+- [x] Minor: JSDoc on `getMenuEligibleLandings()`; Yoast title/description max lengths as named constants
 
-| Finding | Severity | Fix |
-|---------|----------|-----|
-| `landing-page-builder` required before runtime | BLOCKER | Removed from active `REQUIRED_STEPS` in Phase 1 |
-| Canonical store nondeterministic persistence | WARNING | Cache mutates only after successful `update_option()` or verified equal full post-state entry |
-| Unlock/relock nondeterministic persistence | WARNING | Post-state option equality checks |
-| Premature `landing_page_builder` alias pollutes state | WARNING | Unknown-step reject before status writes |
-| Stale unlock marker bypasses lock | BLOCKER | `has_unlock_marker()` vs effective `is_unlocked()` |
-| Completion flag SoT | WARNING | `State_Manager::has_completion_flag()` only |
+Phase 4 verification tasks remain incomplete (manual WP Admin scenarios).
 
-## Phase 2 PR2 Review Blocker Fixes
-
-| Finding | Severity | Fix |
-|---------|----------|-----|
-| Live backend can publish Ads indexable before Phase 3 noindex | BLOCKER | Safer smaller fix: keep `Step_Landing_Page_Builder` implemented but remove `landing-page-builder` from `REQUIRED_STEPS` + `DISPATCHABLE_STEPS`. Dispatch case + alias retained for Phase 3 atomic activation (task 3.7). Existing 7-step UI completion unchanged. |
-| UI/required mismatch (7-step UI vs 8th required) | BLOCKER | Same deactivation; completion stays 7 required steps until UI can send payload/`skip_all`. |
-| Identity mismatch id+key | BLOCKER | `match_existing_landing()` rejects stale cross-pair when both non-empty id and landing_key disagree; order id → key → slug; slug collisions reject other pages (landing or not) when id already matched. |
-| Keyword AI failure publishes placeholders | BLOCKER | `generate_section_copy(..., require_ai=true)` returns `WP_Error` on AI/decode/review/empty-validation failure for hero/seo-content. Updates may preserve existing valid page_sections instead of placeholders. Logs include landing_key/slug/layout. |
-| Multi-landing partial failure diverges state | HIGH | On failure after N-1 successes, `persist_partial_landing_progress()` saves `landing_pages` + canonical summary first, logs counts/post IDs, then marks step failed (logs if status write fails). No delete of updated existing landings. |
-| Persistence checks | HIGH | `persist_wizard_state` / `mark_step_status` re-read post-state; meta safety-net verifies template+type; canonical `replace`/`set_if_empty` failures logged and fall back when possible. Critical full-run state/status failures return `WP_Error`. |
-| Reviewer/JSON observability + keyword priors | HIGH | Reviewer throwables and invalid JSON-on-success logged with context. Reusable/canonical paths use `filter_neutral_priors()` so keyword sections do not pollute neutral generation/review. |
-| `generate-pages` can publish/assign residual landings | BLOCKER | Fail-closed: selected slugs resolving to `rms_landing_type` `seo`/`ads` return `WP_Error` (`rms_wizard_page_slug_is_landing`) before cleanup/update; loop + `assign_reading_pages()` refuse landing Home/Blog assignment; deletion guard kept. |
-| Partial recovery misses thrown exceptions | WARNING | Each `build_one_landing()` call wrapped in try/catch; `\Throwable` → contextual `WP_Error` then existing `persist_partial_landing_progress()`. |
-| `try_preserve_existing_landing()` ignores update result | WARNING | Capture `wp_update_post(..., true)`; on `WP_Error`/invalid result or meta failure log and return `WP_Error` (no false preserved success). |
-| `landing_pages_equivalent()` too narrow | WARNING | Normalize/compare id, landing_key, title, slug, landing_type, menu_eligible, primary_keyword, order-insensitive subkeywords, generated_at, preserved — reject stale/partial state as “saved”. |
-| `build_page()` throwable after create/update bypasses recovery | WARNING | Local try/catch around `build_page()` → contextual `WP_Error` (`landing_key`/`slug`/`title`, recovered `post_id` when known); outer loop still runs `persist_partial_landing_progress()` for prior successes. |
-| Readability/size (shared helper extraction) | WARNING | **Deliberate duplication retained** with Home Builder. See Known limitations for named helper families + extraction plan after PR3/before archive. |
-
-## Files Changed (Phase 2 batch + review fixes)
+## Files Changed (this batch)
 
 | File | Action | What Was Done |
 |------|--------|---------------|
-| `inc/wizard/class-ai-content-harness.php` | Modified | Distinct `PAGE_LANDING` Layer 2; keyword inject only hero/seo-content |
-| `inc/wizard/class-step-home-page-builder.php` | Modified | After success, `set_if_empty` reusable prepared rows |
-| `inc/wizard/class-step-landing-page-builder.php` | Created + hardened | Full backend + PR2 safety: identity, keyword fail-closed, partial persist, persistence checks, observability, neutral priors, richer state equivalence, local `build_page()` exception boundary |
-| `inc/wizard/class-content-builder.php` | Modified | Whitelist-only `meta_input` |
-| `inc/wizard/class-step-generate-pages.php` | Modified | Landing deletion guard + select/update/reading-assignment exclusion (fail-closed) |
-| `inc/wizard/class-wizard-unlock-controller.php` | Modified | `CONTROLLED_UNLOCK_ENABLED = true` |
-| `inc/wizard/class-step-controller.php` | Modified | PR2: required/dispatch remain 7 steps; dispatch case + alias kept dormant with Phase 3 activation comments |
-| `openspec/changes/wizard-landing-page-builder/tasks.md` | Modified | Phase 2 complete + compatibility notes + task 3.7 activation |
-| `openspec/changes/wizard-landing-page-builder/apply-progress.md` | Modified | This cumulative progress note + helper-duplication known limitations |
+| `pages/landing-page.php` | Modified | Split ACF-missing vs ACF-empty fallbacks; safe markup without `get_sub_field` |
+| `inc/wizard/class-step-landing-page-builder.php` | Modified | Ads protect on preserve early fails; SEO append feedback logs |
+| `inc/wizard/class-menu-builder.php` | Modified | Structured `append_page_items` + verify; reconcile reports append failures |
+| `inc/wizard/class-step-menu-setup.php` | Modified | Warning log when SEO append incomplete after Ads removal OK |
+| `inc/wizard/class-yoast-meta-writer.php` | Modified | `TITLE_MAX_LENGTH` / `DESCRIPTION_MAX_LENGTH` constants |
+| `src/ts/admin/wizard.ts` | Modified | JSDoc for `getMenuEligibleLandings` |
+| `openspec/changes/wizard-landing-page-builder/apply-progress.md` | Modified | This cumulative progress note |
 
-## Intentionally not changed (Phase 3+)
+## Design notes
 
-- Menu append/remove / Menu Setup landing merge
-- Yoast title/metadesc/noindex + `wp_robots` + ads sitemap
-- Admin TS/SCSS landing UI
-- `pages/landing-page.php` flexible loop / breadcrumb
-- Shared Home/Landing section-assembly extraction (documented follow-up)
-- Local docs: `Wizard ai harness prompt guide.md`, `wizard-prd.html`
-- No commit/push
-
-## Design notes (Phase 2 + PR2 safety)
-
-- Landing **runtime code** is present; **activation** is Phase 3 (required + dispatchable + UI + noindex/menu).
-- Controlled unlock enabled only because 2.6 deletion guard shipped in the same backend slice.
-- Ads noindex/menu final-state sync deferred to Phase 3 (by design; PR2 cannot go live without it).
-- Keyword scope strict: only `hero` / `seo-content` receive keywords; overrides stay neutral (`PAGE_HOME`).
-- Canonical first-write only; overrides never write store; replace requires `replace_canonical` + confirm flag.
-- Bootstrap failure returns actionable `WP_Error` (`rms_wizard_canonical_bootstrap_failed`).
-
-## Known limitations
-
-1. Step is not callable via REST until Phase 3 activation — intentional PR2 safety.
-2. **Deliberate Home Builder / Landing Builder helper duplication** (readability debt, not a runtime bug). Duplicated helper families today:
-   - Section assembly / section row preparation (`section_data`, service row contracts, image fallbacks orchestration)
-   - Placeholder copy builders (`placeholder_copy`, `placeholder_repeater_rows`, `placeholder_field_value`)
-   - Item-count defaults / clamp (`item_count` and the shared max section item limit **`12`**)
-   - Reviewer/config helpers (`reviewer()`, `is_review_enabled()`, review wiring around AI decode)
-   - Text/HTML/JSON helpers (`text`, `html`, `section_value`, `decode_json_content`, `truthy`)
-   - Completion helper (`maybe_mark_completed` against `Step_Controller::get_required_steps()`)
-   - **Follow-up plan**: extract a shared section-assembly / content-helper collaborator **after PR3 lands or before archive** — not in this PR2 reliability patch. Also extract the repeated max item limit `12` to a named constant during that cleanup.
-3. No automated behavioral tests / no test runner (`strict_tdd: false`). Reliability is verified via `php -l` + code review only — do not claim automated behavior coverage.
-4. Preserve-on-keyword-failure path updates title/slug/meta only; does not rewrite sections.
-5. Partial-failure recovery does not roll back newly created posts (prefers state persistence over destructive delete). Thrown exceptions (including local `build_page()` catch) convert to `WP_Error` and use the same partial persistence path as returned errors. Recovered orphan post IDs are logged/error-data only — not auto-added to successful `landing_pages`.
+- **Breadcrumb (flexible path)**: injected **once after the first Hero row only**. If flexible `page_sections` has no Hero layout, **no breadcrumb** is rendered in that path.
+- **Breadcrumb (fallback path, ACF present)**: hardcoded order still includes Hero then `breadcrumb-slim`.
+- **ACF missing**: minimal `the_title` / `the_content` fallback only — never load section template parts.
+- **Menu policy asymmetry**: SEO append = **best-effort** (warn + continue). Ads removal / noindex = **fail-closed**.
+- **No automated behavioral tests**: Mode Standard (`strict_tdd: false`, no test runner). Verification is `php -l`, `tsc --noEmit`, and `npm run build` only.
 
 ## Verification
 
 ```
+php -l pages/landing-page.php
 php -l inc/wizard/class-step-landing-page-builder.php
+php -l inc/wizard/class-menu-builder.php
+php -l inc/wizard/class-step-menu-setup.php
+php -l inc/wizard/class-yoast-meta-writer.php
+npx tsc --noEmit
+npm run build
 ```
 
-(Plus prior Phase 2 `php -l` on generate-pages/controller/harness/content-builder/unlock/home-builder.)
-
-Mode: **Standard** (`openspec/config.yaml` → `strict_tdd: false`, no test runner). No automated behavior tests exist for these reliability paths.
+Mode: **Standard** (`strict_tdd: false`, no test runner). Manual WP Admin scenarios remain for Phase 4.
 
 ## Workload / PR Boundary
 
 - Mode: chained PR slice (feature-branch-chain)
-- Current work unit: PR2 Backend Landing + remaining reliability follow-up (equivalence + build_page boundary)
-- Boundary: Phase 2 tasks 2.1–2.6 hardened for standalone PR safety; no Phase 3 UI/menu/template
-- Estimated review budget impact: small incremental reliability patch on PR2 surface
+- Current work unit: PR3 remaining risk blockers only
+- Boundary: no archive, no commit/push
+- Estimated review budget impact: small focused delta
 
 ## Status
 
-Phase 1 + Phase 2 complete with PR2 remaining reliability warnings addressed (10/19 tasks incl. new 3.7). Ready for PR2 re-review / next batch Phase 3 UI/menu/SEO/template + activation.
+17/19 tasks complete (Phase 1–3) + PR3 remaining risk blockers addressed. Ready for re-review / Phase 4 verification. No commit performed.

--- a/openspec/changes/wizard-landing-page-builder/tasks.md
+++ b/openspec/changes/wizard-landing-page-builder/tasks.md
@@ -66,13 +66,13 @@ Chain strategy: feature-branch-chain
 
 ## Phase 3: Menu, SEO, UI, Template Slice
 
-- [ ] 3.1 Modify `inc/wizard/class-menu-builder.php` with idempotent `append_page_items()`, `remove_page_items()`, and shared landing reconciliation.
-- [ ] 3.2 Modify `inc/wizard/class-step-menu-setup.php` to merge eligible SEO landings, exclude Ads, and reconcile after destructive menu replacement.
-- [ ] 3.3 Modify `inc/wizard/class-yoast-meta-writer.php` and `inc/wizard/wizard-init.php` for Yoast meta, noindex read-back, `wp_robots`, and Ads sitemap exclusion.
-- [ ] 3.4 Modify `src/ts/admin/wizard.ts` for landing collection, keyword validation, skip-all, identity hydration, duplicate reset, unlock/relock, and replace modal.
-- [ ] 3.5 Modify `src/scss/admin/wizard.scss` for landing and unlock admin states only.
-- [ ] 3.6 Modify `pages/landing-page.php` to render flexible `page_sections` and inject `breadcrumb-slim` once after the first Hero.
-- [ ] 3.7 **Activate** `landing-page-builder` atomically: add to `REQUIRED_STEPS` + `DISPATCHABLE_STEPS` (alias + dispatch case already present) together with UI + noindex/menu final-state sync. Do not activate required/dispatch without the visible skip/payload path.
+- [x] 3.1 Modify `inc/wizard/class-menu-builder.php` with idempotent `append_page_items()`, `remove_page_items()`, and shared landing reconciliation.
+- [x] 3.2 Modify `inc/wizard/class-step-menu-setup.php` to merge eligible SEO landings, exclude Ads, and reconcile after destructive menu replacement.
+- [x] 3.3 Modify `inc/wizard/class-yoast-meta-writer.php` and `inc/wizard/wizard-init.php` for Yoast meta, noindex read-back, `wp_robots`, and Ads sitemap exclusion.
+- [x] 3.4 Modify `src/ts/admin/wizard.ts` for landing collection, keyword validation, skip-all, identity hydration, duplicate reset, unlock/relock, and replace modal.
+- [x] 3.5 Modify `src/scss/admin/wizard.scss` for landing and unlock admin states only.
+- [x] 3.6 Modify `pages/landing-page.php` to render flexible `page_sections` and inject `breadcrumb-slim` once after the first Hero.
+- [x] 3.7 **Activate** `landing-page-builder` atomically: add to `REQUIRED_STEPS` + `DISPATCHABLE_STEPS` (alias + dispatch case already present) together with UI + noindex/menu final-state sync. Do not activate required/dispatch without the visible skip/payload path.
 
 ## Phase 4: Verification
 

--- a/pages/landing-page.php
+++ b/pages/landing-page.php
@@ -1,18 +1,79 @@
 <?php
 /**
  * Template Name: SEO Landing Page
+ *
+ * Renders wizard-generated flexible `page_sections` when present.
+ * Injects `breadcrumb-slim` once after the first Hero row only.
+ * Falls back to the hardcoded section order when ACF is available but empty.
+ * When ACF functions are missing, renders a minimal safe title/content fallback
+ * (template parts call `get_sub_field()` and would fatal without ACF).
+ *
+ * @package Simple_RMS_Theme
  */
 
 get_header();
 
-get_template_part('templates/hero');
-get_template_part('templates/breadcrumb-slim');
-get_template_part('templates/seo-content');
-get_template_part('templates/vision-mission-v1');
-get_template_part('templates/badges');
-get_template_part('templates/portfolio-v1');
-get_template_part('templates/seo-content');
-get_template_part('templates/testimonials-v1');
-get_template_part('templates/seo-content');
+// ACF flexible helpers required for both generated rows and hardcoded parts.
+$acf_available = function_exists( 'have_rows' )
+	&& function_exists( 'the_row' )
+	&& function_exists( 'get_row_layout' )
+	&& function_exists( 'get_sub_field' );
+
+$has_flexible_sections = $acf_available && have_rows( 'page_sections' );
+
+if ( $has_flexible_sections ) :
+	$breadcrumb_injected = false;
+
+	while ( have_rows( 'page_sections' ) ) :
+		the_row();
+		$layout = get_row_layout();
+
+		if ( ! is_string( $layout ) || '' === $layout ) {
+			continue;
+		}
+
+		get_template_part( 'templates/' . $layout );
+
+		// Inject breadcrumb once after the first Hero row only (not an ACF layout).
+		// No Hero in flexible content ⇒ no breadcrumb in this path.
+		if ( ! $breadcrumb_injected && 'hero' === $layout ) {
+			get_template_part( 'templates/breadcrumb-slim' );
+			$breadcrumb_injected = true;
+		}
+	endwhile;
+elseif ( $acf_available ) :
+	// ACF present but empty flexible content — legacy hardcoded section order.
+	// Template parts may call get_sub_field(); safe only when ACF is loaded.
+	get_template_part( 'templates/hero' );
+	get_template_part( 'templates/breadcrumb-slim' );
+	get_template_part( 'templates/seo-content' );
+	get_template_part( 'templates/vision-mission-v1' );
+	get_template_part( 'templates/badges' );
+	get_template_part( 'templates/portfolio-v1' );
+	get_template_part( 'templates/seo-content' );
+	get_template_part( 'templates/testimonials-v1' );
+	get_template_part( 'templates/seo-content' );
+else :
+	// ACF missing/degraded — do not load template parts that call get_sub_field().
+	?>
+	<main id="main" class="landing-page landing-page--acf-missing">
+		<?php
+		while ( have_posts() ) :
+			the_post();
+			?>
+			<article <?php post_class( 'landing-page__article' ); ?>>
+				<header class="landing-page__header">
+					<h1 class="landing-page__title"><?php echo esc_html( get_the_title() ); ?></h1>
+				</header>
+				<div class="landing-page__content entry-content">
+					<?php the_content(); ?>
+				</div>
+			</article>
+			<?php
+		endwhile;
+		?>
+	</main>
+	<?php
+endif;
 
 get_footer();

--- a/src/scss/admin/wizard.scss
+++ b/src/scss/admin/wizard.scss
@@ -846,6 +846,196 @@
   background: var(--rms-wizard-success);
 }
 
+/* Landing Page Builder + unlock admin states */
+.rms-setup-wizard.is-locked .rms-wizard-step-panel {
+  opacity: 0.92;
+}
+
+.rms-setup-wizard.is-unlocked .rms-wizard-step-nav.is-complete {
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--rms-wizard-warning), #fff 40%);
+}
+
+.rms-wizard-controlled-unlock__form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  margin-top: 10px;
+}
+
+.rms-wizard-landing-skip-all {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 12px 14px;
+  margin: 0 0 14px;
+  font-weight: 600;
+  background: #f0f6fc;
+  border: 1px solid #c3d9ed;
+  border-radius: 10px;
+}
+
+.rms-wizard-landing-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.rms-wizard-landing-toolbar .rms-wizard-field__instructions {
+  flex-basis: 100%;
+  margin: 0;
+}
+
+.rms-wizard-landing-builder {
+  display: grid;
+  gap: 12px;
+}
+
+.rms-wizard-landing-rows {
+  display: grid;
+  gap: 14px;
+}
+
+.rms-wizard-landing-row {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+  background: #fff;
+  border: 1px solid var(--rms-wizard-border);
+  border-radius: 12px;
+  box-shadow: 0 1px 1px rgb(0 0 0 / 0.03);
+}
+
+.rms-wizard-landing-row.is-ads {
+  border-color: color-mix(in srgb, var(--rms-wizard-warning), #fff 35%);
+  background: #fffdf8;
+}
+
+.rms-wizard-landing-row__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.rms-wizard-landing-row__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.rms-wizard-landing-row__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.rms-wizard-landing-row__subkeywords {
+  grid-column: 1 / -1;
+}
+
+.rms-wizard-landing-sections {
+  display: grid;
+  gap: 10px;
+  padding-top: 4px;
+  border-top: 1px dashed var(--rms-wizard-border);
+}
+
+.rms-wizard-landing-sections__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.rms-wizard-landing-section-rows {
+  display: grid;
+  gap: 8px;
+}
+
+.rms-wizard-landing-section-row {
+  display: grid;
+  grid-template-columns: minmax(180px, 1.2fr) minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 12px;
+  background: #f8fafc;
+  border: 1px solid #edf0f2;
+  border-radius: 10px;
+}
+
+.rms-wizard-landing-section-override {
+  display: inline-flex;
+  gap: 8px;
+  align-items: flex-start;
+  margin: 0;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--rms-wizard-muted);
+}
+
+.rms-wizard-landing-section-override[hidden] {
+  display: none;
+}
+
+.rms-wizard-landing-builder__empty {
+  padding: 16px;
+  margin: 0;
+  color: var(--rms-wizard-muted);
+  text-align: center;
+  background: #fff;
+  border: 1px dashed var(--rms-wizard-border);
+  border-radius: 12px;
+}
+
+.rms-wizard-landing-replace-panel {
+  display: grid;
+  gap: 8px;
+  margin-top: 16px;
+  padding: 14px;
+  background: #fff8e5;
+  border: 1px solid color-mix(in srgb, var(--rms-wizard-warning), #fff 55%);
+  border-left: 4px solid var(--rms-wizard-warning);
+  border-radius: 10px;
+}
+
+.rms-wizard-landing-replace-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 8px;
+}
+
+.rms-wizard-landing-replace-option {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  margin: 0;
+  padding: 8px 10px;
+  background: #fff;
+  border: 1px solid #f0e2b8;
+  border-radius: 8px;
+  font-size: 13px;
+}
+
+.rms-wizard-fields.is-skip-all .rms-wizard-landing-builder,
+.rms-wizard-fields.is-skip-all .rms-wizard-landing-toolbar,
+.rms-wizard-fields.is-skip-all .rms-wizard-landing-replace-panel {
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+@media (max-width: 782px) {
+  .rms-wizard-landing-row__grid,
+  .rms-wizard-landing-section-row {
+    grid-template-columns: 1fr;
+  }
+}
+
 .rms-wizard-next-step.is-ready:hover,
 .rms-wizard-next-step.is-ready:focus-visible {
   filter: brightness(0.95);

--- a/src/ts/admin/wizard.ts
+++ b/src/ts/admin/wizard.ts
@@ -20,6 +20,21 @@ interface GeneratedPage {
   role?: string;
 }
 
+interface LandingPageState {
+  id?: number | string;
+  landing_key?: string;
+  title?: string;
+  slug?: string;
+  landing_type?: 'seo' | 'ads' | string;
+  menu_eligible?: boolean;
+  primary_keyword?: string;
+  subkeywords?: string[];
+  keywords?: {
+    primary_keyword?: string;
+    subkeywords?: string[];
+  };
+}
+
 interface WizardPageTemplate {
   title?: string;
   slug?: string;
@@ -36,9 +51,35 @@ interface HomeSectionTemplate {
   default_item_count?: number;
 }
 
+interface LandingSectionOption {
+  layout?: string;
+  label?: string;
+  description?: string;
+  is_keyword_layout?: boolean;
+  is_default?: boolean;
+  default_item_count?: number;
+  has_fillable_fields?: boolean;
+}
+
 interface HomeSectionPayload {
   layout: string;
   item_count: number;
+}
+
+interface LandingSectionPayload {
+  layout: string;
+  override_canonical: boolean;
+}
+
+interface LandingPayloadItem {
+  id: number | null;
+  landing_key: string;
+  title: string;
+  slug: string;
+  landing_type: 'seo' | 'ads';
+  primary_keyword: string;
+  subkeywords: string[];
+  sections: LandingSectionPayload[];
 }
 
 interface PagePayloadItem {
@@ -64,7 +105,13 @@ interface WizardState {
     configured_at?: string;
   };
   generated_pages?: GeneratedPage[];
+  landing_pages?: LandingPageState[];
   locked?: boolean;
+  unlocked?: boolean;
+  completed_flag?: boolean;
+  force_unlocked?: boolean;
+  controlled_unlock_ui?: boolean;
+  has_unlock_marker?: boolean;
   logs?: WizardLogEntry[];
 }
 
@@ -164,6 +211,7 @@ declare global {
     { slug: 'menu-setup', label: 'Menu Setup' },
     { slug: 'ia-generation', label: 'IA Generation' },
     { slug: 'home-page-builder', label: 'Home Page Builder' },
+    { slug: 'landing-page-builder', label: 'Landing Page Builder' },
   ];
 
   const destructiveWarnings: Record<string, { message: string; checkboxMessage: string }> = {
@@ -174,6 +222,10 @@ declare global {
     'menu-setup': {
       message: 'Existing menus and location assignments will be removed and replaced. This cannot be undone.',
       checkboxMessage: 'Confirm that existing menus and location assignments can be replaced before continuing.',
+    },
+    'landing-page-builder': {
+      message: 'Replacing canonical reusable sections overwrites shared copy used by future landings. This cannot be undone.',
+      checkboxMessage: 'Confirm replace canonical before overwriting shared reusable sections.',
     },
   };
 
@@ -278,9 +330,15 @@ declare global {
     }).join('');
   };
 
+  const isWizardLocked = (): boolean => Boolean(state.locked) && !state.unlocked && !state.force_unlocked;
+
   const updateButtons = (): void => {
-    const isLocked = Boolean(state.locked);
+    const isLocked = isWizardLocked();
     const isHydrating = root.classList.contains('is-hydrating');
+
+    root.classList.toggle('is-unlocked', Boolean(state.unlocked) && !state.force_unlocked);
+    root.classList.toggle('is-force-unlocked', Boolean(state.force_unlocked));
+    root.classList.toggle('is-locked', isLocked);
 
     navButtons.forEach((button) => {
       button.disabled = isHydrating || runningStep !== null;
@@ -316,6 +374,8 @@ declare global {
       const allComplete = steps.every((step) => statusFor(step.slug) === 'complete');
       completeButton.disabled = isHydrating || isLocked || runningStep !== null || !allComplete;
     }
+
+    syncLandingSkipAllUi();
   };
 
   const render = (): void => {
@@ -325,6 +385,8 @@ declare global {
 
     renderGeneratedPageControls();
     hydrateIaGenerationForm();
+    hydrateLandingRowsFromState();
+    renderLandingReplaceOptions();
     syncGuidedControlState();
     setActiveStep(nextStep);
     updateNav();
@@ -332,8 +394,10 @@ declare global {
     updateLogs();
     updateButtons();
 
-    if (state.locked) {
-      setNotice('The setup wizard is complete and locked. Define RMS_WIZARD_FORCE as true for development reruns.', 'success');
+    if (isWizardLocked()) {
+      setNotice('The setup wizard is complete and locked. Unlock it for editing or define RMS_WIZARD_FORCE as true for development reruns.', 'success');
+    } else if (state.unlocked && !state.force_unlocked) {
+      setNotice('The setup wizard is unlocked for editing. Completion state is preserved.', 'info');
     }
   };
 
@@ -501,6 +565,10 @@ declare global {
       return collectHomePageBuilderPayload(form);
     }
 
+    if (step === 'landing-page-builder') {
+      return collectLandingPageBuilderPayload(form);
+    }
+
     return collectFormPayload(form);
   };
 
@@ -645,6 +713,24 @@ declare global {
   };
 
   const ensureDestructiveConfirmation = async (step: string, payload: StepPayload): Promise<boolean> => {
+    if (step === 'landing-page-builder') {
+      const replaceMap = (payload.replace_canonical ?? {}) as Record<string, boolean>;
+      const needsReplaceConfirm = Object.values(replaceMap).some(Boolean);
+
+      if (!needsReplaceConfirm) {
+        return true;
+      }
+
+      const warning = destructiveWarnings[step];
+      const confirmed = await openConfirmationModal(warning.message);
+
+      if (confirmed) {
+        payload.confirm_replace_canonical = true;
+      }
+
+      return confirmed;
+    }
+
     const warning = destructiveWarnings[step];
 
     if (!warning) {
@@ -665,6 +751,121 @@ declare global {
     }
 
     return confirmed;
+  };
+
+  const collectLandingPageBuilderPayload = (form: HTMLFormElement): StepPayload => {
+    const skipAll = Boolean(form.querySelector<HTMLInputElement>('[data-wizard-landing-skip-all]')?.checked);
+
+    if (skipAll) {
+      return { skip_all: true, landings: [] };
+    }
+
+    const landings: LandingPayloadItem[] = [];
+    const seenSlugs = new Set<string>();
+    const seenKeys = new Set<string>();
+    const seenIds = new Set<number>();
+
+    form.querySelectorAll<HTMLElement>('[data-wizard-landing-row]').forEach((row, index) => {
+      const title = row.querySelector<HTMLInputElement>('[data-wizard-landing-title]')?.value.trim() ?? '';
+      const slugInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-slug]')?.value.trim() ?? '';
+      const slug = sanitizeSlug(slugInput || title);
+      const landingTypeRaw = row.querySelector<HTMLSelectElement>('[data-wizard-landing-type]')?.value ?? 'seo';
+      const landingType: 'seo' | 'ads' = landingTypeRaw === 'ads' ? 'ads' : 'seo';
+      const primaryKeyword = row.querySelector<HTMLInputElement>('[data-wizard-landing-primary-keyword]')?.value.trim() ?? '';
+      const subkeywordsRaw = row.querySelector<HTMLInputElement>('[data-wizard-landing-subkeywords]')?.value ?? '';
+      const idRaw = row.querySelector<HTMLInputElement>('[data-wizard-landing-id]')?.value.trim() ?? '';
+      const landingKey = row.querySelector<HTMLInputElement>('[data-wizard-landing-key]')?.value.trim() || mintLandingKey();
+      const id = idRaw ? Number.parseInt(idRaw, 10) : null;
+
+      if (!title && !slug && !primaryKeyword) {
+        return;
+      }
+
+      if (!title) {
+        throw new Error(`Landing ${index + 1} needs a title.`);
+      }
+
+      if (!slug) {
+        throw new Error(`Landing "${title}" needs a valid slug.`);
+      }
+
+      if (!primaryKeyword) {
+        throw new Error(`Landing "${title}" requires a primary keyword.`);
+      }
+
+      if (seenSlugs.has(slug)) {
+        throw new Error(`Landing slugs must be unique. "${slug}" is already used.`);
+      }
+
+      if (landingKey && seenKeys.has(landingKey)) {
+        throw new Error('Duplicate landing keys are not allowed in one run.');
+      }
+
+      if (id && Number.isFinite(id) && id > 0) {
+        if (seenIds.has(id)) {
+          throw new Error('Duplicate landing ids are not allowed in one run.');
+        }
+
+        seenIds.add(id);
+      }
+
+      seenSlugs.add(slug);
+      seenKeys.add(landingKey);
+
+      const subkeywords = subkeywordsRaw
+        .split(',')
+        .map((value) => value.trim())
+        .filter(Boolean)
+        .slice(0, 10);
+
+      const sections: LandingSectionPayload[] = [];
+
+      row.querySelectorAll<HTMLElement>('[data-wizard-landing-section-row]').forEach((sectionRow) => {
+        const layout = sectionRow.querySelector<HTMLSelectElement>('[data-wizard-landing-section-layout]')?.value.trim() ?? '';
+        const override = Boolean(sectionRow.querySelector<HTMLInputElement>('[data-wizard-landing-section-override]')?.checked);
+
+        if (!layout) {
+          return;
+        }
+
+        sections.push({ layout, override_canonical: override });
+      });
+
+      if (sections.length === 0) {
+        throw new Error(`Landing "${title}" needs at least one section.`);
+      }
+
+      landings.push({
+        id: id && Number.isFinite(id) && id > 0 ? id : null,
+        landing_key: landingKey,
+        title,
+        slug,
+        landing_type: landingType,
+        primary_keyword: primaryKeyword,
+        subkeywords,
+        sections,
+      });
+    });
+
+    if (landings.length === 0) {
+      throw new Error('Add at least one landing page or enable skip-all to complete without landings.');
+    }
+
+    const replaceCanonical: Record<string, boolean> = {};
+
+    form.querySelectorAll<HTMLInputElement>('[data-wizard-landing-replace-layout]:checked').forEach((input) => {
+      const layout = input.value.trim();
+
+      if (layout) {
+        replaceCanonical[layout] = true;
+      }
+    });
+
+    return {
+      landings,
+      replace_canonical: replaceCanonical,
+      skip_all: false,
+    };
   };
 
   const openConfirmationModal = (message: string): Promise<boolean> => {
@@ -783,14 +984,449 @@ declare global {
     });
   };
 
-  const getGeneratedPages = (): GeneratedPage[] => (
-    Array.isArray(state.generated_pages) ? state.generated_pages.filter((page) => Boolean(generatedPageValue(page))) : []
-  );
+  /**
+   * Pages available to the Menu Setup UI.
+   *
+   * Merges standard `state.generated_pages` with menu-eligible SEO landings
+   * from `state.landing_pages`. Ads and `menu_eligible=false` landings are
+   * excluded via `getMenuEligibleLandings()` so they never appear as menu options.
+   */
+  const getGeneratedPages = (): GeneratedPage[] => {
+    const standard = Array.isArray(state.generated_pages)
+      ? state.generated_pages.filter((page) => Boolean(generatedPageValue(page)))
+      : [];
+    const landings = getMenuEligibleLandings().map((landing) => ({
+      id: landing.id,
+      title: landing.title,
+      slug: landing.slug,
+      role: landing.landing_type === 'seo' ? 'landing-seo' : 'landing',
+    }));
 
-  const generatedPageValue = (page: GeneratedPage): string => {
+    const seen = new Set<string>();
+    const merged: GeneratedPage[] = [];
+
+    [...standard, ...landings].forEach((page) => {
+      const value = generatedPageValue(page);
+
+      if (!value || seen.has(value)) {
+        return;
+      }
+
+      seen.add(value);
+      merged.push(page);
+    });
+
+    return merged;
+  };
+
+  /**
+   * SEO landings that may appear in Menu Setup.
+   *
+   * Filters `state.landing_pages` to `landing_type=seo` with `menu_eligible`
+   * true (default true for SEO when the flag is absent). Ads and ineligible
+   * rows are always excluded. Requires a resolvable id/slug via
+   * `generatedPageValue()`.
+   */
+  const getMenuEligibleLandings = (): LandingPageState[] => {
+    if (!Array.isArray(state.landing_pages)) {
+      return [];
+    }
+
+    return state.landing_pages.filter((landing) => {
+      const type = landing.landing_type === 'ads' ? 'ads' : 'seo';
+      const eligible = typeof landing.menu_eligible === 'boolean' ? landing.menu_eligible : type === 'seo';
+
+      return type === 'seo' && eligible && Boolean(generatedPageValue(landing));
+    });
+  };
+
+  const generatedPageValue = (page: GeneratedPage | LandingPageState): string => {
     const id = typeof page.id === 'number' || typeof page.id === 'string' ? String(page.id) : '';
 
     return id || sanitizeSlug(page.slug ?? '');
+  };
+
+  const mintLandingKey = (): string => {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return `lp_${crypto.randomUUID().replace(/-/g, '').slice(0, 12)}`;
+    }
+
+    return `lp_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+  };
+
+  const readLandingSectionOptions = (): LandingSectionOption[] => {
+    const source = root.querySelector<HTMLScriptElement>('script[data-wizard-landing-sections]');
+
+    if (!source?.textContent) {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(source.textContent) as unknown;
+
+      return Array.isArray(parsed)
+        ? parsed.filter((item): item is LandingSectionOption => typeof item === 'object' && item !== null)
+        : [];
+    } catch (_error) {
+      return [];
+    }
+  };
+
+  const readLandingDefaultLayouts = (): string[] => {
+    const source = root.querySelector<HTMLScriptElement>('script[data-wizard-landing-default-layouts]');
+
+    if (!source?.textContent) {
+      return ['hero', 'seo-content', 'vision-mission-v1', 'badges', 'portfolio-v1', 'seo-content', 'testimonials-v1', 'seo-content'];
+    }
+
+    try {
+      const parsed = JSON.parse(source.textContent) as unknown;
+
+      return Array.isArray(parsed) ? parsed.map(String).filter(Boolean) : [];
+    } catch (_error) {
+      return ['hero', 'seo-content'];
+    }
+  };
+
+  const getLandingRowsContainer = (): HTMLElement | null => root.querySelector<HTMLElement>('[data-wizard-landing-rows]');
+
+  const getLandingRowTemplate = (): HTMLTemplateElement | null => root.querySelector<HTMLTemplateElement>('template[data-wizard-landing-row-template]');
+
+  const getLandingSectionRowTemplate = (): HTMLTemplateElement | null => root.querySelector<HTMLTemplateElement>('template[data-wizard-landing-section-row-template]');
+
+  const hydrateLandingRowsFromState = (): void => {
+    const rows = getLandingRowsContainer();
+
+    if (!rows) {
+      return;
+    }
+
+    // Never clobber in-progress edits; only seed when the builder is empty.
+    if (rows.querySelector('[data-wizard-landing-row]')) {
+      syncLandingBuilderEmptyState();
+      return;
+    }
+
+    const landings = Array.isArray(state.landing_pages) ? state.landing_pages : [];
+
+    if (landings.length === 0) {
+      syncLandingBuilderEmptyState();
+      return;
+    }
+
+    landings.forEach((landing) => {
+      const rawId = landing.id;
+      const parsedId = typeof rawId === 'number'
+        ? rawId
+        : (typeof rawId === 'string' ? Number.parseInt(rawId, 10) : NaN);
+
+      addLandingRow({
+        id: Number.isFinite(parsedId) && parsedId > 0 ? parsedId : null,
+        landing_key: landing.landing_key || mintLandingKey(),
+        title: landing.title || '',
+        slug: landing.slug || '',
+        landing_type: landing.landing_type === 'ads' ? 'ads' : 'seo',
+        primary_keyword: landing.primary_keyword || landing.keywords?.primary_keyword || '',
+        subkeywords: landing.subkeywords || landing.keywords?.subkeywords || [],
+      });
+    });
+  };
+
+  const addLandingRow = (data: Partial<LandingPayloadItem> = {}): HTMLElement | null => {
+    const rows = getLandingRowsContainer();
+    const template = getLandingRowTemplate();
+
+    if (!rows || !template) {
+      return null;
+    }
+
+    const index = rows.querySelectorAll('[data-wizard-landing-row]').length;
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = template.innerHTML.replaceAll('__INDEX__', String(index)).trim();
+    const row = wrapper.firstElementChild instanceof HTMLElement ? wrapper.firstElementChild : null;
+
+    if (!row) {
+      return null;
+    }
+
+    const idInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-id]');
+    const keyInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-key]');
+    const titleInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-title]');
+    const slugInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-slug]');
+    const typeSelect = row.querySelector<HTMLSelectElement>('[data-wizard-landing-type]');
+    const keywordInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-primary-keyword]');
+    const subkeywordsInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-subkeywords]');
+    const heading = row.querySelector<HTMLElement>('[data-wizard-landing-heading]');
+
+    if (idInput) {
+      idInput.value = data.id && Number(data.id) > 0 ? String(data.id) : '';
+    }
+
+    if (keyInput) {
+      keyInput.value = data.landing_key || mintLandingKey();
+    }
+
+    if (titleInput) {
+      titleInput.value = data.title || '';
+    }
+
+    if (slugInput) {
+      slugInput.value = sanitizeSlug(data.slug || data.title || '');
+      slugInput.dataset.wizardSlugAuto = data.slug ? '0' : '1';
+    }
+
+    if (typeSelect) {
+      typeSelect.value = data.landing_type === 'ads' ? 'ads' : 'seo';
+    }
+
+    if (keywordInput) {
+      keywordInput.value = data.primary_keyword || '';
+    }
+
+    if (subkeywordsInput) {
+      subkeywordsInput.value = (data.subkeywords || []).join(', ');
+    }
+
+    if (heading) {
+      heading.textContent = data.title || `Landing ${index + 1}`;
+    }
+
+    rows.append(row);
+    row.classList.toggle('is-ads', typeSelect?.value === 'ads');
+
+    const sectionLayouts = (data.sections && data.sections.length > 0)
+      ? data.sections.map((section) => section.layout)
+      : readLandingDefaultLayouts();
+
+    sectionLayouts.forEach((layout, sectionIndex) => {
+      const override = Boolean(data.sections?.[sectionIndex]?.override_canonical);
+      addLandingSectionRow(row, layout, override);
+    });
+
+    reindexLandingRows();
+    syncLandingBuilderEmptyState();
+    syncLandingSkipAllUi();
+    titleInput?.focus();
+
+    return row;
+  };
+
+  const addLandingSectionRow = (landingRow: HTMLElement, layout = '', override = false): void => {
+    const container = landingRow.querySelector<HTMLElement>('[data-wizard-landing-section-rows]');
+    const template = getLandingSectionRowTemplate();
+
+    if (!container || !template) {
+      return;
+    }
+
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = template.innerHTML
+      .replaceAll('__LINDEX__', '0')
+      .replaceAll('__SINDEX__', String(container.querySelectorAll('[data-wizard-landing-section-row]').length))
+      .trim();
+    const sectionRow = wrapper.firstElementChild instanceof HTMLElement ? wrapper.firstElementChild : null;
+
+    if (!sectionRow) {
+      return;
+    }
+
+    const select = sectionRow.querySelector<HTMLSelectElement>('[data-wizard-landing-section-layout]');
+    const overrideInput = sectionRow.querySelector<HTMLInputElement>('[data-wizard-landing-section-override]');
+    const options = readLandingSectionOptions();
+
+    if (select) {
+      select.replaceChildren();
+      options.forEach((option) => {
+        if (!option.layout) {
+          return;
+        }
+
+        const opt = new Option(
+          option.label ? `${option.label} (${option.layout})` : option.layout,
+          option.layout
+        );
+        select.append(opt);
+      });
+
+      if (layout) {
+        select.value = layout;
+      } else if (options[0]?.layout) {
+        select.value = options[0].layout;
+      }
+
+      syncLandingSectionOverrideVisibility(sectionRow);
+    }
+
+    if (overrideInput) {
+      overrideInput.checked = override;
+    }
+
+    container.append(sectionRow);
+    reindexLandingRows();
+  };
+
+  const syncLandingSectionOverrideVisibility = (sectionRow: HTMLElement): void => {
+    const layout = sectionRow.querySelector<HTMLSelectElement>('[data-wizard-landing-section-layout]')?.value ?? '';
+    const overrideLabel = sectionRow.querySelector<HTMLElement>('.rms-wizard-landing-section-override');
+    const isKeyword = layout === 'hero' || layout === 'seo-content';
+
+    if (overrideLabel) {
+      overrideLabel.hidden = isKeyword;
+    }
+
+    if (isKeyword) {
+      const overrideInput = sectionRow.querySelector<HTMLInputElement>('[data-wizard-landing-section-override]');
+
+      if (overrideInput) {
+        overrideInput.checked = false;
+      }
+    }
+  };
+
+  const duplicateLandingRow = (button: HTMLButtonElement): void => {
+    const source = button.closest<HTMLElement>('[data-wizard-landing-row]');
+
+    if (!source) {
+      return;
+    }
+
+    const title = source.querySelector<HTMLInputElement>('[data-wizard-landing-title]')?.value.trim() ?? '';
+    const slug = source.querySelector<HTMLInputElement>('[data-wizard-landing-slug]')?.value.trim() ?? '';
+    const landingType = source.querySelector<HTMLSelectElement>('[data-wizard-landing-type]')?.value === 'ads' ? 'ads' : 'seo';
+    const primaryKeyword = source.querySelector<HTMLInputElement>('[data-wizard-landing-primary-keyword]')?.value.trim() ?? '';
+    const subkeywords = (source.querySelector<HTMLInputElement>('[data-wizard-landing-subkeywords]')?.value ?? '')
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean);
+    const sections: LandingSectionPayload[] = Array.from(source.querySelectorAll<HTMLElement>('[data-wizard-landing-section-row]')).map((sectionRow) => ({
+      layout: sectionRow.querySelector<HTMLSelectElement>('[data-wizard-landing-section-layout]')?.value.trim() ?? '',
+      override_canonical: Boolean(sectionRow.querySelector<HTMLInputElement>('[data-wizard-landing-section-override]')?.checked),
+    })).filter((section) => section.layout);
+
+    // Duplicate must clear id and mint a new landing_key.
+    addLandingRow({
+      id: null,
+      landing_key: mintLandingKey(),
+      title: title ? `${title} copy` : '',
+      slug: slug ? `${slug}-copy` : '',
+      landing_type: landingType,
+      primary_keyword: primaryKeyword,
+      subkeywords,
+      sections,
+    });
+  };
+
+  const removeLandingRow = (button: HTMLButtonElement): void => {
+    button.closest<HTMLElement>('[data-wizard-landing-row]')?.remove();
+    reindexLandingRows();
+    syncLandingBuilderEmptyState();
+  };
+
+  const reindexLandingRows = (): void => {
+    const rows = Array.from(root.querySelectorAll<HTMLElement>('[data-wizard-landing-row]'));
+
+    rows.forEach((row, index) => {
+      row.dataset.wizardLandingIndex = String(index);
+
+      const heading = row.querySelector<HTMLElement>('[data-wizard-landing-heading]');
+      const title = row.querySelector<HTMLInputElement>('[data-wizard-landing-title]')?.value.trim() ?? '';
+
+      if (heading) {
+        heading.textContent = title || `Landing ${index + 1}`;
+      }
+
+      row.classList.toggle('is-ads', row.querySelector<HTMLSelectElement>('[data-wizard-landing-type]')?.value === 'ads');
+
+      row.querySelectorAll<FieldElement>('[name]').forEach((field) => {
+        field.name = field.name
+          .replace(/landings\[\d+\]/g, `landings[${index}]`)
+          .replace(/landings\[__INDEX__\]/g, `landings[${index}]`);
+      });
+
+      row.querySelectorAll<HTMLElement>('[id]').forEach((element) => {
+        element.id = element.id.replace(/rms-wizard-landing-([a-z-]+)-\d+/g, `rms-wizard-landing-$1-${index}`);
+      });
+
+      row.querySelectorAll<HTMLLabelElement>('label[for]').forEach((label) => {
+        label.htmlFor = label.htmlFor.replace(/rms-wizard-landing-([a-z-]+)-\d+/g, `rms-wizard-landing-$1-${index}`);
+      });
+
+      Array.from(row.querySelectorAll<HTMLElement>('[data-wizard-landing-section-row]')).forEach((sectionRow, sectionIndex) => {
+        sectionRow.querySelectorAll<FieldElement>('[name]').forEach((field) => {
+          field.name = field.name
+            .replace(/landings\[\d+\]/g, `landings[${index}]`)
+            .replace(/sections\[\d+\]/g, `sections[${sectionIndex}]`)
+            .replace(/__LINDEX__/g, String(index))
+            .replace(/__SINDEX__/g, String(sectionIndex));
+        });
+      });
+    });
+  };
+
+  const syncLandingBuilderEmptyState = (): void => {
+    const hasRows = Boolean(root.querySelector('[data-wizard-landing-row]'));
+    const emptyMessage = root.querySelector<HTMLElement>('[data-wizard-landing-empty]');
+
+    if (emptyMessage) {
+      emptyMessage.hidden = hasRows;
+    }
+  };
+
+  const syncLandingSkipAllUi = (): void => {
+    const form = root.querySelector<HTMLFormElement>('[data-wizard-landing-page-builder-form]');
+    const skip = form?.querySelector<HTMLInputElement>('[data-wizard-landing-skip-all]');
+    const builder = form?.querySelector<HTMLElement>('[data-wizard-landing-builder]');
+    const toolbar = form?.querySelector<HTMLElement>('.rms-wizard-landing-toolbar');
+    const replacePanel = form?.querySelector<HTMLElement>('[data-wizard-landing-replace-panel]');
+    const skipped = Boolean(skip?.checked);
+
+    if (builder) {
+      builder.hidden = skipped;
+    }
+
+    if (toolbar) {
+      toolbar.hidden = skipped;
+    }
+
+    if (replacePanel) {
+      replacePanel.hidden = skipped;
+    }
+
+    form?.classList.toggle('is-skip-all', skipped);
+  };
+
+  const renderLandingReplaceOptions = (): void => {
+    const list = root.querySelector<HTMLElement>('[data-wizard-landing-replace-list]');
+
+    if (!list || list.dataset.wizardRendered === '1') {
+      return;
+    }
+
+    const options = readLandingSectionOptions().filter((option) => option.layout && !option.is_keyword_layout);
+    list.replaceChildren();
+
+    options.forEach((option) => {
+      if (!option.layout) {
+        return;
+      }
+
+      const label = document.createElement('label');
+      label.className = 'rms-wizard-landing-replace-option';
+
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      input.value = option.layout;
+      input.dataset.wizardLandingReplaceLayout = '1';
+      input.name = `replace_canonical[${option.layout}]`;
+
+      const text = document.createElement('span');
+      text.textContent = option.label ? `${option.label} (${option.layout})` : option.layout;
+
+      label.append(input, text);
+      list.append(label);
+    });
+
+    list.dataset.wizardRendered = '1';
   };
 
   const syncGuidedControlState = (): void => {
@@ -1669,6 +2305,52 @@ declare global {
       if (removePageButton) {
         event.preventDefault();
         removePageRow(removePageButton);
+        return;
+      }
+
+      const addLandingButton = target.closest<HTMLButtonElement>('[data-wizard-add-landing]');
+
+      if (addLandingButton) {
+        event.preventDefault();
+        addLandingRow();
+        return;
+      }
+
+      const duplicateLandingButton = target.closest<HTMLButtonElement>('[data-wizard-duplicate-landing]');
+
+      if (duplicateLandingButton) {
+        event.preventDefault();
+        duplicateLandingRow(duplicateLandingButton);
+        return;
+      }
+
+      const removeLandingButton = target.closest<HTMLButtonElement>('[data-wizard-remove-landing]');
+
+      if (removeLandingButton) {
+        event.preventDefault();
+        removeLandingRow(removeLandingButton);
+        return;
+      }
+
+      const addLandingSectionButton = target.closest<HTMLButtonElement>('[data-wizard-add-landing-section]');
+
+      if (addLandingSectionButton) {
+        event.preventDefault();
+        const landingRow = addLandingSectionButton.closest<HTMLElement>('[data-wizard-landing-row]');
+
+        if (landingRow) {
+          addLandingSectionRow(landingRow);
+        }
+
+        return;
+      }
+
+      const removeLandingSectionButton = target.closest<HTMLButtonElement>('[data-wizard-remove-landing-section]');
+
+      if (removeLandingSectionButton) {
+        event.preventDefault();
+        removeLandingSectionButton.closest<HTMLElement>('[data-wizard-landing-section-row]')?.remove();
+        reindexLandingRows();
       }
     });
 
@@ -1682,6 +2364,24 @@ declare global {
       if (target instanceof HTMLInputElement && target.matches('[data-wizard-page-slug]')) {
         updatePageRowFromSlug(target);
       }
+
+      if (target instanceof HTMLInputElement && target.matches('[data-wizard-landing-title]')) {
+        const row = target.closest<HTMLElement>('[data-wizard-landing-row]');
+        const slugInput = row?.querySelector<HTMLInputElement>('[data-wizard-landing-slug]');
+        const heading = row?.querySelector<HTMLElement>('[data-wizard-landing-heading]');
+
+        if (slugInput && slugInput.dataset.wizardSlugAuto !== '0') {
+          slugInput.value = sanitizeSlug(target.value);
+        }
+
+        if (heading) {
+          heading.textContent = target.value.trim() || 'Landing';
+        }
+      }
+
+      if (target instanceof HTMLInputElement && target.matches('[data-wizard-landing-slug]')) {
+        target.dataset.wizardSlugAuto = '0';
+      }
     });
 
     root.addEventListener('blur', (event) => {
@@ -1689,6 +2389,11 @@ declare global {
 
       if (target instanceof HTMLInputElement && target.matches('[data-wizard-page-slug]')) {
         updatePageRowFromSlug(target, true);
+      }
+
+      if (target instanceof HTMLInputElement && target.matches('[data-wizard-landing-slug]')) {
+        target.value = sanitizeSlug(target.value);
+        target.dataset.wizardSlugAuto = '0';
       }
     }, true);
 
@@ -1711,6 +2416,26 @@ declare global {
 
       if (target instanceof HTMLSelectElement && target.matches('[data-wizard-home-section-select]')) {
         syncGuidedControlState();
+        return;
+      }
+
+      if (target instanceof HTMLInputElement && target.matches('[data-wizard-landing-skip-all]')) {
+        syncLandingSkipAllUi();
+        return;
+      }
+
+      if (target instanceof HTMLSelectElement && target.matches('[data-wizard-landing-type]')) {
+        const row = target.closest<HTMLElement>('[data-wizard-landing-row]');
+        row?.classList.toggle('is-ads', target.value === 'ads');
+        return;
+      }
+
+      if (target instanceof HTMLSelectElement && target.matches('[data-wizard-landing-section-layout]')) {
+        const sectionRow = target.closest<HTMLElement>('[data-wizard-landing-section-row]');
+
+        if (sectionRow) {
+          syncLandingSectionOverrideVisibility(sectionRow);
+        }
       }
     });
 


### PR DESCRIPTION
Closes #16

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Activates the wizard landing page builder as the visible 8th setup step.
- Adds landing UI collection, skip-all, identity hydration, menu reconciliation, Ads noindex/sitemap protection, Yoast meta handling, and flexible landing template rendering.
- Keeps Ads landings noindex/orphan by default and SEO landings menu-eligible/indexable by default.

## Chain Context

Strategy: feature-branch-chain

```text
feature/wizard-setup
└── PR 1: feat/wizard-landing-foundation
    └── PR 2: feat/wizard-landing-backend
        └── 📍 PR 3: feat/wizard-landing-ui
```

Current PR boundary: activation slice. PR1 provided foundation, PR2 provided dormant backend, this PR wires UI/menu/SEO/template and activates `landing-page-builder` in `REQUIRED_STEPS` + `DISPATCHABLE_STEPS`.

## Changes

| File | Change |
|------|--------|
| `inc/wizard/class-menu-builder.php` | Adds idempotent append/remove/read-back reconciliation helpers. |
| `inc/wizard/class-step-menu-setup.php` | Merges eligible SEO landings and fail-closes if Ads remain in menus. |
| `inc/wizard/class-yoast-meta-writer.php` | Adds landing SEO title/metadesc and Ads noindex helpers with read-back. |
| `inc/wizard/class-step-landing-page-builder.php` | Adds menu/noindex final-state sync, skip-all reconciliation, and Ads protection on error paths. |
| `inc/wizard/class-step-controller.php` | Activates `landing-page-builder` as required/dispatchable. |
| `inc/wizard/wizard-init.php` | Adds landing UI markup, robots/sitemap protections, and admin-state support. |
| `src/ts/admin/wizard.ts` | Adds landing rows, validation, payload collection, skip-all, identity hydration, duplicate reset, and replace modal behavior. |
| `src/scss/admin/wizard.scss` | Adds landing/unlock admin styles. |
| `pages/landing-page.php` | Renders flexible `page_sections`, injects breadcrumb after first Hero, and has safe fallback when ACF is absent. |
| `openspec/changes/wizard-landing-page-builder/*` | Marks Phase 3 complete and documents verification/follow-ups. |

## Test Plan

- [x] `php -l` passed on touched PHP files.
- [x] `npx tsc --noEmit` passed.
- [x] `npm run build` passed.
- [x] 4R review completed: risk PASS, reliability PASS except known no-runner limitation, resilience PASS, readability PASS.
- [x] Verified by review: `skip_all` reconciles existing landings before completion.
- [x] Verified by review: Ads final-state has noindex + menu removal + sitemap/robots protection.
- [x] Verified by review: ACF-missing landing template fallback does not call ACF template parts.

## Known Limitations / Follow-ups

- Automated behavioral tests are unavailable in this project (`strict_tdd: false`, no runner). Manual WP Admin runtime verification remains Phase 4.
- SEO menu append is best-effort with structured warnings; Ads menu removal is fail-closed.
- Shared helper extraction between Home Builder and Landing Builder remains planned after PR3 or before archive.

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran applicable syntax/build checks
- [x] SDD artifacts updated
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers