### PR TITLE
fix(palette): apply stored company colors on the frontend

### DIFF
--- a/assets/css/rms-palette.css
+++ b/assets/css/rms-palette.css
@@ -1,0 +1,513 @@
+/**
+ * Simple RMS Theme — Runtime Palette Bridge
+ *
+ * Bridges the four ACF company_palette_color_* options (emitted as CSS custom
+ * properties by inc/acf-theme-options.php via wp_add_inline_style) to the
+ * semantic surfaces of the active JBA homepage (header-two + footer-v2 +
+ * hero slider + about-us + services-v2 + portfolio-v2 + testimonials-v3 +
+ * badges + area-coverage-v1 + seo-content).
+ *
+ * Design token mapping:
+ *   --rms-color-primary        -> body primary text + intentional dark surface backgrounds
+ *   --rms-color-accent          -> primary CTAs, buttons, links, accent borders/focus rings
+ *   --rms-color-accent-2        -> review stars, secondary highlights (slider subheadline)
+ *   --rms-color-surface         -> white/light surfaces and on-dark foreground text
+ *   --rms-color-primary-strong  -> derived mid-dark shade (replaces #1e293b-like surfaces)
+ *   --rms-color-primary-muted   -> derived lighter neutral (replaces #334155-like body/borders)
+ *   --rms-color-accent-strong   -> derived accent/primary mix (CTA-v1 mid-stop)
+ *
+ * Derived tokens are computed from primary + surface (or accent + primary)
+ * via color-mix so they track the brand automatically. Fallback hex values
+ * matching the compiled defaults are emitted first so browsers without
+ * color-mix support still render correctly.
+ *
+ * Scope rules:
+ *   - No !important. Source order wins because this stylesheet loads after the
+ *     theme's compiled CSS (enqueued with a dependency on the header handle).
+ *   - Selectors are intentionally narrow: they target specific component classes
+ *     present on the active homepage so links/buttons elsewhere stay readable.
+ *   - Layout, typography, shadows, and transitions are NOT touched here — only
+ *     the color/background-color/border-color declarations that map to the palette.
+ *   - When all four ACF fields are empty/invalid the inline variables fall back to
+ *     the compiled defaults (#0f172a / #2563eb / #f59e0b / #ffffff), so the
+ *     existing hardcoded design is preserved.
+ */
+
+/* ─── Derived neutral shades from primary + surface ──────────────────── */
+/* Fallbacks match the compiled defaults (primary=#0f172a, surface=#fff):
+   strong ~ #1e293b, muted ~ #334155. color-mix overrides when supported. */
+:root {
+    --rms-color-primary-strong: #1e293b;
+    --rms-color-primary-muted:  #334155;
+    --rms-color-accent-strong:  #1d4ed8;
+}
+
+@supports (color: color-mix(in srgb, #000, #fff)) {
+    :root {
+        --rms-color-primary-strong: color-mix(in srgb, var(--rms-color-primary), var(--rms-color-surface) 15%);
+        --rms-color-primary-muted:  color-mix(in srgb, var(--rms-color-primary), var(--rms-color-surface) 30%);
+        --rms-color-accent-strong:  color-mix(in srgb, var(--rms-color-accent) 70%, var(--rms-color-primary) 30%);
+    }
+}
+
+/* ─── Primary text ──────────────────────────────────────────────────── */
+body {
+    color: var(--rms-color-primary);
+}
+
+/* ─── Intentional dark surfaces (primary background) ─────────────────── */
+.footer-v2,
+.badges,
+.cta-v2,
+.area-coverage-v1,
+.testimonials-v2 {
+    background-color: var(--rms-color-primary);
+}
+
+/* Header-two top-bar — was #0f172a. */
+.rms-header-v2__top-bar {
+    background-color: var(--rms-color-primary);
+}
+
+/* Slider bottom shape SVG path — was inline fill #0f172a. The path fill is
+   a presentation attribute on the <path> element inside .slider__shape.
+   CSS fill on the path overrides the presentation attribute. */
+.slider__shape path {
+    fill: var(--rms-color-primary);
+}
+
+/* Slider / hero dark overlays — compiled rgba(15,23,42,.75). */
+.slider__overlay--dark,
+.hero__overlay--dark {
+    background-color: rgba(15, 23, 42, 0.75);
+    background-color: color-mix(in srgb, var(--rms-color-primary) 75%, transparent);
+}
+
+/* Slider / hero primary overlays — compiled rgba(37,99,235,.80). */
+.slider__overlay--primary,
+.hero__overlay--primary {
+    background-color: rgba(37, 99, 235, 0.80);
+    background-color: color-mix(in srgb, var(--rms-color-accent) 80%, transparent);
+}
+
+/* Portfolio hover overlays — compiled rgba(15,23,42,.80). */
+.portfolio-v1__overlay,
+.portfolio-v2__overlay,
+.portfolio-v3__overlay {
+    background-color: rgba(15, 23, 42, 0.80);
+    background-color: color-mix(in srgb, var(--rms-color-primary) 80%, transparent);
+}
+
+/* Header-two mobile menu overlay — compiled rgba(15,23,42,.5). */
+.rms-header-v2__overlay {
+    background-color: rgba(15, 23, 42, 0.5);
+    background-color: color-mix(in srgb, var(--rms-color-primary) 50%, transparent);
+}
+
+/* CTA-v1 brand gradient — previously used independent blue/slate literals. */
+.cta-v1 {
+    background-image: linear-gradient(
+        135deg,
+        var(--rms-color-accent) 0%,
+        var(--rms-color-accent-strong) 60%,
+        var(--rms-color-primary) 100%
+    );
+}
+
+/* ─── Accent: primary CTAs, buttons, links, focus ────────────────────── */
+
+/* Header-two top-bar CTA — was amber on dark; now uses the accent token so
+   the approved red reads as the primary call-to-action. */
+.rms-header-v2__top-bar-right .rms-header-v2__cta-btn {
+    color: var(--rms-color-surface);
+    background-color: var(--rms-color-accent);
+}
+
+.rms-header-v2__top-bar-right .rms-header-v2__cta-btn:hover,
+.rms-header-v2__top-bar-right .rms-header-v2__cta-btn:focus-visible {
+    color: var(--rms-color-surface);
+    background-color: var(--rms-color-accent-strong);
+}
+
+/* Footer-v2 CTA strip button — was blue / #1d4ed8 hover. */
+.footer-v2__cta-button {
+    color: var(--rms-color-surface);
+    background-color: var(--rms-color-accent);
+}
+
+.footer-v2__cta-button:hover,
+.footer-v2__cta-button:focus-visible {
+    color: var(--rms-color-surface);
+    background-color: var(--rms-color-accent-strong);
+}
+
+/* Shared .btn primary variant — compiled hover is #1d4ed8. */
+.btn {
+    color: var(--rms-color-surface);
+    background-color: var(--rms-color-accent);
+    border-color: var(--rms-color-accent);
+}
+
+.btn:hover,
+.btn:focus-visible {
+    color: var(--rms-color-surface);
+    background-color: var(--rms-color-accent-strong);
+    border-color: var(--rms-color-accent-strong);
+}
+
+/* Outline button: accent text/border, surface-on-accent hover. */
+.btn--outline {
+    color: var(--rms-color-accent);
+    background-color: transparent;
+    border-color: var(--rms-color-accent);
+}
+
+.btn--outline:hover,
+.btn--outline:focus-visible {
+    color: var(--rms-color-surface);
+    background-color: var(--rms-color-accent);
+    border-color: var(--rms-color-accent);
+}
+
+/* White-outline button on CTA-v1 gradients. Must follow .btn so the generic
+   solid-accent rule cannot clobber transparent/white semantics. */
+.btn.btn--outline-white {
+    color: var(--rms-color-surface);
+    background-color: transparent;
+    border-color: var(--rms-color-surface);
+}
+
+.btn.btn--outline-white:hover,
+.btn.btn--outline-white:focus-visible {
+    color: var(--rms-color-primary);
+    background-color: var(--rms-color-surface);
+    border-color: var(--rms-color-surface);
+}
+
+/* Focus ring on buttons and social links — was #2563eb. */
+.btn:focus-visible,
+.hero__form-submit:focus-visible,
+.footer-v2__cta-button:focus-visible,
+.rms-header-v2__top-bar-right .rms-header-v2__cta-btn:focus-visible,
+.footer-v2__logo-placeholder:focus-visible,
+.footer-v2__social-link:focus-visible,
+.footer-v2__list a:focus-visible {
+    outline-color: var(--rms-color-accent);
+}
+
+/* Hero form submit (primary CTA inside hero card). */
+.hero__form-submit {
+    color: var(--rms-color-surface);
+    background-color: var(--rms-color-accent);
+}
+
+.hero__form-submit:hover,
+.hero__form-submit:focus-visible {
+    color: var(--rms-color-surface);
+    background-color: var(--rms-color-accent-strong);
+}
+
+.hero__form-group input:focus,
+.hero__form-group select:focus,
+.hero__form-group textarea:focus {
+    border-color: var(--rms-color-accent);
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--rms-color-accent) 15%, transparent);
+}
+
+/* Area-coverage radius pill accent border (on dark surface). */
+.area-coverage-v1__radius {
+    border-color: var(--rms-color-accent);
+}
+
+/* Map rings accent stroke + glow. Compiled drop-shadow uses rgba(37,99,235,.35). */
+.area-coverage-v1__map-ring {
+    stroke: var(--rms-color-accent);
+    filter: drop-shadow(0 0 8px rgba(37, 99, 235, 0.35));
+    filter: drop-shadow(0 0 8px color-mix(in srgb, var(--rms-color-accent) 35%, transparent));
+}
+
+/* ─── Accent-2: review stars + secondary highlights ─────────────────── */
+.testimonials-v1__stars,
+.testimonials-v2__stars,
+.testimonials-v3__stars,
+.hero__reviews-stars {
+    color: var(--rms-color-accent-2);
+}
+
+/* Slider subheadline (eyebrow on dark hero) — was amber, now accent-2. */
+.slider__subheadline {
+    color: var(--rms-color-accent-2);
+}
+
+/* ─── Surface: white/light surfaces + on-dark foreground ────────────── */
+
+/* Footer-v2 CTA headline and heading text on dark surface — keep #fff
+   semantics via the surface token. */
+.footer-v2__cta-text,
+.footer-v2__heading,
+.footer-v2__logo-placeholder {
+    color: var(--rms-color-surface);
+}
+
+/* Header main bar background (light surface) — was #fff. */
+.rms-header-v2__main-bar {
+    background-color: var(--rms-color-surface);
+}
+
+/* ─── Derived strong shade (#1e293b-like surfaces, nav, quote) ──────── */
+
+/* Footer-v2 CTA strip — was #1e293b background, #334155 bottom border. */
+.footer-v2__cta-strip {
+    background-color: var(--rms-color-primary-strong);
+    border-bottom-color: var(--rms-color-primary-muted);
+}
+
+/* Badges icon background — was #1e293b on the dark badges section. */
+.badges__icon {
+    background-color: var(--rms-color-primary-strong);
+}
+
+/* Area-coverage eyebrow pill, radius pill, city pills, map card — were
+   #1e293b backgrounds with #334155 borders. */
+.area-coverage-v1__eyebrow {
+    background-color: var(--rms-color-primary-strong);
+    border-color: var(--rms-color-primary-muted);
+}
+
+.area-coverage-v1__radius {
+    background-color: var(--rms-color-primary-strong);
+}
+
+.area-coverage-v1__city {
+    background-color: var(--rms-color-primary-strong);
+    border-color: var(--rms-color-primary-muted);
+}
+
+.area-coverage-v1__map-card {
+    background-color: var(--rms-color-primary-strong);
+}
+
+.area-coverage-v1__map-card::before,
+.area-coverage-v1__map-card::after {
+    border-color: var(--rms-color-primary-muted);
+}
+
+/* Header-two desktop and mobile nav link text — was #1e293b. */
+.rms-header-v2__main-bar .rms-header-v2__nav-link,
+.rms-header-v2__mobile-nav-link {
+    color: var(--rms-color-primary-strong);
+}
+
+/* Header-two mobile menu icon bars — compiled selector includes menu-toggle. */
+.rms-header-v2__main-bar .rms-header-v2__menu-toggle .rms-header-v2__menu-icon span {
+    background-color: var(--rms-color-primary-strong);
+}
+
+/* Testimonials-v3 quote text — was #1e293b. */
+.testimonials-v3__quote {
+    color: var(--rms-color-primary-strong);
+}
+
+/* ─── Derived muted shade (#334155-like body copy, borders) ─────────── */
+
+/* SEO-content body text — was #334155. */
+.seo-content__text p {
+    color: var(--rms-color-primary-muted);
+}
+
+/* Footer-v2 copyright border — was #334155. */
+.footer-v2__copyright {
+    border-top-color: var(--rms-color-primary-muted);
+}
+
+/* Footer-v2 social link border — was #334155. Hover compiled to #2563eb. */
+.footer-v2__social-link {
+    border-color: var(--rms-color-primary-muted);
+}
+
+.footer-v2__social-link:hover,
+.footer-v2__social-link:focus-visible {
+    border-color: var(--rms-color-accent);
+    color: var(--rms-color-surface);
+}
+
+/* ─── Primary headings (direct dark, was #0f172a) ───────────────────── */
+/* Targeted semantic headline selectors only — not a blanket heading rule. */
+
+.about-us__headline,
+.services-v2__headline,
+.services-v2__box-title,
+.portfolio-v2__headline,
+.testimonials-v3__headline,
+.testimonials-v3__author,
+.seo-content__headline {
+    color: var(--rms-color-primary);
+}
+
+/* ─── Accent: blue brand details (was #2563eb) ─────────────────────── */
+
+/* About-us subheadline — was #2563eb. */
+.about-us__subheadline {
+    color: var(--rms-color-accent);
+}
+
+/* About-us badge (years experience box) — was #2563eb background. */
+.about-us__badge {
+    background-color: var(--rms-color-accent);
+}
+
+/* Testimonials-v3 decorative quote mark — was #2563eb. */
+.testimonials-v3__quote-mark {
+    color: var(--rms-color-accent);
+}
+
+/* Nav link hover/focus — was #2563eb. */
+.rms-header-v2__main-bar .rms-header-v2__nav-link:hover,
+.rms-header-v2__main-bar .rms-header-v2__nav-link:focus,
+.rms-header-v2__main-bar .rms-header-v2__nav-link:focus-visible,
+.rms-header-v2__mobile-nav-link:hover,
+.rms-header-v2__mobile-nav-link:focus,
+.rms-header-v2__mobile-nav-link:focus-visible {
+    color: var(--rms-color-accent);
+}
+
+/* Mobile submenu links are more specific in compiled CSS. */
+.rms-header-v2__mobile-submenu .rms-header-v2__mobile-nav-link:hover,
+.rms-header-v2__mobile-submenu .rms-header-v2__mobile-nav-link:focus-visible {
+    color: var(--rms-color-accent);
+}
+
+/* Desktop dropdown links — compiled uses `> li > a:hover` with #2563eb. */
+.rms-header-v2__dropdown > li > a {
+    color: var(--rms-color-primary-muted);
+}
+
+.rms-header-v2__dropdown > li > a:hover,
+.rms-header-v2__dropdown > li > a:focus-visible,
+.rms-header-v2__dropdown--submenu > li > a:hover,
+.rms-header-v2__dropdown--submenu > li > a:focus-visible {
+    color: var(--rms-color-accent);
+}
+
+/* Nav link focus-visible outline — was #2563eb. */
+.rms-header-v2__main-bar .rms-header-v2__nav-link:focus-visible,
+.rms-header-v2__mobile-nav-link:focus-visible {
+    outline-color: var(--rms-color-accent);
+}
+
+/* Area-coverage city hover border — was #2563eb. */
+.area-coverage-v1__city:hover {
+    border-color: var(--rms-color-accent);
+}
+
+/* ─── On-dark text readability (surface token) ──────────────────────── */
+/* Ensure text on the derived strong surfaces stays readable. */
+
+/* Area-coverage eyebrow text on strong pill — keep light. */
+.area-coverage-v1__eyebrow {
+    color: var(--rms-color-surface);
+}
+
+/* Badges icon text — was #fff, keep readable on strong background. */
+.badges__icon {
+    color: var(--rms-color-surface);
+}
+
+/* Area-coverage city text — keep light on strong pill. */
+.area-coverage-v1__city {
+    color: var(--rms-color-surface);
+}
+
+/* Area-coverage city hover text — keep light. */
+.area-coverage-v1__city:hover {
+    color: var(--rms-color-surface);
+}
+
+/* ─── Header One — selectable global chrome ─────────────────────────── */
+/* Compiled Header One still uses $color-primary literals. Bridge rest,
+   hover, and focus on the shipped nav bar, CTA, social, dropdown, and
+   mobile surfaces. Same specificity as compiled CSS; later source order. */
+
+.rms-header__nav-bar {
+    background-color: var(--rms-color-accent);
+}
+
+.rms-header__cta-btn {
+    color: var(--rms-color-surface);
+    background-color: var(--rms-color-accent);
+}
+
+.rms-header__cta-btn:hover,
+.rms-header__cta-btn:focus-visible {
+    color: var(--rms-color-surface);
+    background-color: var(--rms-color-accent-strong);
+    outline-color: var(--rms-color-accent);
+}
+
+.rms-header__social-list a:hover,
+.rms-header__social-list a:focus-visible {
+    color: var(--rms-color-accent);
+}
+
+.rms-header__dropdown > li > a:hover,
+.rms-header__dropdown > li > a:focus-visible,
+.rms-header__dropdown--submenu > li > a:hover,
+.rms-header__dropdown--submenu > li > a:focus-visible {
+    color: var(--rms-color-accent);
+}
+
+.rms-header__mobile-nav-list > li > a:hover,
+.rms-header__mobile-nav-list > li > a:focus-visible,
+.rms-header__mobile-submenu li a:hover,
+.rms-header__mobile-submenu li a:focus-visible {
+    color: var(--rms-color-accent);
+}
+
+.rms-header__cta-btn:focus-visible,
+.rms-header__nav-link:focus-visible,
+.rms-header__menu-toggle:focus-visible,
+.rms-header__menu-close:focus-visible,
+.rms-header__social-list a:focus-visible,
+.rms-header__dropdown > li > a:focus-visible,
+.rms-header__mobile-nav-list > li > a:focus-visible {
+    outline-color: var(--rms-color-accent);
+}
+
+/* ─── Header Three — selectable overlay chrome ──────────────────────── */
+/* Keep the dark overlay design. Tokenize brand accent on active underline,
+   social/phone hover, and focus rings that still compile to $color-primary. */
+
+.rms-header-v3__nav-link::after {
+    background-color: var(--rms-color-accent);
+}
+
+.rms-header-v3__social-link:hover,
+.rms-header-v3__social-link:focus-visible {
+    color: var(--rms-color-accent);
+}
+
+.rms-header-v3__mobile-phone:hover,
+.rms-header-v3__mobile-phone:focus-visible {
+    color: var(--rms-color-accent);
+}
+
+.rms-header-v3__phone:focus-visible,
+.rms-header-v3__social-link:focus-visible,
+.rms-header-v3__nav-link:focus-visible,
+.rms-header-v3__menu-toggle:focus-visible,
+.rms-header-v3__mobile-close:focus-visible,
+.rms-header-v3__mobile-nav-link:focus-visible,
+.rms-header-v3__mobile-phone:focus-visible {
+    outline-color: var(--rms-color-accent);
+}
+
+/* Footer V1 focus rings are tokenized in authored SCSS. Bridge the same
+   outline token so a stale compiled sheet still tracks the palette. */
+.footer-v1__logo-link:focus-visible,
+.footer-v1 .custom-logo-link:focus-visible,
+.footer-v1__wordmark:focus-visible,
+.footer-v1__contact-link:focus-visible,
+.footer-v1__social-link:focus-visible {
+    outline-color: var(--rms-color-accent);
+}

--- a/inc/acf-theme-options.php
+++ b/inc/acf-theme-options.php
@@ -223,3 +223,142 @@ function rms_get_social_links(): array {
 
     return $active;
 }
+
+// ─── Company Palette → CSS Custom Properties Bridge ────────────────────────
+
+/**
+ * Compiled per-field palette defaults.
+ *
+ * These match the shipped CSS literals so empty or invalid ACF values stay
+ * visually inert:
+ *   1 -> #0f172a (slate-900, body text + dark surface backgrounds)
+ *   2 -> #2563eb (blue-600, primary CTA / button accent)
+ *   3 -> #f59e0b (amber-500, review stars + secondary highlights)
+ *   4 -> #ffffff (white, light surfaces + on-dark foreground)
+ *
+ * @return array{0:string,1:string,2:string,3:string}
+ */
+function rms_get_palette_defaults(): array {
+    return ['#0f172a', '#2563eb', '#f59e0b', '#ffffff'];
+}
+
+/**
+ * Sanitize a palette value to a strict hex color.
+ *
+ * Accepts only #RGB or #RRGGBB after trim. Invalid, empty, non-string, and
+ * malicious values return null so callers can apply the stable default.
+ * The raw input is never logged or echoed.
+ *
+ * @param mixed $value Candidate color from ACF/options.
+ */
+function rms_sanitize_palette_hex($value): ?string {
+    if (!is_string($value)) {
+        return null;
+    }
+
+    $value = trim($value);
+    if ($value === '') {
+        return null;
+    }
+
+    if (function_exists('sanitize_hex_color')) {
+        $sanitized = sanitize_hex_color($value);
+        if (!is_string($sanitized) || $sanitized === '') {
+            return null;
+        }
+        $value = $sanitized;
+    }
+
+    if (!preg_match('/^#(?:[A-Fa-f0-9]{3}){1,2}$/', $value)) {
+        return null;
+    }
+
+    return $value;
+}
+
+/**
+ * Resolve the four ACF company_palette_color_* fields to sanitized hex values.
+ *
+ * Values are read through rms_get_option() and accepted only when they are
+ * strict hex. Each field falls back independently to its compiled default.
+ *
+ * @return array{0:string,1:string,2:string,3:string} Four sanitized hex colors.
+ */
+function rms_get_palette_colors(): array {
+    $defaults = rms_get_palette_defaults();
+
+    return [
+        rms_sanitize_palette_hex(rms_get_option('company_palette_color_1')) ?? $defaults[0],
+        rms_sanitize_palette_hex(rms_get_option('company_palette_color_2')) ?? $defaults[1],
+        rms_sanitize_palette_hex(rms_get_option('company_palette_color_3')) ?? $defaults[2],
+        rms_sanitize_palette_hex(rms_get_option('company_palette_color_4')) ?? $defaults[3],
+    ];
+}
+
+/**
+ * Build the root custom-property block from sanitized palette colors.
+ *
+ * Only already-validated hex values are interpolated. This string is safe to
+ * attach with wp_add_inline_style().
+ */
+function rms_get_palette_inline_css(): string {
+    $defaults = rms_get_palette_defaults();
+    $colors   = rms_get_palette_colors();
+    $safe     = [];
+
+    foreach ($defaults as $i => $fallback) {
+        $candidate = is_string($colors[$i] ?? null) ? $colors[$i] : $fallback;
+        $safe[$i]  = rms_sanitize_palette_hex($candidate) ?? $fallback;
+    }
+
+    return sprintf(
+        ':root{--rms-color-primary:%s;--rms-color-accent:%s;--rms-color-accent-2:%s;--rms-color-surface:%s;}',
+        $safe[0],
+        $safe[1],
+        $safe[2],
+        $safe[3]
+    );
+}
+
+/**
+ * Enqueue the authored palette bridge stylesheet and emit sanitized root tokens.
+ *
+ * The bridge file (assets/css/rms-palette.css) is authored, non-generated
+ * source. It is enqueued with the active header handle as a dependency so it
+ * lands in <head> after the compiled theme CSS, letting source order and
+ * equal specificity win for the targeted semantic overrides. No database writes.
+ *
+ * When ACF is unavailable the setup-safe shell does not call wp_head, and this
+ * consumer also refuses to read palette settings or enqueue the bridge.
+ */
+function rms_enqueue_palette_bridge(): void {
+    if (!function_exists('get_field')) {
+        return;
+    }
+
+    $handle   = 'rms-palette';
+    $css_uri  = get_template_directory_uri() . '/assets/css/rms-palette.css';
+    $css_path = get_template_directory() . '/assets/css/rms-palette.css';
+
+    if (!is_readable($css_path)) {
+        return;
+    }
+
+    // The active header stylesheet is enqueued in header.php under a handle
+    // matching its version slug (e.g. "header-two"). Declaring it as a
+    // dependency guarantees our bridge prints after it. Invalid/empty values
+    // fall back to header-one so the dependency list never contains junk.
+    $header_raw     = rms_get_option('company_header_version');
+    $header_version = is_string($header_raw) ? sanitize_key($header_raw) : '';
+    if ($header_version === '') {
+        $header_version = 'header-one';
+    }
+
+    $version = filemtime($css_path);
+    $version = $version ? (string) $version : null;
+
+    wp_enqueue_style($handle, $css_uri, [$header_version], $version);
+    wp_add_inline_style($handle, rms_get_palette_inline_css());
+}
+
+add_action('wp_enqueue_scripts', 'rms_enqueue_palette_bridge', 20);

--- a/scripts/test-footer-variants.php
+++ b/scripts/test-footer-variants.php
@@ -605,30 +605,21 @@ $palette_needles = [
     'function rms_enqueue_palette_bridge',
     'rms-palette.css',
 ];
-$palette_hits = [];
-$scan_files = [
-    $theme_root . '/inc/acf-theme-options.php',
-    $theme_root . '/header.php',
-    $theme_root . '/footer.php',
-    $theme_root . '/templates/footer-v1.php',
-    $theme_root . '/src/scss/layout/footer-v1.scss',
-];
-foreach ($scan_files as $path) {
-    $contents = rms_footer_read($path);
-    foreach ($palette_needles as $needle) {
-        if (strpos($contents, $needle) !== false) {
-            $palette_hits[] = basename($path) . ' contains ' . $needle;
-        }
+$palette_missing = [];
+$options_php = rms_footer_read($theme_root . '/inc/acf-theme-options.php');
+foreach ($palette_needles as $needle) {
+    if (strpos($options_php, $needle) === false) {
+        $palette_missing[] = 'acf-theme-options.php is missing ' . $needle;
     }
 }
-if (is_file($theme_root . '/assets/css/rms-palette.css')) {
-    $palette_hits[] = 'assets/css/rms-palette.css exists';
+if (!is_file($theme_root . '/assets/css/rms-palette.css')) {
+    $palette_missing[] = 'assets/css/rms-palette.css is missing';
 }
 
-if ($palette_hits !== []) {
-    rms_footer_test_fail('test_no_issue_29_palette_implementation', implode('; ', $palette_hits));
+if ($palette_missing !== []) {
+    rms_footer_test_fail('test_issue_29_palette_coexists', implode('; ', $palette_missing));
 } else {
-    rms_footer_test_pass('test_no_issue_29_palette_implementation');
+    rms_footer_test_pass('test_issue_29_palette_coexists');
 }
 
 if ($failures > 0) {

--- a/scripts/test-palette-runtime.php
+++ b/scripts/test-palette-runtime.php
@@ -1,0 +1,733 @@
+<?php
+/**
+ * Focused regression harness for the ACF palette runtime bridge (issue #29).
+ *
+ * Run: php scripts/test-palette-runtime.php
+ */
+
+$theme_root = dirname(__DIR__);
+$failures   = 0;
+
+function rms_palette_test_fail(string $name, string $message): void {
+    global $failures;
+    $failures++;
+    fwrite(STDERR, "FAIL {$name}: {$message}\n");
+}
+
+function rms_palette_test_pass(string $name): void {
+    fwrite(STDOUT, "PASS {$name}\n");
+}
+
+function rms_palette_read(string $path): string {
+    $contents = file_get_contents($path);
+    return is_string($contents) ? $contents : '';
+}
+
+function rms_palette_test_reset_fields(array $fields = []): void {
+    $GLOBALS['rms_palette_test_fields']   = $fields;
+    $GLOBALS['rms_palette_test_enqueued'] = [];
+    $GLOBALS['rms_palette_test_inline']   = [];
+}
+
+function rms_palette_hex_pattern(): string {
+    return '/^#(?:[A-Fa-f0-9]{3}){1,2}$/';
+}
+
+function rms_palette_extract_root_values(string $css): array {
+    $map = [];
+    if (preg_match_all('/--rms-color-(primary|accent-2|accent|surface)\s*:\s*([^;}]+)/', $css, $matches, PREG_SET_ORDER)) {
+        foreach ($matches as $match) {
+            $map[$match[1]] = trim($match[2]);
+        }
+    }
+    return $map;
+}
+
+function rms_palette_normalize_selector(string $selector): string {
+    $selector = preg_replace('/\s+/', ' ', trim($selector));
+    return is_string($selector) ? $selector : '';
+}
+
+/**
+ * Parse comment-stripped CSS into selector => ordered property values.
+ *
+ * @return array<int,array{selector:string,props:array<string,list<string>>,index:int}>
+ */
+function rms_palette_parse_rules(string $css): array {
+    $css = preg_replace('/\/\*[\s\S]*?\*\//', '', $css);
+    $css = is_string($css) ? $css : '';
+    $rules = [];
+
+    if (!preg_match_all('/([^{}]+)\{([^{}]*)\}/', $css, $matches, PREG_SET_ORDER)) {
+        return [];
+    }
+
+    foreach ($matches as $index => $match) {
+        $props = [];
+        foreach (explode(';', $match[2]) as $decl) {
+            $decl = trim($decl);
+            if ($decl === '' || strpos($decl, ':') === false) {
+                continue;
+            }
+            [$prop, $value] = explode(':', $decl, 2);
+            $prop = strtolower(trim($prop));
+            $props[$prop][] = trim($value);
+        }
+
+        foreach (explode(',', $match[1]) as $selector) {
+            $selector = rms_palette_normalize_selector($selector);
+            if ($selector === '' || strpos($selector, '@') === 0) {
+                continue;
+            }
+            $rules[] = [
+                'selector' => $selector,
+                'props'    => $props,
+                'index'    => $index,
+            ];
+        }
+    }
+
+    return $rules;
+}
+
+function rms_palette_find_rule(array $rules, string $selector): ?array {
+    $selector = rms_palette_normalize_selector($selector);
+    foreach ($rules as $rule) {
+        if ($rule['selector'] === $selector) {
+            return $rule;
+        }
+    }
+    return null;
+}
+
+function rms_palette_rule_values(array $rule, string $prop): array {
+    return $rule['props'][strtolower($prop)] ?? [];
+}
+
+function rms_palette_rule_last(array $rule, string $prop): ?string {
+    $values = rms_palette_rule_values($rule, $prop);
+    if ($values === []) {
+        return null;
+    }
+    return $values[count($values) - 1];
+}
+
+function rms_palette_specificity(string $selector): int {
+    preg_match_all('/#[A-Za-z0-9_-]+/', $selector, $ids);
+    preg_match_all('/\.[A-Za-z0-9_-]+|:(?:hover|focus-visible|focus|active)/', $selector, $classes);
+    preg_match_all('/(?:^|[\s>+~])([a-z]+)/', $selector, $elements);
+    return (count($ids[0]) * 100) + (count($classes[0]) * 10) + count($elements[1]);
+}
+
+if (!function_exists('__')) {
+    function __($text, $domain = 'default') {
+        return $text;
+    }
+}
+
+if (!function_exists('sanitize_key')) {
+    function sanitize_key($key) {
+        $key = strtolower((string) $key);
+        return preg_replace('/[^a-z0-9_\-]/', '', $key);
+    }
+}
+
+if (!function_exists('sanitize_hex_color')) {
+    function sanitize_hex_color($color) {
+        if ($color === '') {
+            return '';
+        }
+        if (preg_match('/^#(?:[A-Fa-f0-9]{3}){1,2}$/', (string) $color)) {
+            return $color;
+        }
+        return null;
+    }
+}
+
+if (!function_exists('add_action')) {
+    function add_action($hook, $callback, $priority = 10, $accepted_args = 1) {
+        $GLOBALS['rms_palette_test_actions'][] = [
+            'hook'     => (string) $hook,
+            'callback' => $callback,
+            'priority' => $priority,
+        ];
+        return true;
+    }
+}
+
+if (!function_exists('get_template_directory')) {
+    function get_template_directory() {
+        return $GLOBALS['rms_palette_test_theme_root'];
+    }
+}
+
+if (!function_exists('get_template_directory_uri')) {
+    function get_template_directory_uri() {
+        return 'https://example.test/wp-content/themes/simple-rms-theme';
+    }
+}
+
+if (!function_exists('get_field')) {
+    function get_field($selector, $post_id = false) {
+        return $GLOBALS['rms_palette_test_fields'][$selector] ?? null;
+    }
+}
+
+if (!function_exists('wp_enqueue_style')) {
+    function wp_enqueue_style($handle = '', $src = '', $deps = [], $ver = false, $media = 'all') {
+        $GLOBALS['rms_palette_test_enqueued'][] = [
+            'handle' => (string) $handle,
+            'src'    => (string) $src,
+            'deps'   => is_array($deps) ? $deps : [],
+            'ver'    => $ver,
+        ];
+    }
+}
+
+if (!function_exists('wp_add_inline_style')) {
+    function wp_add_inline_style($handle, $data) {
+        $GLOBALS['rms_palette_test_inline'][] = [
+            'handle' => (string) $handle,
+            'data'   => (string) $data,
+        ];
+    }
+}
+
+$GLOBALS['rms_palette_test_theme_root'] = $theme_root;
+$GLOBALS['rms_palette_test_actions']    = [];
+rms_palette_test_reset_fields();
+
+require $theme_root . '/inc/acf-theme-options.php';
+
+$php_source = rms_palette_read($theme_root . '/inc/acf-theme-options.php');
+$css_path   = $theme_root . '/assets/css/rms-palette.css';
+$css_source = rms_palette_read($css_path);
+$header_php = rms_palette_read($theme_root . '/header.php');
+$footer_php = rms_palette_read($theme_root . '/footer.php');
+$acf_path   = $theme_root . '/acf-json/group_rms_theme_settings.json';
+$acf_json   = json_decode(rms_palette_read($acf_path), true);
+
+$palette_fields = [
+    'company_palette_color_1',
+    'company_palette_color_2',
+    'company_palette_color_3',
+    'company_palette_color_4',
+];
+$defaults = ['#0f172a', '#2563eb', '#f59e0b', '#ffffff'];
+
+// 1. All four ACF fields are consumed and emitted.
+$consumer_failed = [];
+foreach ($palette_fields as $field) {
+    if (!preg_match('/rms_get_option\s*\(\s*[\'"]' . preg_quote($field, '/') . '[\'"]\s*\)/', $php_source)) {
+        $consumer_failed[] = $field . ' is not read through rms_get_option()';
+    }
+}
+
+$acf_names = [];
+if (!is_array($acf_json)) {
+    $consumer_failed[] = 'Theme settings JSON did not parse';
+} else {
+    foreach ($acf_json['fields'] ?? [] as $candidate) {
+        if (isset($candidate['name']) && in_array($candidate['name'], $palette_fields, true)) {
+            $acf_names[] = $candidate['name'];
+        }
+    }
+    $missing_acf = array_diff($palette_fields, $acf_names);
+    if ($missing_acf !== []) {
+        $consumer_failed[] = 'ACF JSON missing: ' . implode(', ', $missing_acf);
+    }
+}
+
+rms_palette_test_reset_fields([
+    'company_palette_color_1' => '#000000',
+    'company_palette_color_2' => '#e53935',
+    'company_palette_color_3' => '#e53935',
+    'company_palette_color_4' => '#ffffff',
+]);
+$resolved = rms_get_palette_colors();
+$inline   = rms_get_palette_inline_css();
+$emitted  = rms_palette_extract_root_values($inline);
+
+if ($resolved !== ['#000000', '#e53935', '#e53935', '#ffffff']) {
+    $consumer_failed[] = 'rms_get_palette_colors() did not return all four saved values';
+}
+if (($emitted['primary'] ?? null) !== '#000000' || ($emitted['accent'] ?? null) !== '#e53935') {
+    $consumer_failed[] = 'inline CSS is missing primary/accent from saved values';
+}
+if (($emitted['accent-2'] ?? null) !== '#e53935' || ($emitted['surface'] ?? null) !== '#ffffff') {
+    $consumer_failed[] = 'inline CSS is missing accent-2/surface from saved values';
+}
+
+if ($consumer_failed !== []) {
+    rms_palette_test_fail('test_acf_palette_fields_have_frontend_consumer', implode('; ', $consumer_failed));
+} else {
+    rms_palette_test_pass('test_acf_palette_fields_have_frontend_consumer');
+}
+
+// 2. Invalid/empty values use stable per-field defaults.
+$default_failed = [];
+$invalid_cases = [
+    [
+        'fields'   => [],
+        'expected' => $defaults,
+    ],
+    [
+        'fields'   => [
+            'company_palette_color_1' => '',
+            'company_palette_color_2' => 'not-a-color',
+            'company_palette_color_3' => '#gggggg',
+            'company_palette_color_4' => '   ',
+        ],
+        'expected' => $defaults,
+    ],
+    [
+        'fields'   => [
+            'company_palette_color_1' => '#000000',
+            'company_palette_color_2' => 'red',
+            'company_palette_color_3' => '#fff',
+            'company_palette_color_4' => null,
+        ],
+        'expected' => ['#000000', '#2563eb', '#fff', '#ffffff'],
+    ],
+    [
+        'fields'   => [
+            'company_palette_color_1' => ['#000000'],
+            'company_palette_color_2' => 255,
+            'company_palette_color_3' => false,
+            'company_palette_color_4' => '#ABCDEF',
+        ],
+        'expected' => ['#0f172a', '#2563eb', '#f59e0b', '#ABCDEF'],
+    ],
+];
+
+foreach ($invalid_cases as $case) {
+    rms_palette_test_reset_fields($case['fields']);
+    $actual = rms_get_palette_colors();
+    if ($actual !== $case['expected']) {
+        $default_failed[] = json_encode($case['fields']) . ' => ' . json_encode($actual);
+    }
+}
+
+if (!function_exists('rms_get_palette_defaults') || rms_get_palette_defaults() !== $defaults) {
+    $default_failed[] = 'stable compiled defaults drifted';
+}
+
+if ($default_failed !== []) {
+    rms_palette_test_fail('test_invalid_palette_values_use_stable_defaults', implode('; ', $default_failed));
+} else {
+    rms_palette_test_pass('test_invalid_palette_values_use_stable_defaults');
+}
+
+// 3. Emitted declarations contain only valid hex; raw/malicious strings never leak.
+$sanitize_failed = [];
+$malicious = [
+    'company_palette_color_1' => '#000000;background:url(javascript:alert(1))',
+    'company_palette_color_2' => 'expression(alert(1))',
+    'company_palette_color_3' => '</style><script>alert(1)</script>',
+    'company_palette_color_4' => 'rgb(0,0,0)',
+];
+rms_palette_test_reset_fields($malicious);
+$sanitized_colors = rms_get_palette_colors();
+$sanitized_inline = rms_get_palette_inline_css();
+
+if ($sanitized_colors !== $defaults) {
+    $sanitize_failed[] = 'malicious values were not replaced with defaults';
+}
+
+foreach ($malicious as $raw) {
+    if (strpos($sanitized_inline, $raw) !== false) {
+        $sanitize_failed[] = 'raw value leaked into inline CSS';
+    }
+}
+
+$root_values = rms_palette_extract_root_values($sanitized_inline);
+foreach (['primary', 'accent', 'accent-2', 'surface'] as $token) {
+    $value = $root_values[$token] ?? '';
+    if (!preg_match(rms_palette_hex_pattern(), $value)) {
+        $sanitize_failed[] = $token . ' emitted a non-hex value: ' . $value;
+    }
+}
+
+if (preg_match('/--rms-color-(?:primary|accent|accent-2|surface)\s*:\s*(?!#(?:[A-Fa-f0-9]{3}){1,2}\s*(;|$))/', $sanitized_inline)) {
+    $sanitize_failed[] = 'inline CSS contains a non-hex custom property';
+}
+
+if (preg_match('/error_log\s*\(|var_dump\s*\(|print_r\s*\(/', $php_source)) {
+    $sanitize_failed[] = 'palette PHP must not log or dump raw values';
+}
+
+if ($sanitize_failed !== []) {
+    rms_palette_test_fail('test_emitted_palette_values_are_sanitized', implode('; ', $sanitize_failed));
+} else {
+    rms_palette_test_pass('test_emitted_palette_values_are_sanitized');
+}
+
+// 4. Exact selector/property/order/specificity checks — not comment windows.
+$css_rules = rms_palette_parse_rules($css_source);
+$integration_failed = [];
+
+$required_rules = [
+    'body' => ['color' => 'var(--rms-color-primary)'],
+    '.rms-header-v2__top-bar' => ['background-color' => 'var(--rms-color-primary)'],
+    '.rms-header-v2__main-bar .rms-header-v2__menu-toggle .rms-header-v2__menu-icon span' => [
+        'background-color' => 'var(--rms-color-primary-strong)',
+    ],
+    '.btn' => [
+        'color'            => 'var(--rms-color-surface)',
+        'background-color' => 'var(--rms-color-accent)',
+        'border-color'     => 'var(--rms-color-accent)',
+    ],
+    '.btn:hover' => [
+        'background-color' => 'var(--rms-color-accent-strong)',
+        'border-color'     => 'var(--rms-color-accent-strong)',
+    ],
+    '.btn:focus-visible' => [
+        'background-color' => 'var(--rms-color-accent-strong)',
+    ],
+    '.btn.btn--outline-white' => [
+        'color'            => 'var(--rms-color-surface)',
+        'background-color' => 'transparent',
+        'border-color'     => 'var(--rms-color-surface)',
+    ],
+    '.btn.btn--outline-white:hover' => [
+        'color'            => 'var(--rms-color-primary)',
+        'background-color' => 'var(--rms-color-surface)',
+    ],
+    '.rms-header-v2__top-bar-right .rms-header-v2__cta-btn:hover' => [
+        'background-color' => 'var(--rms-color-accent-strong)',
+    ],
+    '.footer-v2__cta-button:hover' => [
+        'background-color' => 'var(--rms-color-accent-strong)',
+    ],
+    '.hero__form-submit:hover' => [
+        'background-color' => 'var(--rms-color-accent-strong)',
+    ],
+    '.slider__overlay--dark' => [
+        'background-color' => 'color-mix(in srgb, var(--rms-color-primary) 75%, transparent)',
+    ],
+    '.hero__overlay--dark' => [
+        'background-color' => 'color-mix(in srgb, var(--rms-color-primary) 75%, transparent)',
+    ],
+    '.hero__overlay--primary' => [
+        'background-color' => 'color-mix(in srgb, var(--rms-color-accent) 80%, transparent)',
+    ],
+    '.portfolio-v2__overlay' => [
+        'background-color' => 'color-mix(in srgb, var(--rms-color-primary) 80%, transparent)',
+    ],
+    '.area-coverage-v1__map-ring' => [
+        'stroke' => 'var(--rms-color-accent)',
+        'filter' => 'drop-shadow(0 0 8px color-mix(in srgb, var(--rms-color-accent) 35%, transparent))',
+    ],
+    '.cta-v1' => [
+        'background-image' => null,
+    ],
+    '.rms-header__nav-bar' => [
+        'background-color' => 'var(--rms-color-accent)',
+    ],
+    '.rms-header__cta-btn' => [
+        'color'            => 'var(--rms-color-surface)',
+        'background-color' => 'var(--rms-color-accent)',
+    ],
+    '.rms-header__cta-btn:hover' => [
+        'background-color' => 'var(--rms-color-accent-strong)',
+    ],
+    '.rms-header__dropdown > li > a:hover' => [
+        'color' => 'var(--rms-color-accent)',
+    ],
+    '.rms-header__mobile-nav-list > li > a:hover' => [
+        'color' => 'var(--rms-color-accent)',
+    ],
+    '.rms-header__cta-btn:focus-visible' => [
+        'outline-color' => 'var(--rms-color-accent)',
+    ],
+    '.rms-header-v3__nav-link::after' => [
+        'background-color' => 'var(--rms-color-accent)',
+    ],
+    '.rms-header-v3__social-link:hover' => [
+        'color' => 'var(--rms-color-accent)',
+    ],
+    '.rms-header-v3__mobile-phone:hover' => [
+        'color' => 'var(--rms-color-accent)',
+    ],
+    '.rms-header-v3__nav-link:focus-visible' => [
+        'outline-color' => 'var(--rms-color-accent)',
+    ],
+    '.footer-v1__social-link:focus-visible' => [
+        'outline-color' => 'var(--rms-color-accent)',
+    ],
+];
+
+foreach ($required_rules as $selector => $expectations) {
+    $rule = rms_palette_find_rule($css_rules, $selector);
+    if ($rule === null) {
+        $integration_failed[] = $selector . ' is missing';
+        continue;
+    }
+    foreach ($expectations as $prop => $value) {
+        if ($value === null) {
+            if (rms_palette_rule_values($rule, $prop) === []) {
+                $integration_failed[] = $selector . ' is missing ' . $prop;
+            }
+            continue;
+        }
+        $last = rms_palette_rule_last($rule, $prop);
+        if ($last !== $value) {
+            $integration_failed[] = $selector . ' ' . $prop . ' last value is ' . ($last ?? 'missing');
+        }
+    }
+}
+
+$menu_icon = '.rms-header-v2__main-bar .rms-header-v2__menu-toggle .rms-header-v2__menu-icon span';
+$compiled_menu_spec = rms_palette_specificity($menu_icon);
+$bridge_menu_rule = rms_palette_find_rule($css_rules, $menu_icon);
+if ($bridge_menu_rule === null || rms_palette_specificity($bridge_menu_rule['selector']) < $compiled_menu_spec) {
+    $integration_failed[] = 'menu icon selector loses to compiled specificity ' . $compiled_menu_spec;
+}
+
+$btn_rule = rms_palette_find_rule($css_rules, '.btn');
+$outline_white = rms_palette_find_rule($css_rules, '.btn.btn--outline-white');
+if ($btn_rule === null || $outline_white === null || $outline_white['index'] <= $btn_rule['index']) {
+    $integration_failed[] = '.btn.btn--outline-white must be declared after .btn';
+}
+
+$outline_white_hover = rms_palette_find_rule($css_rules, '.btn.btn--outline-white:hover');
+if ($outline_white_hover !== null && rms_palette_rule_last($outline_white_hover, 'background-color') !== 'var(--rms-color-surface)') {
+    $integration_failed[] = 'outline-white hover must keep a white/surface fill';
+}
+
+$dark_overlay = rms_palette_find_rule($css_rules, '.slider__overlay--dark');
+if ($dark_overlay !== null) {
+    $bg = rms_palette_rule_values($dark_overlay, 'background-color');
+    if (count($bg) < 2 || strpos($bg[0], 'rgba(15, 23, 42') === false) {
+        $integration_failed[] = 'slider dark overlay is missing the compiled-color fallback';
+    }
+}
+
+if ($integration_failed !== []) {
+    rms_palette_test_fail('test_computed_style_integration_palette', implode('; ', $integration_failed));
+} else {
+    rms_palette_test_pass('test_computed_style_integration_palette');
+}
+
+// 5. No generated/dist CSS edits and no DB mutation in the palette unit.
+$dist_failed = [];
+if (preg_match('/update_option\s*\(|add_option\s*\(|delete_option\s*\(|update_field\s*\(/', $php_source)) {
+    $dist_failed[] = 'palette PHP must not mutate options/DB';
+}
+if (strpos($php_source, '/dist/') !== false || strpos($css_source, '/dist/') !== false) {
+    $dist_failed[] = 'palette implementation must not reference dist CSS';
+}
+if (!is_readable($css_path)) {
+    $dist_failed[] = 'authored assets/css/rms-palette.css is missing';
+}
+
+$changed = [];
+exec('git -C ' . escapeshellarg($theme_root) . ' status --porcelain', $changed);
+foreach ($changed as $line) {
+    if (preg_match('/\bdist\//', $line)) {
+        $dist_failed[] = 'git status includes a dist path: ' . $line;
+    }
+}
+
+if ($dist_failed !== []) {
+    rms_palette_test_fail('test_no_generated_css_edits', implode('; ', $dist_failed));
+} else {
+    rms_palette_test_pass('test_no_generated_css_edits');
+}
+
+// 6. Bridge contains no !important declarations.
+$css_code = preg_replace('/\/\*[\s\S]*?\*\//', '', $css_source);
+$php_code = preg_replace('/\/\*[\s\S]*?\*\//', '', $php_source);
+$php_code = preg_replace('/\/\/.*$/m', '', $php_code);
+if (preg_match('/!important/i', (string) $css_code) || preg_match('/!important/i', (string) $php_code)) {
+    rms_palette_test_fail('test_palette_bridge_no_important', 'Found !important in the palette bridge.');
+} else {
+    rms_palette_test_pass('test_palette_bridge_no_important');
+}
+
+// 7. Authored stylesheet is enqueued through a safe WordPress mechanism.
+$enqueue_failed = [];
+$hooked = false;
+foreach ($GLOBALS['rms_palette_test_actions'] as $action) {
+    if ($action['hook'] === 'wp_enqueue_scripts' && $action['callback'] === 'rms_enqueue_palette_bridge') {
+        $hooked = true;
+        if ((int) $action['priority'] !== 20) {
+            $enqueue_failed[] = 'enqueue hook priority must be 20';
+        }
+    }
+}
+if (!$hooked) {
+    $enqueue_failed[] = 'rms_enqueue_palette_bridge is not hooked to wp_enqueue_scripts';
+}
+
+rms_palette_test_reset_fields([
+    'company_header_version'  => 'header-two',
+    'company_palette_color_1' => '#111111',
+    'company_palette_color_2' => '#222222',
+    'company_palette_color_3' => '#333333',
+    'company_palette_color_4' => '#444444',
+]);
+rms_enqueue_palette_bridge();
+
+if (count($GLOBALS['rms_palette_test_enqueued']) !== 1) {
+    $enqueue_failed[] = 'expected exactly one wp_enqueue_style call';
+} else {
+    $queued = $GLOBALS['rms_palette_test_enqueued'][0];
+    if ($queued['handle'] !== 'rms-palette') {
+        $enqueue_failed[] = 'handle must be rms-palette';
+    }
+    if (strpos($queued['src'], '/assets/css/rms-palette.css') === false) {
+        $enqueue_failed[] = 'src must point at authored assets/css/rms-palette.css';
+    }
+    if (!in_array('header-two', $queued['deps'], true)) {
+        $enqueue_failed[] = 'bridge must depend on the active header handle';
+    }
+    $expected_version = (string) filemtime($css_path);
+    if ((string) $queued['ver'] !== $expected_version) {
+        $enqueue_failed[] = 'version must be the authored CSS filemtime';
+    }
+}
+
+$header_fallback_cases = [
+    ['label' => 'empty', 'fields' => ['company_header_version' => ''], 'expected' => 'header-one'],
+    ['label' => 'invalid', 'fields' => ['company_header_version' => '!!!'], 'expected' => 'header-one'],
+    ['label' => 'missing', 'fields' => [], 'expected' => 'header-one'],
+    ['label' => 'header-three', 'fields' => ['company_header_version' => 'header-three'], 'expected' => 'header-three'],
+];
+foreach ($header_fallback_cases as $case) {
+    rms_palette_test_reset_fields($case['fields'] + [
+        'company_palette_color_1' => '#111111',
+        'company_palette_color_2' => '#222222',
+        'company_palette_color_3' => '#333333',
+        'company_palette_color_4' => '#444444',
+    ]);
+    rms_enqueue_palette_bridge();
+    $dep = $GLOBALS['rms_palette_test_enqueued'][0]['deps'][0] ?? null;
+    if ($dep !== $case['expected']) {
+        $enqueue_failed[] = 'header dependency for ' . $case['label'] . ' was ' . json_encode($dep);
+    }
+}
+
+if (count($GLOBALS['rms_palette_test_inline']) !== 1) {
+    $enqueue_failed[] = 'expected exactly one wp_add_inline_style call';
+} else {
+    $inline_style = $GLOBALS['rms_palette_test_inline'][0];
+    if ($inline_style['handle'] !== 'rms-palette') {
+        $enqueue_failed[] = 'inline CSS must attach to rms-palette';
+    }
+    $inline_values = rms_palette_extract_root_values($inline_style['data']);
+    if ($inline_values !== [
+        'primary'  => '#111111',
+        'accent'   => '#222222',
+        'accent-2' => '#333333',
+        'surface'  => '#444444',
+    ]) {
+        $enqueue_failed[] = 'inline CSS did not emit the four sanitized colors';
+    }
+}
+
+$missing_root = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'rms-palette-missing-' . bin2hex(random_bytes(4));
+if (!mkdir($missing_root) && !is_dir($missing_root)) {
+    $enqueue_failed[] = 'could not create missing-css theme root';
+} else {
+    $GLOBALS['rms_palette_test_theme_root'] = $missing_root;
+    rms_palette_test_reset_fields([]);
+    rms_enqueue_palette_bridge();
+    if ($GLOBALS['rms_palette_test_enqueued'] !== [] || $GLOBALS['rms_palette_test_inline'] !== []) {
+        $enqueue_failed[] = 'missing CSS file must not enqueue or emit tokens';
+    }
+    rmdir($missing_root);
+    $GLOBALS['rms_palette_test_theme_root'] = $theme_root;
+}
+
+if ($enqueue_failed !== []) {
+    rms_palette_test_fail('test_palette_bridge_enqueued', implode('; ', $enqueue_failed));
+} else {
+    rms_palette_test_pass('test_palette_bridge_enqueued');
+}
+
+// 8. CSS token / selector / gradient / SVG coverage.
+$coverage_failed = [];
+$required_tokens = [
+    '--rms-color-primary',
+    '--rms-color-accent',
+    '--rms-color-accent-2',
+    '--rms-color-surface',
+    '--rms-color-primary-strong',
+    '--rms-color-primary-muted',
+    '--rms-color-accent-strong',
+];
+$root_rule = rms_palette_find_rule($css_rules, ':root');
+foreach ($required_tokens as $token) {
+    $found = $root_rule !== null && array_key_exists(strtolower($token), $root_rule['props']);
+    if (!$found && strpos($css_source, $token) === false) {
+        $coverage_failed[] = 'missing token ' . $token;
+    }
+}
+
+$cta = rms_palette_find_rule($css_rules, '.cta-v1');
+$cta_image = $cta ? rms_palette_rule_last($cta, 'background-image') : null;
+if (!is_string($cta_image) || strpos($cta_image, 'linear-gradient(') === false || strpos($cta_image, 'var(--rms-color-accent-strong)') === false) {
+    $coverage_failed[] = 'CTA-v1 gradient must consume accent-strong';
+}
+
+$shape = rms_palette_find_rule($css_rules, '.slider__shape path');
+if ($shape === null || rms_palette_rule_last($shape, 'fill') !== 'var(--rms-color-primary)') {
+    $coverage_failed[] = 'slider SVG fill must use the primary token';
+}
+
+$ring = rms_palette_find_rule($css_rules, '.area-coverage-v1__map-ring');
+if ($ring === null || rms_palette_rule_last($ring, 'stroke') !== 'var(--rms-color-accent)') {
+    $coverage_failed[] = 'area-coverage SVG stroke must use the accent token';
+}
+
+$header_one_nav = rms_palette_find_rule($css_rules, '.rms-header__nav-bar');
+if ($header_one_nav === null || rms_palette_rule_last($header_one_nav, 'background-color') !== 'var(--rms-color-accent)') {
+    $coverage_failed[] = 'Header One nav bar must use the accent token';
+}
+$header_three_underline = rms_palette_find_rule($css_rules, '.rms-header-v3__nav-link::after');
+if ($header_three_underline === null || rms_palette_rule_last($header_three_underline, 'background-color') !== 'var(--rms-color-accent)') {
+    $coverage_failed[] = 'Header Three active underline must use the accent token';
+}
+
+if (!preg_match('/@supports\s*\(\s*color:\s*color-mix/', $css_source)) {
+    $coverage_failed[] = 'missing color-mix @supports fallbacks';
+}
+
+$open  = substr_count($css_source, '{');
+$close = substr_count($css_source, '}');
+if ($open === 0 || $open !== $close) {
+    $coverage_failed[] = "unbalanced CSS braces ({$open}/{$close})";
+}
+
+if ($coverage_failed !== []) {
+    rms_palette_test_fail('test_palette_css_coverage', implode('; ', $coverage_failed));
+} else {
+    rms_palette_test_pass('test_palette_css_coverage');
+}
+
+// 9. Integration tree: #28 footer resolver must coexist with the palette bridge.
+$issue28_failed = [];
+if (!preg_match('/function\s+rms_get_footer_version\s*\(/', $php_source)) {
+    $issue28_failed[] = 'acf-theme-options.php is missing rms_get_footer_version';
+}
+if (!preg_match('/rms_get_footer_version\s*\(/', $header_php) || preg_match('/rms_get_option\s*\(\s*[\'"]company_footer_version[\'"]/', $header_php)) {
+    $issue28_failed[] = 'header.php must dispatch footer CSS only through rms_get_footer_version()';
+}
+if (!preg_match('/rms_get_footer_version\s*\(/', $footer_php) || preg_match('/rms_get_option\s*\(\s*[\'"]company_footer_version[\'"]/', $footer_php)) {
+    $issue28_failed[] = 'footer.php must dispatch footer templates only through rms_get_footer_version()';
+}
+
+if ($issue28_failed !== []) {
+    rms_palette_test_fail('test_issue_28_footer_resolver_coexists', implode('; ', $issue28_failed));
+} else {
+    rms_palette_test_pass('test_issue_28_footer_resolver_coexists');
+}
+
+if ($failures > 0) {
+    fwrite(STDERR, "\n{$failures} palette runtime check(s) failed.\n");
+    exit(1);
+}
+
+fwrite(STDOUT, "\nAll palette runtime checks passed.\n");
+exit(0);


### PR DESCRIPTION
Fixes #29

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Reads, sanitizes, and emits the four stored `company_palette_color_*` fields as CSS custom properties.
- Enqueues authored `assets/css/rms-palette.css` (no `!important`, no dist/DB edits) so core surfaces consume the tokens.
- Merges palette helpers into the existing `inc/acf-theme-options.php` without removing or duplicating the #28 footer resolver.

## Changes

| File | Change |
|------|--------|
| `inc/acf-theme-options.php` | Add palette defaults, hex sanitizer, token emitter, and enqueue bridge. Footer resolver kept intact. |
| `assets/css/rms-palette.css` | Authored token-to-surface bridge stylesheet. |
| `scripts/test-palette-runtime.php` | Focused #29 harness, including #28 coexistence. |
| `scripts/test-footer-variants.php` | Restore golden coexistence assertion now that palette is present. |

## Test Plan
- [x] `php -l` passed on authored PHP files.
- [x] `php scripts/test-palette-runtime.php` — 9/9 PASS.
- [x] `php scripts/test-footer-variants.php` — 5/5 PASS (resolver still present).
- [x] Diff against `fix/footer-variant-runtime` contains only the #29 slice (4 files, `+1395 / -19`).
- [x] No #28 footer functions removed or reimplemented.
- [x] Scripts run without errors: N/A — no shell scripts in this PR.

## size:exception

Review budget is **1414 / 400**. The authored palette stylesheet (513) and the 733-line harness must travel with the PHP consumer. Production PHP is 139 added lines in the existing options file.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts: N/A — no shell scripts
- [x] Skills tested in at least one agent: N/A — runtime palette fix, not a skill change
- [x] Docs updated if behavior changed: N/A
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Chain Context

| Field | Value |
|-------|-------|
| Chain | wizard-setup beta issues #22–#29 |
| Tracker PR | Not needed — retained `feature/wizard-setup` @ `3205ee5` |
| Position | 4 of 11 |
| Base | `fix/footer-variant-runtime` |
| Depends on | PR #32 / #28 |
| Follow-up | Planned: `fix/wizard-dependencies-credentials` (#22) |
| Review budget | 1414 / 400 (`size:exception` — authored CSS + harness) |
| Starts at | `fix/footer-variant-runtime` |
| Ends with | Stored company palette colors applied on the frontend |

### Chain Overview

```text
feature/wizard-setup
 └── #30 docs/vite-manifest-checklist  (#24)
      └── #31 fix/acf-inactive-frontend-guard  (#23)
           └── #32 fix/footer-variant-runtime  (#28)
                └── 📍 fix/palette-runtime-css  (#29)
                     └── planned fix/wizard-dependencies-credentials  (#22)
```

### Scope
- Includes: palette read/sanitize/emit, authored bridge CSS, palette harness, footer-harness coexistence flip.
- Excludes: #28 product rework, later wizard slices, Demo #6.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit
