### PR TITLE
fix(footer): render shipped footer variants

### DIFF
--- a/acf-json/group_rms_theme_settings.json
+++ b/acf-json/group_rms_theme_settings.json
@@ -884,7 +884,7 @@
             "name": "company_footer_version",
             "aria-label": "",
             "type": "select",
-            "instructions": "",
+            "instructions": "Compact Footer V1 or full Footer V2. Legacy Footer One and Footer Two values still resolve automatically.",
             "required": false,
             "conditional_logic": false,
             "wrapper": {
@@ -893,12 +893,12 @@
                 "id": ""
             },
             "choices": {
-                "footer-one": "Footer One",
-                "footer-two": "Footer Two"
+                "footer-v1": "Footer V1",
+                "footer-v2": "Footer V2"
             },
             "multiple": 0,
             "allow_null": 0,
-            "default_value": false,
+            "default_value": "footer-v2",
             "ui": 0,
             "ajax": 0,
             "placeholder": "",
@@ -1427,5 +1427,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1779850014
+    "modified": 1779912000
 }

--- a/footer.php
+++ b/footer.php
@@ -1,6 +1,8 @@
 <?php
-$footer_version = sanitize_key(rms_get_option('company_footer_version') ?: 'footer-v2');
-get_template_part("templates/{$footer_version}");
+$footer_version = rms_get_footer_version();
+if ($footer_version !== '') {
+    get_template_part("templates/{$footer_version}");
+}
 wp_footer();
 ?>
 </body>

--- a/header.php
+++ b/header.php
@@ -145,8 +145,10 @@
      }
 
     // Footer — deferred
-    $footer_version = sanitize_key(rms_get_option('company_footer_version') ?: 'footer-v2');
-    $vite->get_deferred_style("layout-{$footer_version}", "src/scss/layout/{$footer_version}.scss");
+    $footer_version = rms_get_footer_version();
+    if ($footer_version !== '') {
+        $vite->get_deferred_style("layout-{$footer_version}", "src/scss/layout/{$footer_version}.scss");
+    }
     ?>
     <?php wp_head(); ?>
 </head>

--- a/inc/acf-theme-options.php
+++ b/inc/acf-theme-options.php
@@ -56,6 +56,104 @@ function rms_get_option(string $field_name, $default = null) {
 }
 
 /**
+ * Map stored footer version values to canonical slugs.
+ *
+ * Offered choices are footer-v1 and footer-v2. Legacy aliases remain
+ * readable so existing option rows still resolve after the rename.
+ *
+ * @return array<string,string>
+ */
+function rms_get_footer_version_aliases(): array {
+    return [
+        'footer-v1'  => 'footer-v1',
+        'footer-v2'  => 'footer-v2',
+        'footer-one' => 'footer-v1',
+        'footer-two' => 'footer-v2',
+    ];
+}
+
+/**
+ * Whether a footer slug has both a PHP template and an authored stylesheet.
+ */
+function rms_footer_version_assets_exist(string $slug, string $theme_root = ''): bool {
+    if ($slug === '') {
+        return false;
+    }
+
+    $root = $theme_root !== ''
+        ? $theme_root
+        : (function_exists('get_template_directory') ? get_template_directory() : '');
+
+    if ($root === '') {
+        return false;
+    }
+
+    $template = $root . '/templates/' . $slug . '.php';
+    $styles   = $root . '/src/scss/layout/' . $slug . '.scss';
+
+    return is_readable($template) && is_readable($styles);
+}
+
+/**
+ * Normalize a stored footer version to a verified, renderable slug.
+ *
+ * Empty, unknown, or incomplete assets fall back to footer-v2. The fallback
+ * is returned only when its own PHP + SCSS exist; otherwise the resolver
+ * fails closed with an empty string so callers can skip rendering.
+ */
+function rms_resolve_footer_version(?string $raw, string $theme_root = ''): string {
+    $fallback  = 'footer-v2';
+    $aliases   = rms_get_footer_version_aliases();
+    $candidate = $raw ? sanitize_key($raw) : '';
+
+    if ($candidate !== '' && isset($aliases[$candidate])) {
+        $candidate = $aliases[$candidate];
+    } else {
+        $candidate = $fallback;
+    }
+
+    if (rms_footer_version_assets_exist($candidate, $theme_root)) {
+        return $candidate;
+    }
+
+    if ($candidate !== $fallback && rms_footer_version_assets_exist($fallback, $theme_root)) {
+        return $fallback;
+    }
+
+    return rms_footer_version_assets_exist($fallback, $theme_root) ? $fallback : '';
+}
+
+/**
+ * Resolve the active footer version for header and footer dispatch.
+ */
+function rms_get_footer_version(): string {
+    $raw = rms_get_option('company_footer_version');
+
+    return rms_resolve_footer_version(is_string($raw) ? $raw : '');
+}
+
+/**
+ * Present legacy footer aliases as the current ACF choices without changing the field key.
+ *
+ * @param mixed $value
+ * @return mixed
+ */
+function rms_migrate_footer_version_value($value) {
+    if (!is_string($value) || $value === '') {
+        return $value;
+    }
+
+    $aliases = rms_get_footer_version_aliases();
+    $key     = sanitize_key($value);
+
+    return $aliases[$key] ?? $value;
+}
+
+if (function_exists('add_filter')) {
+    add_filter('acf/load_value/key=field_rms_company_footer_version', 'rms_migrate_footer_version_value');
+}
+
+/**
  * Get the primary phone number from theme options.
  *
  * @return string

--- a/scripts/test-footer-variants.php
+++ b/scripts/test-footer-variants.php
@@ -1,0 +1,640 @@
+<?php
+/**
+ * Focused regression harness for footer variants (issue #28).
+ *
+ * Run: php scripts/test-footer-variants.php
+ */
+
+$theme_root = dirname(__DIR__);
+$failures   = 0;
+
+function rms_footer_test_fail(string $name, string $message): void {
+    global $failures;
+    $failures++;
+    fwrite(STDERR, "FAIL {$name}: {$message}\n");
+}
+
+function rms_footer_test_pass(string $name): void {
+    fwrite(STDOUT, "PASS {$name}\n");
+}
+
+function rms_footer_read(string $path): string {
+    $contents = file_get_contents($path);
+    return is_string($contents) ? $contents : '';
+}
+
+function rms_footer_test_rrmdir(string $dir): void {
+    if (!is_dir($dir)) {
+        return;
+    }
+
+    $items = scandir($dir);
+    if (!is_array($items)) {
+        return;
+    }
+
+    foreach ($items as $item) {
+        if ($item === '.' || $item === '..') {
+            continue;
+        }
+        $path = $dir . DIRECTORY_SEPARATOR . $item;
+        if (is_dir($path)) {
+            rms_footer_test_rrmdir($path);
+            continue;
+        }
+        unlink($path);
+    }
+
+    rmdir($dir);
+}
+
+function rms_footer_test_reset_fields(array $fields = []): void {
+    $GLOBALS['rms_footer_test_fields'] = $fields;
+    $GLOBALS['rms_footer_test_parts']  = [];
+    if (isset($GLOBALS['rms_footer_test_vite']) && is_object($GLOBALS['rms_footer_test_vite'])) {
+        $GLOBALS['rms_footer_test_vite']->deferred = [];
+    }
+}
+
+function rms_footer_test_count_tags(string $html, string $tag): int {
+    return preg_match_all('/<' . preg_quote($tag, '/') . '\b/i', $html, $matches) ? count($matches[0]) : 0;
+}
+
+if (!function_exists('__')) {
+    function __($text, $domain = 'default') {
+        return $text;
+    }
+}
+
+if (!function_exists('sanitize_key')) {
+    function sanitize_key($key) {
+        $key = strtolower((string) $key);
+        return preg_replace('/[^a-z0-9_\-]/', '', $key);
+    }
+}
+
+if (!function_exists('add_action')) {
+    function add_action($hook, $callback, $priority = 10, $accepted_args = 1) {
+        return true;
+    }
+}
+
+if (!function_exists('add_filter')) {
+    function add_filter($hook, $callback, $priority = 10, $accepted_args = 1) {
+        return true;
+    }
+}
+
+if (!function_exists('get_template_directory')) {
+    function get_template_directory() {
+        return $GLOBALS['rms_footer_test_theme_root'];
+    }
+}
+
+if (!function_exists('get_field')) {
+    function get_field($selector, $post_id = false) {
+        return $GLOBALS['rms_footer_test_fields'][$selector] ?? null;
+    }
+}
+
+if (!function_exists('esc_url')) {
+    function esc_url($url) {
+        $url = trim((string) $url);
+        if ($url === '' || preg_match('#^(javascript|data):#i', $url)) {
+            return '';
+        }
+        return $url;
+    }
+}
+
+if (!function_exists('esc_attr')) {
+    function esc_attr($text) {
+        return htmlspecialchars((string) $text, ENT_QUOTES, 'UTF-8');
+    }
+}
+
+if (!function_exists('esc_html')) {
+    function esc_html($text) {
+        return htmlspecialchars((string) $text, ENT_QUOTES, 'UTF-8');
+    }
+}
+
+if (!function_exists('esc_html_e')) {
+    function esc_html_e($text, $domain = 'default') {
+        echo esc_html($text);
+    }
+}
+
+if (!function_exists('esc_attr__')) {
+    function esc_attr__($text, $domain = 'default') {
+        return esc_attr($text);
+    }
+}
+
+if (!function_exists('home_url')) {
+    function home_url($path = '/') {
+        return 'https://example.test' . $path;
+    }
+}
+
+if (!function_exists('get_bloginfo')) {
+    function get_bloginfo($show = '') {
+        if ($show === 'name') {
+            return (string) ($GLOBALS['rms_footer_test_fields']['blogname'] ?? '');
+        }
+        return $show === 'charset' ? 'UTF-8' : '';
+    }
+}
+
+if (!function_exists('has_custom_logo')) {
+    function has_custom_logo() {
+        return false;
+    }
+}
+
+if (!function_exists('the_custom_logo')) {
+    function the_custom_logo() {}
+}
+
+if (!function_exists('language_attributes')) {
+    function language_attributes() {
+        echo 'en';
+    }
+}
+
+if (!function_exists('bloginfo')) {
+    function bloginfo($show = '') {
+        echo get_bloginfo($show);
+    }
+}
+
+if (!function_exists('is_front_page')) {
+    function is_front_page() {
+        return false;
+    }
+}
+
+if (!function_exists('is_page_template')) {
+    function is_page_template($template = '') {
+        return false;
+    }
+}
+
+if (!function_exists('is_single')) {
+    function is_single() {
+        return false;
+    }
+}
+
+if (!function_exists('wp_enqueue_style')) {
+    function wp_enqueue_style($handle = '', $src = '', $deps = [], $ver = false, $media = 'all') {}
+}
+
+if (!function_exists('wp_enqueue_script')) {
+    function wp_enqueue_script($handle = '', $src = '', $deps = [], $ver = false, $in_footer = false) {}
+}
+
+if (!function_exists('wp_head')) {
+    function wp_head() {}
+}
+
+if (!function_exists('wp_footer')) {
+    function wp_footer() {}
+}
+
+if (!function_exists('body_class')) {
+    function body_class($class = '') {}
+}
+
+if (!function_exists('get_template_part')) {
+    function get_template_part($slug, $name = null) {
+        $GLOBALS['rms_footer_test_parts'][] = $slug;
+        if (strpos((string) $slug, 'templates/footer-') !== 0) {
+            return;
+        }
+        $file = get_template_directory() . '/' . $slug . '.php';
+        if (is_readable($file)) {
+            include $file;
+        }
+    }
+}
+
+if (!class_exists('Vite_Icons_Integration')) {
+    class Vite_Icons_Integration {
+        public $deferred = [];
+
+        public static function get_instance() {
+            if (!isset($GLOBALS['rms_footer_test_vite']) || !($GLOBALS['rms_footer_test_vite'] instanceof self)) {
+                $GLOBALS['rms_footer_test_vite'] = new self();
+            }
+            return $GLOBALS['rms_footer_test_vite'];
+        }
+
+        public function get_critical_css($entry, $id = '') {
+            return '';
+        }
+
+        public function get_asset($entry) {
+            return '';
+        }
+
+        public function get_deferred_style($handle, $entry): void {
+            $this->deferred[] = [
+                'handle' => (string) $handle,
+                'entry'  => (string) $entry,
+            ];
+        }
+    }
+}
+
+$GLOBALS['rms_footer_test_theme_root'] = $theme_root;
+rms_footer_test_reset_fields();
+
+require $theme_root . '/inc/acf-theme-options.php';
+
+$acf_path = $theme_root . '/acf-json/group_rms_theme_settings.json';
+$acf_json = json_decode(rms_footer_read($acf_path), true);
+$footer_field = null;
+$social_choices = [];
+
+if (!is_array($acf_json)) {
+    rms_footer_test_fail('test_acf_footer_choices_map_to_existing_templates', 'Theme settings JSON did not parse.');
+} else {
+    foreach ($acf_json['fields'] ?? [] as $candidate) {
+        if (($candidate['key'] ?? '') === 'field_rms_company_footer_version') {
+            $footer_field = $candidate;
+        }
+        if (($candidate['name'] ?? '') !== 'company_social_media') {
+            continue;
+        }
+        foreach ($candidate['sub_fields'] ?? [] as $sub) {
+            if (($sub['name'] ?? '') === 'social_platform' && is_array($sub['choices'] ?? null)) {
+                $social_choices = $sub['choices'];
+            }
+        }
+    }
+}
+
+if (!is_array($footer_field)) {
+    rms_footer_test_fail('test_acf_footer_choices_map_to_existing_templates', 'field_rms_company_footer_version is missing.');
+} else {
+    $choices  = $footer_field['choices'] ?? [];
+    $expected = ['footer-v1' => 'Footer V1', 'footer-v2' => 'Footer V2'];
+    if ($choices !== $expected) {
+        rms_footer_test_fail(
+            'test_acf_footer_choices_map_to_existing_templates',
+            'ACF choices must be exactly footer-v1 / footer-v2. Got: ' . json_encode($choices)
+        );
+    } elseif (($footer_field['default_value'] ?? null) !== 'footer-v2') {
+        rms_footer_test_fail(
+            'test_acf_footer_choices_map_to_existing_templates',
+            'Default value must be footer-v2.'
+        );
+    } else {
+        $missing = [];
+        foreach (array_keys($expected) as $slug) {
+            $php  = $theme_root . '/templates/' . $slug . '.php';
+            $scss = $theme_root . '/src/scss/layout/' . $slug . '.scss';
+            if (!is_readable($php) || !is_readable($scss)) {
+                $missing[] = $slug;
+            }
+        }
+        if ($missing !== []) {
+            rms_footer_test_fail(
+                'test_acf_footer_choices_map_to_existing_templates',
+                'Missing PHP/SCSS for: ' . implode(', ', $missing)
+            );
+        } else {
+            rms_footer_test_pass('test_acf_footer_choices_map_to_existing_templates');
+        }
+    }
+}
+
+$header_php    = rms_footer_read($theme_root . '/header.php');
+$footer_php    = rms_footer_read($theme_root . '/footer.php');
+$inline_option = '/rms_get_option\s*\(\s*[\'"]company_footer_version[\'"]/';
+$dispatch_failed = [];
+
+if (!preg_match('/rms_get_footer_version\s*\(/', $header_php) || preg_match($inline_option, $header_php)) {
+    $dispatch_failed[] = 'header.php must call only rms_get_footer_version()';
+}
+if (!preg_match('/rms_get_footer_version\s*\(/', $footer_php) || preg_match($inline_option, $footer_php)) {
+    $dispatch_failed[] = 'footer.php must call only rms_get_footer_version()';
+}
+
+$GLOBALS['rms_footer_test_theme_root'] = $theme_root;
+rms_footer_test_reset_fields(['company_footer_version' => 'footer-v1']);
+ob_start();
+include $theme_root . '/header.php';
+include $theme_root . '/footer.php';
+ob_end_clean();
+
+$vite = Vite_Icons_Integration::get_instance();
+$deferred_entries = array_column($vite->deferred, 'entry');
+if (!in_array('src/scss/layout/footer-v1.scss', $deferred_entries, true)) {
+    $dispatch_failed[] = 'header.php did not enqueue footer-v1 through the shared resolver';
+}
+if (!in_array('templates/footer-v1', $GLOBALS['rms_footer_test_parts'], true)) {
+    $dispatch_failed[] = 'footer.php did not dispatch templates/footer-v1 through the shared resolver';
+}
+
+$empty_root = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'rms-footer-empty-' . bin2hex(random_bytes(4));
+if (!mkdir($empty_root) && !is_dir($empty_root)) {
+    $dispatch_failed[] = 'could not create empty theme root for header/footer skip';
+} else {
+    $GLOBALS['rms_footer_test_theme_root'] = $empty_root;
+    rms_footer_test_reset_fields(['company_footer_version' => 'footer-v1']);
+    ob_start();
+    include $theme_root . '/header.php';
+    include $theme_root . '/footer.php';
+    ob_end_clean();
+
+    $footer_deferred = array_filter(
+        Vite_Icons_Integration::get_instance()->deferred,
+        static function (array $item): bool {
+            return strpos($item['entry'], 'src/scss/layout/footer-') === 0;
+        }
+    );
+    $footer_parts = array_filter(
+        $GLOBALS['rms_footer_test_parts'],
+        static function (string $slug): bool {
+            return strpos($slug, 'templates/footer-') === 0;
+        }
+    );
+    if ($footer_deferred !== []) {
+        $dispatch_failed[] = 'header.php enqueued footer CSS when resolver returned empty';
+    }
+    if ($footer_parts !== []) {
+        $dispatch_failed[] = 'footer.php dispatched a template when resolver returned empty';
+    }
+    rms_footer_test_rrmdir($empty_root);
+}
+
+if ($dispatch_failed !== []) {
+    rms_footer_test_fail('test_header_footer_share_normalization', implode('; ', $dispatch_failed));
+} else {
+    rms_footer_test_pass('test_header_footer_share_normalization');
+}
+
+$GLOBALS['rms_footer_test_theme_root'] = $theme_root;
+$resolution_failed = [];
+$production_cases = [
+    'footer-v1'    => 'footer-v1',
+    'footer-v2'    => 'footer-v2',
+    'footer-one'   => 'footer-v1',
+    'footer-two'   => 'footer-v2',
+    ''             => 'footer-v2',
+    'footer-three' => 'footer-v2',
+    'not a slug!!' => 'footer-v2',
+];
+
+foreach ($production_cases as $raw => $expected_slug) {
+    rms_footer_test_reset_fields(['company_footer_version' => $raw]);
+    $actual = rms_get_footer_version();
+    if ($actual !== $expected_slug) {
+        $resolution_failed[] = $raw . " => {$actual} (expected {$expected_slug})";
+    }
+}
+
+rms_footer_test_reset_fields([]);
+if (rms_get_footer_version() !== 'footer-v2') {
+    $resolution_failed[] = 'missing option => ' . rms_get_footer_version();
+}
+
+$v2_only_root = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'rms-footer-v2-only-' . bin2hex(random_bytes(4));
+$v2_php_dir   = $v2_only_root . '/templates';
+$v2_scss_dir  = $v2_only_root . '/src/scss/layout';
+if (!mkdir($v2_php_dir, 0777, true) || !mkdir($v2_scss_dir, 0777, true)) {
+    $resolution_failed[] = 'could not create V2-only theme root';
+} elseif (
+    !copy($theme_root . '/templates/footer-v2.php', $v2_php_dir . '/footer-v2.php')
+    || !copy($theme_root . '/src/scss/layout/footer-v2.scss', $v2_scss_dir . '/footer-v2.scss')
+) {
+    $resolution_failed[] = 'could not copy V2 assets into isolated root';
+} else {
+    $GLOBALS['rms_footer_test_theme_root'] = $v2_only_root;
+    rms_footer_test_reset_fields(['company_footer_version' => 'footer-v1']);
+    $actual = rms_get_footer_version();
+    if ($actual !== 'footer-v2') {
+        $resolution_failed[] = "V1 missing/V2 present => {$actual} (expected footer-v2)";
+    }
+    rms_footer_test_reset_fields(['company_footer_version' => 'footer-one']);
+    $actual = rms_get_footer_version();
+    if ($actual !== 'footer-v2') {
+        $resolution_failed[] = "alias footer-one with missing V1 => {$actual} (expected footer-v2)";
+    }
+}
+
+$closed_root = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'rms-footer-closed-' . bin2hex(random_bytes(4));
+if (!mkdir($closed_root) && !is_dir($closed_root)) {
+    $resolution_failed[] = 'could not create empty theme root for fail-closed check';
+} else {
+    $GLOBALS['rms_footer_test_theme_root'] = $closed_root;
+    rms_footer_test_reset_fields(['company_footer_version' => 'footer-v2']);
+    $closed = rms_get_footer_version();
+    if ($closed !== '') {
+        $resolution_failed[] = "missing fallback should fail closed, got {$closed}";
+    }
+    rms_footer_test_rrmdir($closed_root);
+}
+
+rms_footer_test_rrmdir($v2_only_root);
+$GLOBALS['rms_footer_test_theme_root'] = $theme_root;
+
+if ($resolution_failed !== []) {
+    rms_footer_test_fail(
+        'test_invalid_legacy_value_renders_deterministic_fallback',
+        implode('; ', $resolution_failed)
+    );
+} else {
+    rms_footer_test_pass('test_invalid_legacy_value_renders_deterministic_fallback');
+}
+
+$markup_failed = [];
+$GLOBALS['rms_footer_test_theme_root'] = $theme_root;
+rms_footer_test_reset_fields([]);
+ob_start();
+include $theme_root . '/templates/footer-v1.php';
+$empty_html = (string) ob_get_clean();
+if (rms_footer_test_count_tags($empty_html, 'footer') !== 1) {
+    $markup_failed[] = 'empty ACF render does not contain exactly one <footer>';
+}
+if (stripos($empty_html, '<nav') !== false) {
+    $markup_failed[] = 'empty ACF render emitted a social <nav>';
+}
+
+if ($social_choices === []) {
+    $markup_failed[] = 'ACF social_platform choices were not found';
+}
+
+$required_social_platforms = ['facebook', 'instagram', 'linkedin', 'x', 'twitter', 'youtube', 'tiktok', 'pinterest', 'other'];
+foreach ($required_social_platforms as $platform) {
+    if (!array_key_exists($platform, $social_choices) && !in_array($platform, ['twitter', 'x'], true)) {
+        $markup_failed[] = "ACF social_platform choices are missing {$platform}";
+    }
+}
+
+foreach (['footer-v1' => 'footer-v1__social-link', 'footer-v2' => 'footer-v2__social-link'] as $slug => $link_class) {
+    foreach ($social_choices as $platform => $label) {
+        rms_footer_test_reset_fields([
+            'company_social_media' => [[
+                'social_is_active' => 1,
+                'social_platform'  => $platform,
+                'social_url'       => 'https://example.test/' . $platform,
+                'social_label'     => $label,
+            ]],
+        ]);
+        ob_start();
+        include $theme_root . '/templates/' . $slug . '.php';
+        $html = (string) ob_get_clean();
+
+        if (rms_footer_test_count_tags($html, 'footer') !== 1) {
+            $markup_failed[] = "{$slug} {$platform} render does not contain exactly one <footer>";
+            continue;
+        }
+        if (rms_footer_test_count_tags($html, 'nav') !== 1) {
+            $markup_failed[] = "{$slug} {$platform} render did not emit exactly one social <nav>";
+            continue;
+        }
+        if (preg_match('/<nav\b[^>]*>\s*<\/nav>/i', $html)) {
+            $markup_failed[] = "{$slug} {$platform} render emitted an empty social <nav>";
+            continue;
+        }
+
+        $href = 'https://example.test/' . $platform;
+        if (!preg_match(
+            '/<a\b[^>]*class="' . preg_quote($link_class, '/') . '"[^>]*>/i',
+            $html,
+            $link_match
+        )) {
+            $markup_failed[] = "{$slug} {$platform} render is missing a social link";
+            continue;
+        }
+
+        $link = $link_match[0];
+        if (strpos($link, 'href="' . $href . '"') === false) {
+            $markup_failed[] = "{$slug} {$platform} link href is missing";
+        }
+        if (strpos($link, 'aria-label="' . $label . '"') === false) {
+            $markup_failed[] = "{$slug} {$platform} link is missing an accessible name";
+        }
+        if (strpos($link, 'target="_blank"') === false || !preg_match('/rel="[^"]*noopener[^"]*noreferrer[^"]*"/', $link)) {
+            $markup_failed[] = "{$slug} {$platform} link is missing external-link safety";
+        }
+        if (stripos($html, '<svg') === false) {
+            $markup_failed[] = "{$slug} {$platform} is missing a generic-or-platform icon";
+        }
+    }
+
+    rms_footer_test_reset_fields([
+        'company_social_media' => [[
+            'social_is_active' => 1,
+            'social_platform'  => 'youtube',
+            'social_url'       => '',
+            'social_label'     => 'YouTube',
+        ]],
+    ]);
+    ob_start();
+    include $theme_root . '/templates/' . $slug . '.php';
+    $invalid_social_html = (string) ob_get_clean();
+    if (stripos($invalid_social_html, '<nav') !== false) {
+        $markup_failed[] = "{$slug} invalid/empty social data still emitted a <nav>";
+    }
+}
+
+$v1_scss = rms_footer_read($theme_root . '/src/scss/layout/footer-v1.scss');
+if (!preg_match('/&:focus-visible\s*\{[^}]*outline:\s*2px solid var\(--footer-v1-accent/', $v1_scss)) {
+    $markup_failed[] = 'footer-v1.scss must tokenize focus-visible outline with --footer-v1-accent';
+}
+if (preg_match('/\.footer-v1[^{]*\{[^}]*@include\s+focus-ring/', $v1_scss) || preg_match('/footer-v1__[a-z-]+[^{]*\{[^}]*@include\s+focus-ring/', $v1_scss)) {
+    $markup_failed[] = 'footer-v1.scss still uses the global blue focus-ring mixin';
+}
+if (preg_match('/!important/i', $v1_scss)) {
+    $markup_failed[] = 'footer-v1.scss must not use !important';
+}
+
+foreach (['footer-v1', 'footer-v2'] as $slug) {
+    $template = rms_footer_read($theme_root . '/templates/' . $slug . '.php');
+    if (rms_footer_test_count_tags($template, 'footer') !== 1) {
+        $markup_failed[] = "{$slug} source does not contain exactly one <footer>";
+    }
+}
+
+$manifest_path = $theme_root . '/dist/.vite/manifest.json';
+if (!is_readable($manifest_path)) {
+    $markup_failed[] = 'Vite manifest is missing; run npm run build first';
+} else {
+    $manifest = json_decode(rms_footer_read($manifest_path), true);
+    if (!is_array($manifest)) {
+        $markup_failed[] = 'Vite manifest did not parse';
+    } else {
+        foreach (['footer-v1', 'footer-v2'] as $slug) {
+            $entry = 'src/scss/layout/' . $slug . '.scss';
+            $file  = $manifest[$entry]['file'] ?? '';
+            if (!is_string($file) || $file === '' || !is_readable($theme_root . '/dist/' . $file)) {
+                $markup_failed[] = "manifest is missing a built stylesheet for {$slug}";
+                continue;
+            }
+            if ($slug === 'footer-v1') {
+                $compiled = rms_footer_read($theme_root . '/dist/' . $file);
+                if (preg_match('/\.footer-v1__social-link:focus-visible\s*\{[^}]*outline:\s*2px solid\s*#2563eb/i', $compiled)) {
+                    $markup_failed[] = 'compiled footer-v1 still uses a hardcoded blue focus ring';
+                }
+                if (!preg_match('/\.footer-v1__social-link:focus-visible\s*\{[^}]*outline:\s*2px solid\s*var\(--footer-v1-accent/', $compiled)) {
+                    $markup_failed[] = 'compiled footer-v1 must emit a tokenized focus-visible outline';
+                }
+                if (preg_match('/!important/i', $compiled)) {
+                    $markup_failed[] = 'compiled footer-v1 must not use !important';
+                }
+            }
+        }
+    }
+}
+
+if ($markup_failed !== []) {
+    rms_footer_test_fail(
+        'test_rendered_page_has_exactly_one_footer_and_matching_css',
+        implode('; ', $markup_failed)
+    );
+} else {
+    rms_footer_test_pass('test_rendered_page_has_exactly_one_footer_and_matching_css');
+}
+
+$palette_needles = [
+    'function rms_get_palette_colors',
+    'function rms_enqueue_palette_bridge',
+    'rms-palette.css',
+];
+$palette_hits = [];
+$scan_files = [
+    $theme_root . '/inc/acf-theme-options.php',
+    $theme_root . '/header.php',
+    $theme_root . '/footer.php',
+    $theme_root . '/templates/footer-v1.php',
+    $theme_root . '/src/scss/layout/footer-v1.scss',
+];
+foreach ($scan_files as $path) {
+    $contents = rms_footer_read($path);
+    foreach ($palette_needles as $needle) {
+        if (strpos($contents, $needle) !== false) {
+            $palette_hits[] = basename($path) . ' contains ' . $needle;
+        }
+    }
+}
+if (is_file($theme_root . '/assets/css/rms-palette.css')) {
+    $palette_hits[] = 'assets/css/rms-palette.css exists';
+}
+
+if ($palette_hits !== []) {
+    rms_footer_test_fail('test_no_issue_29_palette_implementation', implode('; ', $palette_hits));
+} else {
+    rms_footer_test_pass('test_no_issue_29_palette_implementation');
+}
+
+if ($failures > 0) {
+    fwrite(STDERR, "\n{$failures} footer variant check(s) failed.\n");
+    exit(1);
+}
+
+fwrite(STDOUT, "\nAll footer variant checks passed.\n");
+exit(0);

--- a/src/scss/layout/footer-v1.scss
+++ b/src/scss/layout/footer-v1.scss
@@ -1,0 +1,148 @@
+// ============================================
+// Footer V1 — compact identity rail
+// ============================================
+@use '../base/variables' as *;
+@use '../base/mixins' as *;
+
+@mixin footer-v1-focus-ring {
+  &:focus-visible {
+    outline: 2px solid var(--footer-v1-accent, var(--rms-color-accent, #{$color-primary}));
+    outline-offset: 2px;
+  }
+}
+
+.footer-v1 {
+  --footer-v1-bg: var(--rms-color-primary, #{$color-gray-900});
+  --footer-v1-ink: var(--rms-color-surface, #{$color-gray-300});
+  --footer-v1-accent: var(--rms-color-accent, #{$color-primary});
+  --footer-v1-rule: var(--rms-color-primary-muted, #{$color-gray-700});
+
+  background-color: var(--footer-v1-bg);
+  color: var(--footer-v1-ink);
+  border-top: 3px solid var(--footer-v1-accent);
+}
+
+.footer-v1__inner {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: $space-4;
+  padding-block: $space-5;
+
+  @include breakpoint($breakpoint-md) {
+    display: grid;
+    grid-template-columns: minmax(0, auto) minmax(0, 1fr) auto;
+    grid-template-areas:
+      "brand contact social"
+      "copy copy copy";
+    align-items: center;
+    column-gap: $space-6;
+    row-gap: $space-3;
+    padding-block: $space-4;
+  }
+}
+
+.footer-v1__brand {
+  grid-area: brand;
+  min-width: 0;
+
+  .custom-logo-link,
+  .footer-v1__logo-link {
+    display: inline-flex;
+    align-items: center;
+    @include footer-v1-focus-ring;
+  }
+
+  img,
+  .custom-logo {
+    display: block;
+    width: auto;
+    max-width: 9rem;
+    height: 2.5rem;
+    object-fit: contain;
+  }
+}
+
+.footer-v1__wordmark {
+  color: var(--footer-v1-ink);
+  font-size: $font-size-sm;
+  font-weight: $font-weight-semibold;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-decoration: none;
+  @include footer-v1-focus-ring;
+
+  &:hover {
+    color: var(--rms-color-surface, #{$color-white});
+  }
+}
+
+.footer-v1__contact {
+  grid-area: contact;
+  display: flex;
+  flex-wrap: wrap;
+  gap: $space-2 $space-4;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: $font-size-sm;
+
+  @include breakpoint($breakpoint-md) {
+    justify-content: center;
+  }
+}
+
+.footer-v1__contact-link,
+.footer-v1__address {
+  color: var(--footer-v1-ink);
+  text-decoration: none;
+}
+
+.footer-v1__contact-link {
+  @include footer-v1-focus-ring;
+
+  &:hover {
+    color: var(--footer-v1-accent);
+  }
+}
+
+.footer-v1__social {
+  grid-area: social;
+  display: flex;
+  flex-wrap: wrap;
+  gap: $space-2;
+}
+
+.footer-v1__social-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: 1px solid var(--footer-v1-rule);
+  border-radius: $radius-sm;
+  color: var(--footer-v1-ink);
+  transition: border-color $transition-fast, color $transition-fast, background-color $transition-fast;
+  @include footer-v1-focus-ring;
+
+  &:hover {
+    border-color: var(--footer-v1-accent);
+    color: var(--rms-color-surface, #{$color-white});
+    background-color: transparent;
+  }
+}
+
+.footer-v1__copyright {
+  grid-area: copy;
+  margin: 0;
+  padding-top: $space-3;
+  border-top: 1px solid var(--footer-v1-rule);
+  color: var(--footer-v1-ink);
+  font-size: $font-size-xs;
+  letter-spacing: 0.02em;
+  width: 100%;
+}
+
+.footer-v1__sr-only {
+  @include sr-only;
+}

--- a/templates/footer-v1.php
+++ b/templates/footer-v1.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Footer V1 — compact identity rail.
+ *
+ * Renders logo/name, concise contact details, social links, and copyright.
+ * Omits invented marketing copy, menus, and service lists.
+ */
+
+$identity_name = rms_get_option('company_name') ?: get_bloginfo('name');
+$identity_name = is_string($identity_name) ? trim($identity_name) : '';
+$footer_logo   = rms_get_option('company_logo_footer');
+$phone         = rms_get_primary_phone();
+$email         = rms_get_primary_email();
+$socials       = rms_get_social_links();
+$year          = (int) gmdate('Y');
+
+$addr_line1 = rms_get_option('company_address_line_1');
+$addr_city  = rms_get_option('company_city');
+$addr_state = rms_get_option('company_state');
+$address    = implode(', ', array_filter([
+    is_string($addr_line1) ? $addr_line1 : '',
+    is_string($addr_city) ? $addr_city : '',
+    is_string($addr_state) ? $addr_state : '',
+]));
+
+$phone_clean = is_string($phone) ? preg_replace('/[^0-9+]/', '', $phone) : '';
+$has_contact = ($phone !== '' && $phone_clean !== '') || $email !== '' || $address !== '';
+
+$social_icons = [
+    'facebook'  => '<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z"/></svg>',
+    'instagram' => '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"/><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"/><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"/></svg>',
+    'linkedin'  => '<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"/><rect x="2" y="9" width="4" height="12"/><circle cx="4" cy="4" r="2"/></svg>',
+    'x'         => '<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>',
+    'twitter'   => '<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>',
+    'youtube'   => '<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.1C19.5 3.6 12 3.6 12 3.6s-7.5 0-9.4.5A3 3 0 0 0 .5 6.2 31.5 31.5 0 0 0 0 12a31.5 31.5 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 0 0 2.1-2.1A31.5 31.5 0 0 0 24 12a31.5 31.5 0 0 0-.5-5.8zM9.75 15.57V8.43L15.84 12z"/></svg>',
+    'tiktok'    => '<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M14.5 3h2.1c.2 1.8 1.2 3.4 2.8 4.4 1 .6 2.1.9 3.2 1v2.3c-1.5 0-3-.4-4.3-1.2v6.7A6.8 6.8 0 1 1 10 9.5v2.4a4.4 4.4 0 1 0 4.5 4.4V3z"/></svg>',
+    'pinterest' => '<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M12 2C6.5 2 2 6.5 2 12c0 4.2 2.6 7.8 6.3 9.2-.1-.8-.2-2 0-2.8l2.1-8.8s-.5-1.1-.5-2.6c0-2.5 1.4-4.3 3.2-4.3 1.5 0 2.3 1.1 2.3 2.5 0 1.5-1 3.8-1.5 5.9-.4 1.8.9 3.2 2.6 3.2 3.2 0 5.3-4.1 5.3-8.9 0-3.7-2.5-6.4-7-6.4A7.3 7.3 0 0 0 5.7 11c.5 1.1 1.4 2.9 1.4 2.9s-.5 2.1-.6 2.6A10 10 0 1 0 12 2z"/></svg>',
+    'other'     => '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 4h6v6"/><path d="M10 14 20 4"/><path d="M20 14v5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h5"/></svg>',
+];
+
+$social_items = [];
+if (is_array($socials)) {
+    foreach ($socials as $platform => $social) {
+        $url = is_array($social) ? ($social['url'] ?? '') : '';
+        $url = is_string($url) ? trim($url) : '';
+        if ($url === '' || esc_url($url) === '') {
+            continue;
+        }
+
+        $label = is_array($social) && !empty($social['label'])
+            ? (string) $social['label']
+            : (string) $platform;
+
+        $social_items[] = [
+            'url'   => $url,
+            'label' => $label,
+            'icon'  => $social_icons[$platform] ?? $social_icons['other'],
+        ];
+    }
+}
+?>
+<footer class="footer-v1" role="contentinfo">
+    <div class="container footer-v1__inner">
+        <div class="footer-v1__brand">
+            <?php if (has_custom_logo()) : ?>
+                <?php the_custom_logo(); ?>
+            <?php elseif (!empty($footer_logo)) : ?>
+                <a class="footer-v1__logo-link" href="<?php echo esc_url(home_url('/')); ?>">
+                    <img
+                        class="footer-v1__logo"
+                        src="<?php echo esc_url($footer_logo); ?>"
+                        alt="<?php echo esc_attr($identity_name !== '' ? $identity_name : __('Home', 'simple-rms-theme')); ?>"
+                        width="140"
+                        height="42"
+                    >
+                </a>
+            <?php elseif ($identity_name !== '') : ?>
+                <a class="footer-v1__wordmark" href="<?php echo esc_url(home_url('/')); ?>">
+                    <?php echo esc_html($identity_name); ?>
+                </a>
+            <?php endif; ?>
+        </div>
+
+        <?php if ($has_contact) : ?>
+            <ul class="footer-v1__contact">
+                <?php if ($phone !== '' && $phone_clean !== '') : ?>
+                    <li>
+                        <a class="footer-v1__contact-link" href="<?php echo esc_url('tel:' . $phone_clean); ?>">
+                            <span class="footer-v1__sr-only"><?php esc_html_e('Phone', 'simple-rms-theme'); ?></span>
+                            <?php echo esc_html($phone); ?>
+                        </a>
+                    </li>
+                <?php endif; ?>
+                <?php if ($email !== '') : ?>
+                    <li>
+                        <a class="footer-v1__contact-link" href="<?php echo esc_url('mailto:' . $email); ?>">
+                            <span class="footer-v1__sr-only"><?php esc_html_e('Email', 'simple-rms-theme'); ?></span>
+                            <?php echo esc_html($email); ?>
+                        </a>
+                    </li>
+                <?php endif; ?>
+                <?php if ($address !== '') : ?>
+                    <li>
+                        <span class="footer-v1__address">
+                            <span class="footer-v1__sr-only"><?php esc_html_e('Address', 'simple-rms-theme'); ?></span>
+                            <?php echo esc_html($address); ?>
+                        </span>
+                    </li>
+                <?php endif; ?>
+            </ul>
+        <?php endif; ?>
+
+        <?php if ($social_items !== []) : ?>
+            <nav class="footer-v1__social" aria-label="<?php echo esc_attr__('Social media', 'simple-rms-theme'); ?>">
+                <?php foreach ($social_items as $social_item) : ?>
+                    <a
+                        class="footer-v1__social-link"
+                        href="<?php echo esc_url($social_item['url']); ?>"
+                        aria-label="<?php echo esc_attr($social_item['label']); ?>"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    ><?php echo $social_item['icon']; ?></a>
+                <?php endforeach; ?>
+            </nav>
+        <?php endif; ?>
+
+        <p class="footer-v1__copyright">
+            <?php if ($identity_name !== '') : ?>
+                <?php echo esc_html('© ' . $year . ' ' . $identity_name . '. All rights reserved.'); ?>
+            <?php else : ?>
+                <?php echo esc_html('© ' . $year . '. All rights reserved.'); ?>
+            <?php endif; ?>
+        </p>
+    </div>
+</footer>

--- a/templates/footer-v2.php
+++ b/templates/footer-v2.php
@@ -34,35 +34,50 @@
                 </p>
                 <?php
                 $socials = rms_get_social_links();
-                if (!empty($socials)) :
-                ?>
-                <div class="footer-v2__social" aria-label="Social media links">
-                    <?php foreach ($socials as $platform => $social) : ?>
-                        <?php
-                        $svg = '';
-                        switch ($platform) {
-                            case 'facebook':
-                                $svg = '<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z"/></svg>';
-                                break;
-                            case 'twitter':
-                            case 'x':
-                                $svg = '<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>';
-                                break;
-                            case 'instagram':
-                                $svg = '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"/><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"/><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"/></svg>';
-                                break;
-                            case 'linkedin':
-                                $svg = '<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"/><rect x="2" y="9" width="4" height="12"/><circle cx="4" cy="4" r="2"/></svg>';
-                                break;
-                            default:
-                                $svg = '';
+                $social_icons = [
+                    'facebook'  => '<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z"/></svg>',
+                    'instagram' => '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"/><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"/><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"/></svg>',
+                    'linkedin'  => '<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"/><rect x="2" y="9" width="4" height="12"/><circle cx="4" cy="4" r="2"/></svg>',
+                    'x'         => '<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>',
+                    'twitter'   => '<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>',
+                    'youtube'   => '<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.1C19.5 3.6 12 3.6 12 3.6s-7.5 0-9.4.5A3 3 0 0 0 .5 6.2 31.5 31.5 0 0 0 0 12a31.5 31.5 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 0 0 2.1-2.1A31.5 31.5 0 0 0 24 12a31.5 31.5 0 0 0-.5-5.8zM9.75 15.57V8.43L15.84 12z"/></svg>',
+                    'tiktok'    => '<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M14.5 3h2.1c.2 1.8 1.2 3.4 2.8 4.4 1 .6 2.1.9 3.2 1v2.3c-1.5 0-3-.4-4.3-1.2v6.7A6.8 6.8 0 1 1 10 9.5v2.4a4.4 4.4 0 1 0 4.5 4.4V3z"/></svg>',
+                    'pinterest' => '<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M12 2C6.5 2 2 6.5 2 12c0 4.2 2.6 7.8 6.3 9.2-.1-.8-.2-2 0-2.8l2.1-8.8s-.5-1.1-.5-2.6c0-2.5 1.4-4.3 3.2-4.3 1.5 0 2.3 1.1 2.3 2.5 0 1.5-1 3.8-1.5 5.9-.4 1.8.9 3.2 2.6 3.2 3.2 0 5.3-4.1 5.3-8.9 0-3.7-2.5-6.4-7-6.4A7.3 7.3 0 0 0 5.7 11c.5 1.1 1.4 2.9 1.4 2.9s-.5 2.1-.6 2.6A10 10 0 1 0 12 2z"/></svg>',
+                    'other'     => '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 4h6v6"/><path d="M10 14 20 4"/><path d="M20 14v5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h5"/></svg>',
+                ];
+                $social_items = [];
+                if (is_array($socials)) {
+                    foreach ($socials as $platform => $social) {
+                        $url = is_array($social) ? ($social['url'] ?? '') : '';
+                        $url = is_string($url) ? trim($url) : '';
+                        if ($url === '' || esc_url($url) === '') {
+                            continue;
                         }
-                        if (!empty($svg)) :
-                        ?>
-                        <a href="<?php echo esc_url($social['url']); ?>" class="footer-v2__social-link" aria-label="<?php echo esc_attr($social['label']); ?>" target="_blank" rel="noopener noreferrer"><?php echo $svg; ?></a>
-                        <?php endif; ?>
+
+                        $label = is_array($social) && !empty($social['label'])
+                            ? (string) $social['label']
+                            : (string) $platform;
+
+                        $social_items[] = [
+                            'url'   => $url,
+                            'label' => $label,
+                            'icon'  => $social_icons[$platform] ?? $social_icons['other'],
+                        ];
+                    }
+                }
+                if ($social_items !== []) :
+                ?>
+                <nav class="footer-v2__social" aria-label="<?php echo esc_attr__('Social media', 'simple-rms-theme'); ?>">
+                    <?php foreach ($social_items as $social_item) : ?>
+                        <a
+                            href="<?php echo esc_url($social_item['url']); ?>"
+                            class="footer-v2__social-link"
+                            aria-label="<?php echo esc_attr($social_item['label']); ?>"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        ><?php echo $social_item['icon']; ?></a>
                     <?php endforeach; ?>
-                </div>
+                </nav>
                 <?php endif; ?>
             </div>
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -81,6 +81,7 @@ export default defineConfig({
         // Internal page breadcrumbs
         'breadcrumb': path.resolve(__dirname, 'src/scss/templates/breadcrumb.scss'),
         // Footer
+        'footer-v1': path.resolve(__dirname, 'src/scss/layout/footer-v1.scss'),
         'footer-v2': path.resolve(__dirname, 'src/scss/layout/footer-v2.scss'),
         // Layout CSS
         'header-one': path.resolve(__dirname, 'src/scss/layout/header-one.scss'),


### PR DESCRIPTION
Fixes #28

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Offered ACF footer choices now map to shipped templates: `footer-v1` and `footer-v2`.
- Header and footer share one resolver with legacy aliases (`footer-one` → V1, `footer-two` → V2) and a deterministic `footer-v2` fallback.
- Ports the golden Footer V2 social refactor while preserving the #23 `rms_get_option()` reads.

## Changes

| File | Change |
|------|--------|
| `inc/acf-theme-options.php` | Add footer aliases, existence check, resolver, and ACF load-value migration. No palette code. |
| `footer.php` / `header.php` | Dispatch only through `rms_get_footer_version()`. |
| `acf-json/group_rms_theme_settings.json` | Offer `footer-v1` / `footer-v2` with `footer-v2` default. |
| `vite.config.ts` | Register the `footer-v1` stylesheet entry. |
| `templates/footer-v1.php` | New compact Footer V1 template. |
| `src/scss/layout/footer-v1.scss` | New Footer V1 styles (tokenized focus, no `!important`). |
| `templates/footer-v2.php` | Golden social refactor + preserved #23 option-safety. |
| `scripts/test-footer-variants.php` | Golden #28 harness; last assertion inverted to prove this slice does not implement #29. |

## Test Plan
- [x] `php -l` passed on authored PHP files.
- [x] `npm run build` passed (`tsc` + Vite; `footer-v1` emitted).
- [x] `php scripts/test-footer-variants.php` — 5/5 PASS.
- [x] Diff against `fix/acf-inactive-frontend-guard` contains only the #28 slice (9 files, `+1078 / -37`).
- [x] `inc/acf-theme-options.php` has no palette functions.
- [x] Scripts run without errors: N/A — no shell scripts in this PR.

## size:exception

Review budget is **1115 / 400**. The new Footer V1 template + SCSS (283 lines) and the 640-line harness must travel with the resolver so every offered choice actually renders. Production behavior without the harness is still above 400 because shipping the missing variant is the product fix, not a separable follow-up.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts: N/A — no shell scripts
- [x] Skills tested in at least one agent: N/A — runtime footer fix, not a skill change
- [x] Docs updated if behavior changed: N/A — ACF field labels updated in JSON
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Chain Context

| Field | Value |
|-------|-------|
| Chain | wizard-setup beta issues #22–#29 |
| Tracker PR | Not needed — retained `feature/wizard-setup` @ `3205ee5` |
| Position | 3 of 11 |
| Base | `fix/acf-inactive-frontend-guard` |
| Depends on | PR #31 / #23 |
| Follow-up | `fix/palette-runtime-css` (#29) |
| Review budget | 1115 / 400 (`size:exception` — new variant + harness) |
| Starts at | `fix/acf-inactive-frontend-guard` |
| Ends with | Both offered footer variants render; invalid values fall back to `footer-v2` |

### Chain Overview

```text
feature/wizard-setup
 └── #30 docs/vite-manifest-checklist  (#24)
      └── #31 fix/acf-inactive-frontend-guard  (#23)
           └── 📍 fix/footer-variant-runtime  (#28)
                └── fix/palette-runtime-css  (#29)
```

### Scope
- Includes: footer resolver/aliases, ACF choices, Vite entry, Footer V1, golden Footer V2 social refactor, #28 harness.
- Excludes: #29 palette bridge, later wizard slices.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit
