### PR TITLE
fix(wizard): clear plaintext API keys after save

### DIFF
--- a/inc/wizard/class-logger.php
+++ b/inc/wizard/class-logger.php
@@ -67,7 +67,24 @@ class Logger {
     }
 
     /**
+     * Context keys that must never be persisted in wizard logs.
+     *
+     * @var string[]
+     */
+    private const SECRET_CONTEXT_KEYS = [
+        'api_key',
+        'apikey',
+        'api-key',
+        'authorization',
+        'x-api-key',
+        'secret',
+        'password',
+        'token',
+    ];
+
+    /**
      * Sanitize nested log context without losing scalar structure.
+     * Secret-bearing keys are replaced with a boolean/masked sentinel.
      *
      * @param array $context Raw context.
      *
@@ -78,6 +95,11 @@ class Logger {
 
         foreach ( $context as $key => $value ) {
             $safe_key = \sanitize_key( (string) $key );
+
+            if ( $this->is_secret_context_key( $safe_key ) ) {
+                $sanitized[ $safe_key ] = '[redacted]';
+                continue;
+            }
 
             if ( is_array( $value ) ) {
                 $sanitized[ $safe_key ] = $this->sanitize_context( $value );
@@ -93,5 +115,9 @@ class Logger {
         }
 
         return $sanitized;
+    }
+
+    private function is_secret_context_key( string $key ): bool {
+        return in_array( $key, self::SECRET_CONTEXT_KEYS, true );
     }
 }

--- a/src/ts/admin/wizard-helpers.ts
+++ b/src/ts/admin/wizard-helpers.ts
@@ -1,4 +1,29 @@
+export const SAVED_KEY_PLACEHOLDER = 'Leave blank to use the saved encrypted key';
+
+export type ApiKeyInputLike = {
+  value: string;
+  placeholder: string;
+  getAttribute?: (name: string) => string | null;
+};
+
 export type StepOutcomePresentation = 'success' | 'progress' | 'error';
+
+/**
+ * Clear plaintext from the API-key input after a successful Test/Load or
+ * save, and whenever hydration sees a saved credential. Failure/correction
+ * paths must call this with both flags false so the typed value is kept.
+ */
+export const applyApiKeyInputSafety = (
+  input: ApiKeyInputLike,
+  options: { clear: boolean; hasSavedCredential: boolean }
+): void => {
+  if (!options.clear && !options.hasSavedCredential) {
+    return;
+  }
+
+  input.value = '';
+  input.placeholder = SAVED_KEY_PLACEHOLDER;
+};
 
 /**
  * Client presentation for a step response.
@@ -52,4 +77,22 @@ export const summarizeDependencyResult = (result: unknown): string => {
   });
 
   return `${activeCount} of ${plugins.length} dependencies active. ${lines.join(' ')}`;
+};
+
+export const inputContainsSecret = (input: ApiKeyInputLike, sentinel: string): boolean => {
+  if (input.value.includes(sentinel)) {
+    return true;
+  }
+
+  if (input.placeholder.includes(sentinel)) {
+    return true;
+  }
+
+  if (typeof input.getAttribute !== 'function') {
+    return false;
+  }
+
+  const attributeNames = ['value', 'data-api-key', 'data-value', 'data-credential', 'data-key'];
+
+  return attributeNames.some((name) => (input.getAttribute?.(name) ?? '').includes(sentinel));
 };

--- a/src/ts/admin/wizard.ts
+++ b/src/ts/admin/wizard.ts
@@ -1,4 +1,5 @@
 import {
+  applyApiKeyInputSafety,
   presentStepOutcome,
   summarizeDependencyResult,
 } from './wizard-helpers';
@@ -497,6 +498,16 @@ declare global {
       setStepResult(step, response.result ?? response);
 
       if (outcome === 'success') {
+        /*
+         * Clear the API key input immediately after a successful IA Generation
+         * save so the plaintext does not linger in the DOM between the
+         * response and the state re-hydration. The saved-key status element
+         * already shows masked metadata.
+         */
+        if (step === 'ia-generation') {
+          clearApiKeyInput();
+        }
+
         const nextStep = nextStepFor(step);
         setStepActionStatus(step, 'Step completed.', 'success');
         setNotice(
@@ -1975,6 +1986,15 @@ declare global {
     return defaults[normalized] ?? 1;
   };
 
+  const clearApiKeyInput = (): void => {
+    const form = root.querySelector<HTMLFormElement>('[data-wizard-ia-generation-form]');
+    const apiKeyInput = form?.querySelector<HTMLInputElement>('input[name="api_key"]');
+
+    if (apiKeyInput) {
+      applyApiKeyInputSafety(apiKeyInput, { clear: true, hasSavedCredential: true });
+    }
+  };
+
   const hydrateIaGenerationForm = (): void => {
     const form = root.querySelector<HTMLFormElement>('[data-wizard-ia-generation-form]');
     const aiConfig = state.ai_config;
@@ -1996,8 +2016,20 @@ declare global {
       providerSelect.value = provider;
     }
 
-    if (apiKeyInput && (aiConfig.has_credentials || aiConfig.credential?.has_key)) {
-      apiKeyInput.placeholder = '************';
+    if (apiKeyInput) {
+      const hasSavedCredential = Boolean(aiConfig.has_credentials || aiConfig.credential?.has_key);
+
+      /*
+       * When a saved credential exists, clear any residual value from the
+       * input so a plaintext key cannot survive a render triggered by a
+       * state reload (e.g. after a successful save or on re-opening the
+       * wizard). When no credential is saved (error/correction path), the
+       * user's typed value is retained so they can fix and retry.
+       */
+      applyApiKeyInputSafety(apiKeyInput, {
+        clear: false,
+        hasSavedCredential,
+      });
     }
 
     if (credentialStatus) {
@@ -2061,6 +2093,16 @@ declare global {
 
       if (credentialStatus && response.credential?.status) {
         credentialStatus.textContent = response.credential.status;
+      }
+
+      /*
+       * After a successful provider test with a newly entered key, the
+       * credential is persisted server-side. Clear the plaintext from the
+       * input value so it does not linger in the DOM or any accessibility
+       * snapshot. The saved-key placeholder/status is shown instead.
+       */
+      if (apiKeyInput) {
+        applyApiKeyInputSafety(apiKeyInput, { clear: true, hasSavedCredential: true });
       }
 
       setInlineStatus(

--- a/tests/wizard-client-truth-harness.mjs
+++ b/tests/wizard-client-truth-harness.mjs
@@ -1,12 +1,14 @@
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
+import { writeFileSync } from 'node:fs';
 
 const require = createRequire(import.meta.url);
 const ts = require('typescript');
 
+const SENTINEL = 'rms-sentinel-not-a-real-key-22f25';
 const here = dirname(fileURLToPath(import.meta.url));
 const themeRoot = resolve(here, '..');
 const helperSource = readFileSync(resolve(themeRoot, 'src/ts/admin/wizard-helpers.ts'), 'utf8');
@@ -16,7 +18,10 @@ const transpiled = ts.transpileModule(helperSource, {
 const helperPath = resolve(tmpdir(), 'rms-wizard-helpers-harness.mjs');
 writeFileSync(helperPath, transpiled);
 const {
+  applyApiKeyInputSafety,
+  inputContainsSecret,
   presentStepOutcome,
+  SAVED_KEY_PLACEHOLDER,
   summarizeDependencyResult,
 } = await import('file:///' + helperPath.replace(/\\/g, '/'));
 
@@ -27,6 +32,52 @@ const assert = (condition, message) => {
 };
 
 let passed = 0;
+
+const input = {
+  value: SENTINEL,
+  placeholder: 'Enter key',
+  attrs: {
+    value: SENTINEL,
+    'data-api-key': '',
+    'data-value': '',
+    'data-credential': '',
+    'data-key': '',
+  },
+  getAttribute(name) {
+    return this.attrs[name] ?? null;
+  },
+};
+
+assert(inputContainsSecret(input, SENTINEL), 'sentinel must be visible before action');
+console.log('PASS sentinel-present-before-action');
+passed += 1;
+
+applyApiKeyInputSafety(input, { clear: true, hasSavedCredential: true });
+input.attrs.value = input.value;
+assert(input.value === '', 'successful test/save must clear the input value');
+assert(input.placeholder === SAVED_KEY_PLACEHOLDER, 'successful test/save must set the saved-key placeholder');
+assert(!inputContainsSecret(input, SENTINEL), 'sentinel remained in the DOM after success');
+const successSnapshot = JSON.stringify({ placeholder: input.placeholder, value: input.value, attrs: input.attrs });
+assert(!successSnapshot.includes(SENTINEL), 'post-success snapshot leaked sentinel');
+console.log('PASS sentinel-absent-after-success');
+passed += 1;
+
+input.value = SENTINEL;
+input.attrs.value = SENTINEL;
+applyApiKeyInputSafety(input, { clear: false, hasSavedCredential: true });
+input.attrs.value = input.value;
+assert(input.value === '', 'hydration with a saved credential must clear the input');
+assert(!inputContainsSecret(input, SENTINEL), 'hydration reintroduced the sentinel');
+console.log('PASS hydration-never-repopulates');
+passed += 1;
+
+input.value = SENTINEL;
+input.placeholder = 'Enter key';
+input.attrs.value = SENTINEL;
+applyApiKeyInputSafety(input, { clear: false, hasSavedCredential: false });
+assert(input.value === SENTINEL, 'failed test/save must retain the typed value for correction');
+console.log('PASS failure-retains-input');
+passed += 1;
 
 assert(presentStepOutcome('complete', true) === 'success', 'complete must present success');
 assert(presentStepOutcome('running', true) === 'progress', '#27 running must present progress, not error');
@@ -66,10 +117,13 @@ passed += 1;
 const wizardSource = readFileSync(resolve(themeRoot, 'src/ts/admin/wizard.ts'), 'utf8');
 assert(wizardSource.includes("from './wizard-helpers'"), 'wizard.ts must use the shared helpers');
 assert(wizardSource.includes('presentStepOutcome'), 'wizard.ts must consult presentStepOutcome');
-assert(wizardSource.includes('summarizeDependencyResult'), 'wizard.ts must summarize dependency results');
-assert(wizardSource.includes('is still in progress'), 'wizard.ts must keep running as progress');
-assert(!wizardSource.includes('applyApiKeyInputSafety'), 'issue #22 must not include credential clearing');
+assert(wizardSource.includes('applyApiKeyInputSafety'), 'wizard.ts must clear credentials through the helper');
+assert(wizardSource.includes('is still in progress'), 'wizard.ts must keep #27 running as progress');
 console.log('PASS production-wiring');
+passed += 1;
+
+assert(!successSnapshot.includes(SENTINEL), 'stored success snapshot leaked sentinel');
+console.log('PASS no-sentinel-in-success-snapshot');
 passed += 1;
 
 console.log(`Harness passed: ${passed} scenarios.`);

--- a/tests/wizard-credential-dom-safety-harness.php
+++ b/tests/wizard-credential-dom-safety-harness.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Focused production-path harness for issue #25 (credential DOM / response safety).
+ *
+ * Sentinel-only. Never uses a real API key.
+ *
+ * Usage: php tests/wizard-credential-dom-safety-harness.php
+ */
+
+if ( PHP_SAPI !== 'cli' ) {
+	fwrite( STDERR, "CLI only.\n" );
+	exit( 1 );
+}
+
+const RMS_HARNESS_SENTINEL = 'rms-sentinel-not-a-real-key-22f25';
+
+/**
+ * @param mixed $condition
+ */
+function rms_harness_assert( $condition, string $message ): void {
+	if ( ! $condition ) {
+		fwrite( STDERR, $message . "\n" );
+		exit( 1 );
+	}
+}
+
+function rms_harness_contains_sentinel( $value ): bool {
+	return false !== strpos( wp_json_encode( $value ), RMS_HARNESS_SENTINEL );
+}
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$GLOBALS['rms_harness'] = array(
+	'options' => array(),
+);
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) {
+		return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', (string) $key ) );
+	}
+}
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $value ) {
+		return trim( (string) $value );
+	}
+}
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = '' ) {
+		return $text;
+	}
+}
+if ( ! function_exists( 'current_time' ) ) {
+	function current_time( $type = 'mysql', $gmt = false ) {
+		return '2026-08-24 00:00:00';
+	}
+}
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $key, $default = false ) {
+		return $GLOBALS['rms_harness']['options'][ $key ] ?? $default;
+	}
+}
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( $key, $value, $autoload = true ) {
+		$GLOBALS['rms_harness']['options'][ $key ] = $value;
+		return true;
+	}
+}
+if ( ! function_exists( 'delete_option' ) ) {
+	function delete_option( $key ) {
+		unset( $GLOBALS['rms_harness']['options'][ $key ] );
+		return true;
+	}
+}
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value ) {
+		return json_encode( $value );
+	}
+}
+if ( ! function_exists( 'wp_salt' ) ) {
+	function wp_salt( $scheme = 'auth' ) {
+		return 'harness-salt-' . $scheme;
+	}
+}
+
+$root = dirname( __DIR__ );
+require_once $root . '/inc/wizard/class-logger.php';
+require_once $root . '/inc/wizard/class-ai-credential-store.php';
+
+$passed = 0;
+
+$logger = new Inc\Wizard\Logger();
+$entry  = $logger->log(
+	'info',
+	'Provider test completed.',
+	array(
+		'provider' => 'openai',
+		'api_key'  => RMS_HARNESS_SENTINEL,
+		'nested'   => array( 'authorization' => RMS_HARNESS_SENTINEL ),
+	)
+);
+rms_harness_assert( ! rms_harness_contains_sentinel( $entry ), 'log entry leaked sentinel' );
+rms_harness_assert( ! rms_harness_contains_sentinel( $logger->all() ), 'stored logs leaked sentinel' );
+rms_harness_assert( '[redacted]' === ( $entry['context']['api_key'] ?? null ), 'api_key context was not redacted' );
+rms_harness_assert( '[redacted]' === ( $entry['context']['nested']['authorization'] ?? null ), 'nested authorization was not redacted' );
+echo "PASS logger-redacts-sentinel\n";
+$passed++;
+
+$option = Inc\Wizard\AI_Credential_Store::OPTION_PREFIX . 'openai';
+$GLOBALS['rms_harness']['options'][ $option ] = 'openssl:dGVzdC1jaXBoZXJ0ZXh0LW5vdC1hLXNlbnRpbmVs';
+$status = Inc\Wizard\AI_Credential_Store::status( 'openai' );
+rms_harness_assert( true === $status['has_key'], 'saved key must report has_key true' );
+rms_harness_assert( ! rms_harness_contains_sentinel( $status ), 'status payload leaked sentinel' );
+rms_harness_assert( ! array_key_exists( 'api_key', $status ), 'status must not expose api_key field' );
+
+$models_response = array(
+	'success'    => true,
+	'provider'   => 'openai',
+	'models'     => array( array( 'id' => 'gpt-test', 'label' => 'GPT Test' ) ),
+	'credential' => $status,
+);
+$save_response = array(
+	'success' => true,
+	'step'    => 'ia-generation',
+	'result'  => array(
+		'ai_config' => array(
+			'provider'        => 'openai',
+			'model'           => 'gpt-test',
+			'credential'      => $status,
+			'has_credentials' => true,
+		),
+	),
+);
+rms_harness_assert( ! rms_harness_contains_sentinel( $models_response ), 'models response leaked sentinel' );
+rms_harness_assert( ! rms_harness_contains_sentinel( $save_response ), 'save response leaked sentinel' );
+echo "PASS responses-masked\n";
+$passed++;
+
+$markup = (string) file_get_contents( $root . '/inc/wizard/wizard-init.php' );
+rms_harness_assert( false !== strpos( $markup, 'name="api_key"' ), 'IA form is missing the api_key input' );
+rms_harness_assert( false === strpos( $markup, 'data-api-key' ), 'IA form must not expose a data-api-key attribute' );
+	rms_harness_assert( 1 !== preg_match( '/name="api_key"[^>]*value="/', $markup ), 'IA form must not hydrate a value attribute' );
+rms_harness_assert( false !== strpos( $markup, 'Leave blank to use the saved encrypted key' ), 'IA form is missing the saved-key placeholder' );
+echo "PASS markup-has-no-secret-value\n";
+$passed++;
+
+echo "Harness passed: {$passed} scenarios.\n";
+exit( 0 );


### PR DESCRIPTION
Fixes #25

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Logger recursively redacts secret-bearing context keys before persistence.
- API-key input is cleared after successful Test/Load and IA save, hydrated without plaintext, and retained on failure for correction.
- Credential harness and full client truth assertions cover sentinel-only secret handling.

## Changes

| File | Change |
|------|--------|
| `inc/wizard/class-logger.php` | Recursive redaction of secret context keys. |
| `src/ts/admin/wizard-helpers.ts` | API-key input safety helper (preserves #22 outcome/dependency helpers). |
| `src/ts/admin/wizard.ts` | Test/Load + IA success clearing, hydration, and failure retention. |
| `tests/wizard-credential-dom-safety-harness.php` | Sentinel-only #25 PHP harness. |
| `tests/wizard-client-truth-harness.mjs` | Full client truth including credential assertions. |

## Test Plan
- [x] `php -l` passed on authored PHP files.
- [x] `php tests/wizard-credential-dom-safety-harness.php` — 3/3 PASS.
- [x] `node tests/wizard-client-truth-harness.mjs` — 8/8 PASS (full client truth).
- [x] `php tests/wizard-dependency-truth-harness.php` — 10/10 PASS (#22 still green).
- [x] `npm run build` (`tsc && vite build`) passed.
- [x] Sentinel-only secret scan: only `rms-sentinel-not-a-real-key-22f25` in this slice.
- [x] Diff against `fix/wizard-dependency-truth` contains only the #25 slice.
- [x] Scripts run without errors: N/A — no shell scripts in this PR.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts: N/A — no shell scripts
- [x] Skills tested in at least one agent: N/A — wizard runtime fix, not a skill change
- [x] Docs updated if behavior changed: N/A
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Chain Context

| Field | Value |
|-------|-------|
| Chain | wizard-setup beta issues #22–#29 |
| Tracker PR | Not needed — retained `feature/wizard-setup` @ `3205ee5` |
| Position | 6 of 11 |
| Base | `fix/wizard-dependency-truth` |
| Depends on | PR #34 / #22 |
| Follow-up | Planned: `feat/home-seo-backend` (#26 backend) |
| Review budget | 326 / 400 |
| Starts at | `fix/wizard-dependency-truth` |
| Ends with | Plaintext API keys cleared after save; logs redact secrets |

### Chain Overview

```text
feature/wizard-setup
 └── #30 docs/vite-manifest-checklist  (#24)
      └── #31 fix/acf-inactive-frontend-guard  (#23)
           └── #32 fix/footer-variant-runtime  (#28)
                └── #33 fix/palette-runtime-css  (#29)
                     └── #34 fix/wizard-dependency-truth  (#22)
                          └── 📍 fix/wizard-credential-dom  (#25)
                               └── planned feat/home-seo-backend  (#26 backend)
```

### Scope
- Includes: logger redaction, API-key DOM safety, credential harness, full client truth.
- Excludes: #26 Home SEO, #27 landing runtime.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit
