### PR TITLE
fix(schema): survive inactive ACF on the frontend

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -24,6 +24,9 @@ require_once get_template_directory() . '/inc/vite-integration.php';
 // ─── Structured Data (Schema) — AEO/GEO ─────────────────────────────
 require_once get_template_directory() . '/inc/schema.php';
 
+// ─── ACF Frontend Template Boundary (setup-safe shell when ACF inactive) ─
+require_once get_template_directory() . '/inc/acf-template-boundary.php';
+
 // ─── TGM Plugin Activation ────────────────────────────────────────
 require_once get_template_directory() . '/inc/tgmpa.php';
 

--- a/inc/acf-template-boundary.php
+++ b/inc/acf-template-boundary.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * ACF Frontend Template Boundary
+ *
+ * ACF Pro is a required theme dependency. When its APIs are unavailable
+ * (plugin inactive), `template_include` swaps ANY frontend template for
+ * the single setup-safe shell before any ACF-dependent partial can fatal.
+ * With ACF active, the original template is returned unchanged.
+ *
+ * @package Simple_RMS_Theme
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Whether the ACF Pro APIs the theme requires are available.
+ *
+ * @return bool
+ */
+function rms_acf_available(): bool {
+    return function_exists( 'get_field' )
+        && function_exists( 'get_sub_field' )
+        && function_exists( 'have_rows' )
+        && function_exists( 'the_row' )
+        && function_exists( 'get_row_layout' );
+}
+
+/**
+ * Whether this request is admin, REST, or CLI and must keep its original template.
+ *
+ * `template_include` does not run in those contexts, but the bypass is explicit
+ * so those surfaces are never masked if the filter is applied manually.
+ *
+ * @return bool
+ */
+function rms_acf_boundary_should_bypass(): bool {
+    if ( function_exists( 'is_admin' ) && is_admin() ) {
+        return true;
+    }
+
+    if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+        return true;
+    }
+
+    if ( defined( 'WP_CLI' ) && WP_CLI ) {
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * `template_include`: swap to the setup-safe shell when ACF is unavailable.
+ * If the safe template is missing/unreadable, return the original rather
+ * than introduce another error.
+ *
+ * @param string $template The template WordPress selected for this request.
+ * @return string Template to load.
+ */
+function rms_template_include_acf_boundary( string $template ): string {
+    if ( rms_acf_available() || '' === $template || rms_acf_boundary_should_bypass() ) {
+        return $template;
+    }
+
+    $safe = trailingslashit( get_template_directory() ) . 'templates/setup-safe.php';
+    if ( is_readable( $safe ) ) {
+        return $safe;
+    }
+
+    return $template;
+}
+add_filter( 'template_include', 'rms_template_include_acf_boundary' );

--- a/inc/schema.php
+++ b/inc/schema.php
@@ -183,8 +183,9 @@ function rms_schema_local_business(): array {
         ];
     }
 
-    // Payment methods — pull from ACF
-    $payment_methods = get_field('company_payment_methods', 'option');
+    // Payment methods — pulled from ACF via the guarded option helper so the
+    // schema path never fatals when ACF Pro is inactive (returns null → fallback below).
+    $payment_methods = rms_get_option('company_payment_methods');
     $payment_labels = [];
     if (!empty($payment_methods) && is_array($payment_methods)) {
         foreach ($payment_methods as $pm) {
@@ -655,6 +656,12 @@ function rms_schema_testimonials_page(): void {
  * These schemas appear on every page: LocalBusiness, Organization, WebSite.
  */
 function rms_schema_header(): void {
+    // Omit schema when ACF is inactive so wp_head cannot emit fallback
+    // client/demo facts or call missing ACF APIs.
+    if (!function_exists('get_field')) {
+        return;
+    }
+
     // LocalBusiness + HomeAndConstructionBusiness
     rms_schema_output(rms_schema_local_business());
 

--- a/templates/contact-info.php
+++ b/templates/contact-info.php
@@ -16,7 +16,7 @@
                 <div class="contact-info__list">
 
                     <?php
-                    $phones = get_field('company_phones', 'option');
+                    $phones = rms_get_option('company_phones');
                     if (is_array($phones) && !empty($phones)) :
                         $primary_phone = $phones[0]['phone_number'] ?? '';
                         $primary_phone_clean = preg_replace('/[^0-9+]/', '', $primary_phone);
@@ -46,7 +46,7 @@
                     <?php endif; ?>
 
                     <?php
-                    $emails = get_field('company_emails', 'option');
+                    $emails = rms_get_option('company_emails');
                     if (is_array($emails) && !empty($emails)) :
                         $primary_email = $emails[0]['email_address'] ?? '';
                         ?>
@@ -134,7 +134,7 @@
                     <?php endif; ?>
 
                     <?php
-                    $schedule = get_field('company_schedule', 'option');
+                    $schedule = rms_get_option('company_schedule');
                     if (is_array($schedule) && !empty($schedule)) :
                         $day_labels = [
                             'monday'    => 'Mon',
@@ -199,7 +199,7 @@
                         <div>
                             <strong class="contact-info__item-label">Payment Methods</strong>
                             <?php
-                        $methods = get_field('company_payment_methods', 'option');
+                        $methods = rms_get_option('company_payment_methods');
                         $method_labels = [];
                         if (!empty($methods) && is_array($methods)) {
                             foreach ($methods as $m) {

--- a/templates/footer-v2.php
+++ b/templates/footer-v2.php
@@ -91,8 +91,8 @@
             <div class="footer-v2__column footer-v2__column--info">
                 <h2 class="footer-v2__heading">Company Info</h2>
                 <?php
-                    $phones = get_field('company_phones', 'option');
-                    $emails = get_field('company_emails', 'option');
+                    $phones = rms_get_option('company_phones');
+                    $emails = rms_get_option('company_emails');
                     $addr_line1 = rms_get_option('company_address_line_1');
                     $addr_line2 = rms_get_option('company_address_line_2');
                     $addr_city  = rms_get_option('company_city');
@@ -160,7 +160,7 @@
                     <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="1" y="4" width="22" height="16" rx="2" ry="2"/><line x1="1" y1="10" x2="23" y2="10"/></svg>
                     <strong>Payment Methods:</strong>
                     <?php
-                    $methods = get_field('company_payment_methods', 'option');
+                    $methods = rms_get_option('company_payment_methods');
                     if (!empty($methods) && is_array($methods)) {
                         $labels = array_filter(array_column($methods, 'payment_method_name'));
                         if (!empty($labels)) {

--- a/templates/setup-safe.php
+++ b/templates/setup-safe.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Setup-Safe Frontend Shell
+ *
+ * Rendered by `rms_template_include_acf_boundary` when ACF Pro is inactive.
+ * Self-contained on purpose: header/footer chrome contains demo client facts
+ * and would also fire `wp_head` schema. This shell returns HTTP 200 HTML
+ * with no client facts and no ACF API calls.
+ *
+ * Visitors see a plain setup message. Users who can manage options also
+ * see a link to the plugins admin screen (capability-checked).
+ *
+ * @package Simple_RMS_Theme
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( function_exists( 'nocache_headers' ) ) {
+    nocache_headers();
+}
+
+if ( function_exists( 'status_header' ) ) {
+    status_header( 200 );
+}
+
+$site_name = get_bloginfo( 'name' );
+?><!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo( 'charset' ); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><?php echo esc_html( $site_name ); ?></title>
+</head>
+<body class="setup-safe">
+<main id="main-content" class="setup-safe">
+    <section class="setup-safe__section">
+        <div class="container">
+            <h1 class="setup-safe__title">
+                <?php echo esc_html( $site_name ); ?>
+            </h1>
+            <p class="setup-safe__message">
+                <?php
+                esc_html_e(
+                    'This site is almost ready. A required plugin needs to be activated before the full content can be displayed.',
+                    'simple-rms-theme'
+                );
+                ?>
+            </p>
+            <?php if ( current_user_can( 'manage_options' ) ) : ?>
+                <p class="setup-safe__action">
+                    <a class="btn setup-safe__button" href="<?php echo esc_url( admin_url( 'plugins.php' ) ); ?>">
+                        <?php esc_html_e( 'Activate plugins in the admin dashboard', 'simple-rms-theme' ); ?>
+                    </a>
+                </p>
+            <?php endif; ?>
+        </div>
+    </section>
+</main>
+</body>
+</html>

--- a/tests/acf-inactive-frontend-harness.php
+++ b/tests/acf-inactive-frontend-harness.php
@@ -1,0 +1,360 @@
+<?php
+/**
+ * Focused smoke harness for issue #23 (ACF-inactive frontend).
+ *
+ * No framework. Parent process runs isolated child scenarios because
+ * `function_exists` / ACF stubs cannot be toggled in one process.
+ *
+ * Usage: php tests/acf-inactive-frontend-harness.php
+ */
+
+if ( PHP_SAPI !== 'cli' ) {
+    fwrite( STDERR, "CLI only.\n" );
+    exit( 1 );
+}
+
+$scenario = getenv( 'RMS_HARNESS_SCENARIO' );
+
+if ( false === $scenario || '' === $scenario ) {
+    $php       = PHP_BINARY;
+    $self      = __FILE__;
+    $scenarios = array(
+        'inactive-swap',
+        'active-passthrough',
+        'admin-bypass',
+        'rest-bypass',
+        'cli-bypass',
+        'option-helper',
+        'option-helper-active',
+        'schema-no-get-field',
+        'shell-guest',
+        'shell-admin',
+        'safe-missing',
+    );
+
+    $failed = 0;
+    foreach ( $scenarios as $name ) {
+        $cmd = '"' . $php . '" ' . escapeshellarg( $self );
+        putenv( 'RMS_HARNESS_SCENARIO=' . $name );
+        $output = array();
+        $code   = 0;
+        exec( $cmd, $output, $code );
+        $text = implode( "\n", $output );
+        if ( 0 !== $code ) {
+            fwrite( STDERR, "FAIL {$name}\n{$text}\n" );
+            $failed++;
+            continue;
+        }
+        echo "PASS {$name}\n";
+        if ( '' !== $text ) {
+            echo $text . "\n";
+        }
+    }
+    putenv( 'RMS_HARNESS_SCENARIO' );
+
+    if ( $failed > 0 ) {
+        fwrite( STDERR, "Harness failed: {$failed} scenario(s).\n" );
+        exit( 1 );
+    }
+
+    echo "Harness passed: " . count( $scenarios ) . " scenarios.\n";
+    exit( 0 );
+}
+
+$theme_root = dirname( __DIR__ );
+
+/**
+ * @param mixed $condition
+ */
+function rms_harness_assert( $condition, string $message ): void {
+    if ( ! $condition ) {
+        fwrite( STDERR, $message . "\n" );
+        exit( 1 );
+    }
+}
+
+function rms_harness_stub_wordpress( array $overrides = array() ): void {
+    if ( ! defined( 'ABSPATH' ) ) {
+        define( 'ABSPATH', __DIR__ . '/' );
+    }
+
+    $defaults = array(
+        'is_admin'        => false,
+        'can_manage'      => false,
+        'status'          => null,
+        'nocache'         => false,
+        'blogname'        => 'Harness Site',
+        'charset'         => 'UTF-8',
+        'filters'         => array(),
+        'template_dir'    => dirname( __DIR__ ),
+        'get_field_calls' => 0,
+    );
+    $existing = isset( $GLOBALS['rms_harness'] ) && is_array( $GLOBALS['rms_harness'] ) ? $GLOBALS['rms_harness'] : array();
+    $GLOBALS['rms_harness'] = array_merge( $defaults, $existing, $overrides );
+
+    if ( ! function_exists( 'add_filter' ) ) {
+        function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+            $GLOBALS['rms_harness']['filters'][ $hook ][] = $callback;
+            return true;
+        }
+    }
+
+    if ( ! function_exists( 'add_action' ) ) {
+        function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+            return add_filter( $hook, $callback, $priority, $accepted_args );
+        }
+    }
+
+    if ( ! function_exists( 'trailingslashit' ) ) {
+        function trailingslashit( $value ) {
+            return rtrim( (string) $value, '/\\' ) . '/';
+        }
+    }
+
+    if ( ! function_exists( 'get_template_directory' ) ) {
+        function get_template_directory() {
+            return $GLOBALS['rms_harness']['template_dir'];
+        }
+    }
+
+    if ( ! function_exists( 'is_admin' ) ) {
+        function is_admin() {
+            return ! empty( $GLOBALS['rms_harness']['is_admin'] );
+        }
+    }
+
+    if ( ! function_exists( 'get_bloginfo' ) ) {
+        function get_bloginfo( $show = '' ) {
+            if ( 'charset' === $show ) {
+                return $GLOBALS['rms_harness']['charset'];
+            }
+            return $GLOBALS['rms_harness']['blogname'];
+        }
+    }
+
+    if ( ! function_exists( 'bloginfo' ) ) {
+        function bloginfo( $show = '' ) {
+            echo esc_html( get_bloginfo( $show ) );
+        }
+    }
+
+    if ( ! function_exists( 'language_attributes' ) ) {
+        function language_attributes() {
+            echo 'lang="en-US"';
+        }
+    }
+
+    if ( ! function_exists( 'esc_html' ) ) {
+        function esc_html( $text ) {
+            return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' );
+        }
+    }
+
+    if ( ! function_exists( 'esc_html_e' ) ) {
+        function esc_html_e( $text, $domain = '' ) {
+            echo esc_html( $text );
+        }
+    }
+
+    if ( ! function_exists( 'esc_url' ) ) {
+        function esc_url( $url ) {
+            return filter_var( (string) $url, FILTER_SANITIZE_URL );
+        }
+    }
+
+    if ( ! function_exists( 'current_user_can' ) ) {
+        function current_user_can( $cap ) {
+            return ! empty( $GLOBALS['rms_harness']['can_manage'] ) && 'manage_options' === $cap;
+        }
+    }
+
+    if ( ! function_exists( 'admin_url' ) ) {
+        function admin_url( $path = '' ) {
+            return 'https://example.test/wp-admin/' . ltrim( (string) $path, '/' );
+        }
+    }
+
+    if ( ! function_exists( 'nocache_headers' ) ) {
+        function nocache_headers() {
+            $GLOBALS['rms_harness']['nocache'] = true;
+        }
+    }
+
+    if ( ! function_exists( 'status_header' ) ) {
+        function status_header( $code ) {
+            $GLOBALS['rms_harness']['status'] = (int) $code;
+        }
+    }
+
+    if ( ! function_exists( 'home_url' ) ) {
+        function home_url( $path = '' ) {
+            return 'https://example.test' . $path;
+        }
+    }
+}
+
+function rms_harness_define_acf_stubs(): void {
+    if ( ! function_exists( 'get_field' ) ) {
+        function get_field( $selector, $post_id = false, $format_value = true ) {
+            $GLOBALS['rms_harness']['get_field_calls']++;
+            return 'acf-active-value';
+        }
+    }
+    if ( ! function_exists( 'get_sub_field' ) ) {
+        function get_sub_field( $selector, $format_value = true ) {
+            return null;
+        }
+    }
+    if ( ! function_exists( 'have_rows' ) ) {
+        function have_rows( $selector, $post_id = false ) {
+            return false;
+        }
+    }
+    if ( ! function_exists( 'the_row' ) ) {
+        function the_row() {
+            return false;
+        }
+    }
+    if ( ! function_exists( 'get_row_layout' ) ) {
+        function get_row_layout() {
+            return '';
+        }
+    }
+}
+
+switch ( $scenario ) {
+    case 'inactive-swap':
+        rms_harness_stub_wordpress();
+        require $theme_root . '/inc/acf-template-boundary.php';
+        rms_harness_assert( function_exists( 'rms_acf_available' ), 'missing rms_acf_available' );
+        rms_harness_assert( false === rms_acf_available(), 'ACF should be unavailable' );
+
+        $paths = array(
+            $theme_root . '/front-page.php',
+            $theme_root . '/index.php',
+            $theme_root . '/pages/contact-us.php',
+            $theme_root . '/templates/flexible-content.php',
+            $theme_root . '/templates/footer-v2.php',
+        );
+        $safe = $theme_root . '/templates/setup-safe.php';
+        foreach ( $paths as $path ) {
+            $result = rms_template_include_acf_boundary( $path );
+            rms_harness_assert( $safe === $result, 'expected setup-safe for ' . $path . ' got ' . $result );
+        }
+        break;
+
+    case 'active-passthrough':
+        rms_harness_stub_wordpress();
+        rms_harness_define_acf_stubs();
+        require $theme_root . '/inc/acf-template-boundary.php';
+        rms_harness_assert( true === rms_acf_available(), 'ACF should be available' );
+        $original = $theme_root . '/front-page.php';
+        $result   = rms_template_include_acf_boundary( $original );
+        rms_harness_assert( $original === $result, 'ACF-active path must keep original template' );
+        break;
+
+    case 'admin-bypass':
+        rms_harness_stub_wordpress( array( 'is_admin' => true ) );
+        require $theme_root . '/inc/acf-template-boundary.php';
+        $original = $theme_root . '/front-page.php';
+        $result   = rms_template_include_acf_boundary( $original );
+        rms_harness_assert( $original === $result, 'admin must bypass setup-safe swap' );
+        break;
+
+    case 'rest-bypass':
+        define( 'REST_REQUEST', true );
+        rms_harness_stub_wordpress();
+        require $theme_root . '/inc/acf-template-boundary.php';
+        $original = $theme_root . '/front-page.php';
+        $result   = rms_template_include_acf_boundary( $original );
+        rms_harness_assert( $original === $result, 'REST must bypass setup-safe swap' );
+        break;
+
+    case 'cli-bypass':
+        define( 'WP_CLI', true );
+        rms_harness_stub_wordpress();
+        require $theme_root . '/inc/acf-template-boundary.php';
+        $original = $theme_root . '/front-page.php';
+        $result   = rms_template_include_acf_boundary( $original );
+        rms_harness_assert( $original === $result, 'CLI must bypass setup-safe swap' );
+        break;
+
+    case 'option-helper':
+        rms_harness_stub_wordpress();
+        require $theme_root . '/inc/acf-theme-options.php';
+        rms_harness_assert( false === function_exists( 'get_field' ), 'get_field must stay undefined' );
+        $value = rms_get_option( 'company_payment_methods', 'SAFE_DEFAULT' );
+        rms_harness_assert( 'SAFE_DEFAULT' === $value, 'rms_get_option must return default without get_field' );
+        $empty = rms_get_option( 'company_phones' );
+        rms_harness_assert( null === $empty, 'rms_get_option must return null default without get_field' );
+        break;
+
+    case 'option-helper-active':
+        rms_harness_stub_wordpress();
+        rms_harness_define_acf_stubs();
+        require $theme_root . '/inc/acf-theme-options.php';
+        $value = rms_get_option( 'company_payment_methods', 'SAFE_DEFAULT' );
+        rms_harness_assert( 'acf-active-value' === $value, 'ACF-active rms_get_option must call get_field' );
+        rms_harness_assert( $GLOBALS['rms_harness']['get_field_calls'] > 0, 'get_field was not called on the active path' );
+        break;
+
+    case 'schema-no-get-field':
+        rms_harness_stub_wordpress();
+        require $theme_root . '/inc/acf-theme-options.php';
+        require $theme_root . '/inc/schema.php';
+        rms_harness_assert( false === function_exists( 'get_field' ), 'get_field must stay undefined' );
+        $schema = rms_schema_local_business();
+        rms_harness_assert( is_array( $schema ), 'schema helper must return an array without get_field' );
+        ob_start();
+        rms_schema_header();
+        $out = ob_get_clean();
+        rms_harness_assert( '' === $out, 'schema header must emit nothing when ACF is inactive' );
+        break;
+
+    case 'shell-guest':
+        rms_harness_stub_wordpress();
+        ob_start();
+        require $theme_root . '/templates/setup-safe.php';
+        $html = ob_get_clean();
+        rms_harness_assert( 200 === $GLOBALS['rms_harness']['status'], 'setup-safe must set HTTP 200' );
+        rms_harness_assert( true === $GLOBALS['rms_harness']['nocache'], 'setup-safe must send nocache headers' );
+        rms_harness_assert( false !== stripos( $html, '<!DOCTYPE html>' ), 'missing doctype' );
+        rms_harness_assert( false !== stripos( $html, '<main' ), 'missing main landmark' );
+        rms_harness_assert( false !== stripos( $html, '<h1' ), 'missing h1' );
+        rms_harness_assert( false !== stripos( $html, 'almost ready' ), 'missing setup copy' );
+        rms_harness_assert( false === stripos( $html, 'plugins.php' ), 'guest must not see plugins link' );
+        rms_harness_assert( false === stripos( $html, '414' ), 'must not leak demo phone' );
+        rms_harness_assert( false === stripos( $html, 'Milwaukee' ), 'must not leak demo city' );
+        rms_harness_assert( false === stripos( $html, 'get_field' ), 'must not mention get_field' );
+        rms_harness_assert( false === function_exists( 'get_field' ), 'shell must not define get_field' );
+        break;
+
+    case 'safe-missing':
+        $temp = sys_get_temp_dir() . '/rms-acf-harness-' . getmypid();
+        if ( ! is_dir( $temp ) && ! mkdir( $temp ) && ! is_dir( $temp ) ) {
+            fwrite( STDERR, "Unable to create temp dir\n" );
+            exit( 1 );
+        }
+        rms_harness_stub_wordpress( array( 'template_dir' => $temp ) );
+        require $theme_root . '/inc/acf-template-boundary.php';
+        $original = $theme_root . '/front-page.php';
+        $result   = rms_template_include_acf_boundary( $original );
+        rms_harness_assert( $original === $result, 'missing setup-safe must return original template' );
+        @rmdir( $temp );
+        break;
+
+    case 'shell-admin':
+        rms_harness_stub_wordpress( array( 'can_manage' => true ) );
+        ob_start();
+        require $theme_root . '/templates/setup-safe.php';
+        $html = ob_get_clean();
+        rms_harness_assert( false !== stripos( $html, 'plugins.php' ), 'capable admin must see plugins link' );
+        rms_harness_assert( false === stripos( $html, 'advanced-custom-fields' ), 'must not leak plugin slug' );
+        break;
+
+    default:
+        fwrite( STDERR, "Unknown scenario: {$scenario}\n" );
+        exit( 1 );
+}
+
+exit( 0 );


### PR DESCRIPTION
Fixes #23

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Guards the frontend when ACF Pro is inactive so `GET /` no longer fatals on `get_field()`.
- Swaps any frontend template to a setup-safe shell before ACF-dependent partials can run.
- Routes schema and contact/footer option reads through `rms_get_option()` and omits schema in `wp_head` when ACF is missing.

## Changes

| File | Change |
|------|--------|
| `inc/acf-template-boundary.php` | New `template_include` boundary; setup-safe swap when ACF APIs are absent. |
| `templates/setup-safe.php` | Guest/admin setup-safe shell. |
| `functions.php` | Load the ACF template boundary. |
| `inc/schema.php` | Guard `rms_schema_header()`; read payment methods via `rms_get_option()`. |
| `templates/contact-info.php` | Replace unguarded `get_field()` option reads. |
| `templates/footer-v2.php` | Isolated #23 option-safety only (no #28 social refactor). |
| `tests/acf-inactive-frontend-harness.php` | Focused 11-scenario regression harness. |

## Test Plan
- [x] `php -l` passed on all authored PHP files.
- [x] `php tests/acf-inactive-frontend-harness.php` — 11/11 PASS.
- [x] Diff against `docs/vite-manifest-checklist` contains only the #23 slice (7 files, `+515 / -9`).
- [x] `templates/footer-v2.php` contains option-safety only; no golden social refactor.
- [x] Scripts run without errors: N/A — no shell scripts in this PR.

## size:exception

Review budget is **524 / 400** because the 360-line harness must travel with the runtime guard. Production behavior is 7 files / 164 authored lines excluding the harness. Maintainer exception requested for the inseparable test surface.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts: N/A — no shell scripts
- [x] Skills tested in at least one agent: N/A — runtime PHP guard, not a skill change
- [x] Docs updated if behavior changed: N/A — no user-facing docs in this slice
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Chain Context

| Field | Value |
|-------|-------|
| Chain | wizard-setup beta issues #22–#29 |
| Tracker PR | Not needed — retained `feature/wizard-setup` @ `3205ee5` |
| Position | 2 of 11 |
| Base | `docs/vite-manifest-checklist` |
| Depends on | PR #30 / #24 |
| Follow-up | `fix/footer-variant-runtime` (#28) |
| Review budget | 524 / 400 (`size:exception` — harness) |
| Starts at | `docs/vite-manifest-checklist` |
| Ends with | Frontend survives inactive ACF via boundary + guarded option reads |

### Chain Overview

```text
feature/wizard-setup
 └── #30 docs/vite-manifest-checklist  (#24)
      └── 📍 fix/acf-inactive-frontend-guard  (#23)
           └── fix/footer-variant-runtime  (#28)
                └── fix/palette-runtime-css  (#29)
```

### Scope
- Includes: ACF-inactive frontend boundary, setup-safe shell, schema/contact/footer option-safety, harness.
- Excludes: #28 footer variants/social refactor, #29 palette, later wizard slices.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit
