### PR TITLE
feat(wizard): persist homepage SEO targeting into generation

### DIFF
--- a/docs/wizard-ai-content.md
+++ b/docs/wizard-ai-content.md
@@ -14,7 +14,7 @@ The wizard is orchestrated by `Inc\Wizard\Step_Controller` and currently runs th
 | `generate-pages` | Create selected WordPress pages. |
 | `menu-setup` | Build menu assignments. |
 | `ia-generation` | Store AI provider/model/key configuration. |
-| `home-page-builder` | Generate and save Home page flexible content sections. |
+| `home-page-builder` | Generate and save Home page flexible content sections. Optional page-level SEO targeting can add editorial keyword intent to Hero and SEO Content only. |
 
 State is stored in `wp_options` through `Inc\Wizard\State_Manager`.
 
@@ -53,6 +53,16 @@ The reviewer runs after JSON decode and before final validation. If review fails
 | `AI_Content_Harness` | Source of truth for generation prompts, fillable fields, blocked fields, text repeater rules, and shared editorial rules. |
 | `AI_Content_Reviewer` | Diagnosis-first quality review, rewrite guidance, cross-section repetition checks, and dev-only quality report. |
 | `Step_Home_Page_Builder` | Runtime orchestration, request-scoped prior section context, kill-switch handling, fallback, and bounded logging. |
+
+## Homepage SEO targeting
+
+Home Page Builder can optionally declare a primary keyword and up to ten secondary keywords. The control is off by default.
+
+- Disabled mode keeps the current neutral Home generation prompts and does not persist stale keyword values.
+- Enabled mode requires a normalized primary keyword. Keywords are editorial intent, not evidence, and must not invent services, locations, credentials, guarantees, statistics, or other business facts.
+- Keyword context is injected only into Hero and SEO Content generation and review. About, testimonials, FAQ, portfolio, trust, and other reusable sections stay on their own purpose plus trusted client facts.
+- Declared homepage keyword intent is excluded from the canonical reusable-section store and from neutral prior-section context.
+- This path does not write Yoast focus keyphrase, title, or meta description. Landing Page Builder keyword behavior is unchanged.
 
 ## Current quality principles
 

--- a/inc/wizard/class-ai-content-harness.php
+++ b/inc/wizard/class-ai-content-harness.php
@@ -380,7 +380,7 @@ PROMPT;
 	}
 
 	/**
-	 * Whether a layout may consume landing keyword placeholders.
+	 * Whether a layout may consume declared keyword intent (Hero / SEO Content only).
 	 */
 	public function is_keyword_layout( string $layout ): bool {
 		return in_array( $this->normalize_layout_key( $layout ), self::KEYWORD_LAYOUTS, true );
@@ -426,6 +426,56 @@ PROMPT;
 			}
 		}
 
+			return [
+			'primary_keyword' => $primary,
+			'subkeywords'     => $subkeywords,
+		];
+	}
+
+	/**
+	 * Normalize homepage SEO keywords: collapse whitespace, drop empties,
+	 * case-insensitive de-dupe (first wins), and clamp secondaries to 0–10.
+	 *
+	 * @param array<string,mixed> $keywords Raw keyword payload.
+	 *
+	 * @return array{primary_keyword:string,subkeywords:string[]}
+	 */
+	public function normalize_home_seo_keywords( array $keywords ): array {
+		$primary = $this->collapse_keyword( (string) ( $keywords['primary_keyword'] ?? $keywords['keyword'] ?? '' ) );
+		$raw     = $keywords['secondary_keywords'] ?? $keywords['subkeywords'] ?? $keywords['sub_keywords'] ?? [];
+
+		if ( is_string( $raw ) ) {
+			$raw = preg_split( '/[\n,]+/', $raw ) ?: [];
+		}
+
+		$subkeywords = [];
+		$seen        = [];
+
+		if ( '' !== $primary ) {
+			$seen[ $this->keyword_identity( $primary ) ] = true;
+		}
+
+		foreach ( is_array( $raw ) ? $raw : [] as $item ) {
+			$item = $this->collapse_keyword( (string) $item );
+
+			if ( '' === $item ) {
+				continue;
+			}
+
+			$identity = $this->keyword_identity( $item );
+
+			if ( isset( $seen[ $identity ] ) ) {
+				continue;
+			}
+
+			$seen[ $identity ] = true;
+			$subkeywords[]     = $item;
+
+			if ( count( $subkeywords ) >= 10 ) {
+				break;
+			}
+		}
+
 		return [
 			'primary_keyword' => $primary,
 			'subkeywords'     => $subkeywords,
@@ -433,8 +483,121 @@ PROMPT;
 	}
 
 	/**
+	 * Parse the Home Page Builder SEO-targeting payload.
+	 *
+	 * Disabled mode returns only `{ enabled: false }` so stale keywords cannot persist.
+	 *
+	 * @param array<string,mixed> $payload Step payload or nested seo_targeting object.
+	 *
+	 * @return array{enabled:bool,primary_keyword?:string,secondary_keywords?:string[]}|\WP_Error
+	 */
+	public function normalize_home_seo_intent( array $payload ) {
+		$raw     = is_array( $payload['seo_targeting'] ?? null ) ? $payload['seo_targeting'] : $payload;
+		$enabled = $this->is_truthy( $raw['enabled'] ?? $payload['seo_targeting_enabled'] ?? false );
+
+		if ( ! $enabled ) {
+			return [ 'enabled' => false ];
+		}
+
+		$normalized = $this->normalize_home_seo_keywords(
+			[
+				'primary_keyword'     => $raw['primary_keyword'] ?? $payload['primary_keyword'] ?? '',
+				'secondary_keywords'  => $raw['secondary_keywords'] ?? $raw['subkeywords'] ?? $payload['secondary_keywords'] ?? $payload['subkeywords'] ?? [],
+			]
+		);
+
+		if ( '' === $normalized['primary_keyword'] ) {
+			return new \WP_Error(
+				'rms_wizard_home_seo_primary_required',
+				\__( 'Enter a primary keyword before generating with SEO targeting enabled.', 'simple-rms-theme' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		return [
+			'enabled'             => true,
+			'primary_keyword'     => $normalized['primary_keyword'],
+			'secondary_keywords'  => $normalized['subkeywords'],
+		];
+	}
+
+	/**
+	 * Persistable homepage SEO intent. Disabled mode stores no keyword values.
+	 *
+	 * @param array<string,mixed> $intent Normalized intent from normalize_home_seo_intent().
+	 *
+	 * @return array{enabled:bool,primary_keyword?:string,secondary_keywords?:string[]}
+	 */
+	public function persist_home_seo_intent( array $intent ): array {
+		if ( empty( $intent['enabled'] ) ) {
+			return [ 'enabled' => false ];
+		}
+
+		return [
+			'enabled'            => true,
+			'primary_keyword'    => (string) ( $intent['primary_keyword'] ?? '' ),
+			'secondary_keywords' => array_values( is_array( $intent['secondary_keywords'] ?? null ) ? $intent['secondary_keywords'] : [] ),
+		];
+	}
+
+	/**
+	 * Keyword payload for one homepage layout, or empty when targeting is off / out of scope.
+	 *
+	 * @param array<string,mixed> $intent Normalized homepage SEO intent.
+	 *
+	 * @return array{primary_keyword:string,subkeywords:string[]}|array{}
+	 */
+	public function home_seo_keywords_for_layout( array $intent, string $layout ): array {
+		if ( empty( $intent['enabled'] ) || ! $this->is_keyword_layout( $layout ) ) {
+			return [];
+		}
+
+		$primary = trim( (string) ( $intent['primary_keyword'] ?? '' ) );
+
+		if ( '' === $primary ) {
+			return [];
+		}
+
+		$secondary = is_array( $intent['secondary_keywords'] ?? null ) ? $intent['secondary_keywords'] : [];
+
+		return [
+			'primary_keyword' => $primary,
+			'subkeywords'     => array_values( array_map( 'strval', $secondary ) ),
+		];
+	}
+
+	/**
+	 * Drop keyword-driven layouts from prior-section context used by neutral sections.
+	 *
+	 * @param array<int,mixed> $priors Prior section payloads.
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	public function filter_neutral_priors( array $priors ): array {
+		$neutral = [];
+
+		foreach ( $priors as $prior ) {
+			if ( ! is_array( $prior ) ) {
+				continue;
+			}
+
+			$layout = $this->normalize_layout_key( (string) ( $prior['layout'] ?? '' ) );
+
+			if ( '' === $layout || $this->is_keyword_layout( $layout ) ) {
+				continue;
+			}
+
+			$neutral[] = $prior;
+		}
+
+		return $neutral;
+	}
+
+	/**
 	 * @param array<string,mixed> $client_context Approved client context.
-	 * @param array<string,mixed> $keywords       Optional landing keywords (PAGE_LANDING only).
+	 * @param array<string,mixed> $keywords       Optional keywords. Landing uses PAGE_LANDING + keyword layouts.
+	 *                                            Homepage injects only when PAGE_HOME, layout is keyword-eligible,
+	 *                                            and a primary keyword is present.
 	 */
 	public function get_layer3( string $layout, int $item_count, array $client_context, string $page_type = self::PAGE_HOME, array $keywords = [] ): string {
 		$layout        = $this->normalize_layout_key( $layout );
@@ -444,19 +607,35 @@ PROMPT;
 		$client_json   = false === $client_json ? '{}' : $client_json;
 		$service_rules = isset( self::SERVICE_DESCRIPTION_FIELDS[ $layout ] ) ? sprintf( ' For service repeaters, preserve the order of client_json.company_services. Service names/titles and service-specific benefits must come only from company_services[].service_name and service_short_description; return descriptions only in %s.', (string) self::SERVICE_DESCRIPTION_FIELDS[ $layout ]['description'] ) : '';
 		$layout_rules  = $this->layout_rules( $layout, $item_count );
-		$normalized    = $this->normalize_keywords( $keywords );
-		$inject_kw     = self::PAGE_LANDING === $page_type && $this->is_keyword_layout( $layout );
-		$primary       = $inject_kw ? $normalized['primary_keyword'] : '';
-		$subkeywords   = $inject_kw ? implode( ', ', $normalized['subkeywords'] ) : '';
-		$keyword_block = '';
+		$inject_landing = self::PAGE_LANDING === $page_type && $this->is_keyword_layout( $layout );
+		$home_keywords  = $this->normalize_home_seo_keywords( $keywords );
+		$inject_home    = self::PAGE_HOME === $page_type && $this->is_keyword_layout( $layout ) && '' !== $home_keywords['primary_keyword'];
+		$normalized     = [ 'primary_keyword' => '', 'subkeywords' => [] ];
+		$primary        = '';
+		$subkeywords    = '';
+		$keyword_block  = '';
 
-		if ( $inject_kw ) {
+		if ( $inject_landing ) {
+			$normalized    = $this->normalize_keywords( $keywords );
+			$primary       = $normalized['primary_keyword'];
+			$subkeywords   = implode( ', ', $normalized['subkeywords'] );
 			$keyword_block = "\n\nKEYWORD CONTEXT (mandatory for this section only):\n"
 				. '- Primary keyword: {{primary_keyword}}' . "\n"
 				. '- Subkeywords: {{subkeywords}}' . "\n"
 				. "- Naturally incorporate the primary keyword in headlines and body copy where it fits.\n"
 				. "- Use subkeywords sparingly and only when natural. Do not keyword-stuff.\n"
 				. "- Do not invent services, locations, or proof to force keyword usage.";
+		} elseif ( $inject_home ) {
+			$normalized    = $home_keywords;
+			$primary       = $normalized['primary_keyword'];
+			$subkeywords   = implode( ', ', $normalized['subkeywords'] );
+			$keyword_block = "\n\nKEYWORD INTENT (editorial only, this section only):\n"
+				. '- Primary keyword: ' . ( '' !== $primary ? $primary : '(none provided)' ) . "\n"
+				. '- Secondary keywords: ' . ( '' !== $subkeywords ? $subkeywords : '(none)' ) . "\n"
+				. "- Keywords are editorial search intent, never evidence.\n"
+				. "- Do not invent services, locations, credentials, guarantees, statistics, or other business facts to force keyword usage.\n"
+				. "- Naturally incorporate the primary keyword in headlines and body copy only where it fits trusted client facts.\n"
+				. "- Use secondary keywords sparingly and only when natural. Do not keyword-stuff.";
 		}
 
 		$template = "Layout: {{layout}}\nRequested item count: {{item_count}}\nAllowed JSON keys: {{fillable_fields}}\nBlocked JSON keys: {{blocked_fields}}\nClient JSON: {{client_json}}\nReturn one compact JSON object using only allowed keys. Do not include blocked or unknown keys.{{service_rules}}\n\n{{layout_rules}}{{keyword_block}}";
@@ -884,5 +1063,37 @@ RULES,
 
 	private function log_warning( string $message ): void {
 		\error_log( '[Simple RMS Wizard] ' . $message );
+	}
+
+	private function collapse_keyword( string $value ): string {
+		$value = preg_replace( '/\s+/u', ' ', $value );
+		$value = is_string( $value ) ? $value : '';
+
+		return trim( \sanitize_text_field( $value ) );
+	}
+
+	private function keyword_identity( string $value ): string {
+		return function_exists( 'mb_strtolower' ) ? mb_strtolower( $value, 'UTF-8' ) : strtolower( $value );
+	}
+
+	/**
+	 * @param mixed $value Raw flag.
+	 */
+	private function is_truthy( $value ): bool {
+		if ( is_bool( $value ) ) {
+			return $value;
+		}
+
+		if ( is_int( $value ) ) {
+			return 0 !== $value;
+		}
+
+		if ( is_string( $value ) ) {
+			$value = strtolower( trim( $value ) );
+
+			return in_array( $value, [ '1', 'true', 'on', 'yes' ], true );
+		}
+
+		return ! empty( $value );
 	}
 }

--- a/inc/wizard/class-ai-content-reviewer.php
+++ b/inc/wizard/class-ai-content-reviewer.php
@@ -274,25 +274,55 @@ PROMPT;
 	private function json_prompt( string $instruction, string $layout, array $payload, array $prior_sections, array $ai_config, array $directives ): string {
 		$client_context = is_array( $ai_config['client_context'] ?? null ) ? $ai_config['client_context'] : [];
 
-		$data = [
-			'instruction'          => $instruction,
-			'layout'               => $layout,
-			'allowed_keys'         => $this->harness->get_fillable_fields( $layout ),
-			'harness_rules'        => AI_Content_Harness::get_editorial_rules( $layout ),
-			'trusted_client_context' => $client_context,
-			'current_payload'      => $payload,
-			'prior_sections'       => array_values( $prior_sections ),
-			'rewrite_directives'   => $directives,
-			'output_contract'      => 'Return one JSON object using only allowed_keys. Preserve valid fields unless a directive requires change.',
-			'negative_constraints' => 'Do not invent facts, URLs, media, credentials, years, guarantees, brands, licenses, bilingual service, special equipment, statistics, service areas, reviews, keys, repeater subfields, or services absent from trusted_client_context.company_services.',
-		];
+			$data = [
+				'instruction'          => $instruction,
+				'layout'               => $layout,
+				'allowed_keys'         => $this->harness->get_fillable_fields( $layout ),
+				'harness_rules'        => AI_Content_Harness::get_editorial_rules( $layout ),
+				'trusted_client_context' => $client_context,
+				'current_payload'      => $payload,
+				'prior_sections'       => array_values( $prior_sections ),
+				'rewrite_directives'   => $directives,
+				'output_contract'      => 'Return one JSON object using only allowed_keys. Preserve valid fields unless a directive requires change.',
+				'negative_constraints' => 'Do not invent facts, URLs, media, credentials, years, guarantees, brands, licenses, bilingual service, special equipment, statistics, service areas, reviews, keys, repeater subfields, or services absent from trusted_client_context.company_services.',
+			];
+
+			$keyword_intent = $this->declared_keyword_intent( $ai_config );
+
+			if ( [] !== $keyword_intent ) {
+				$data['declared_keyword_intent'] = $keyword_intent;
+			}
 
 		$json = \wp_json_encode( $data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 
 		return false === $json ? '{}' : $json;
 	}
 
-	private function decode_json( string $content ): array {
+		/**
+		 * @param array<string,mixed> $ai_config Review config.
+		 *
+		 * @return array<string,mixed>
+		 */
+		private function declared_keyword_intent( array $ai_config ): array {
+			$raw = is_array( $ai_config['keyword_intent'] ?? null ) ? $ai_config['keyword_intent'] : [];
+			$primary = trim( (string) ( $raw['primary_keyword'] ?? '' ) );
+
+			if ( '' === $primary ) {
+				return [];
+			}
+
+			$secondary = is_array( $raw['secondary_keywords'] ?? null )
+				? $raw['secondary_keywords']
+				: ( is_array( $raw['subkeywords'] ?? null ) ? $raw['subkeywords'] : [] );
+
+			return [
+				'primary_keyword'     => $primary,
+				'secondary_keywords'  => array_values( array_map( 'strval', $secondary ) ),
+				'role'                => 'Editorial search intent for this homepage section only. Not evidence. Distinguish natural target-keyword usage from keyword stuffing and flag intent mismatch. Do not invent services, locations, credentials, guarantees, statistics, or business facts.',
+			];
+		}
+
+		private function decode_json( string $content ): array {
 		$content = trim( preg_replace( '/^```(?:json)?|```$/m', '', $content ) ?? $content );
 		$data    = json_decode( $content, true );
 

--- a/inc/wizard/class-state-manager.php
+++ b/inc/wizard/class-state-manager.php
@@ -36,6 +36,7 @@ class State_Manager {
             'menu_config'            => [],
             'selected_home_sections' => [],
             'home_sections'          => [],
+            'home_seo_targeting'     => [ 'enabled' => false ],
             'landing_pages'          => [],
             'canonical_sections'     => [],
             'logs'                   => self::LOG_OPTION,

--- a/inc/wizard/class-step-home-page-builder.php
+++ b/inc/wizard/class-step-home-page-builder.php
@@ -44,13 +44,21 @@ class Step_Home_Page_Builder {
 		$section_rows = $this->selected_section_rows( $payload );
 		$sections     = array_column( $section_rows, 'layout' );
 
-		if ( [] === $sections ) {
-			$this->state_manager->set_step_status( self::STEP, 'failed' );
+			if ( [] === $sections ) {
+				$this->state_manager->set_step_status( self::STEP, 'failed' );
 
-			return new \WP_Error( 'rms_wizard_home_sections_required', \__( 'Select at least one section for the Home page', 'simple-rms-theme' ), [ 'status' => 400 ] );
-		}
+				return new \WP_Error( 'rms_wizard_home_sections_required', \__( 'Select at least one section for the Home page', 'simple-rms-theme' ), [ 'status' => 400 ] );
+			}
 
-		$state     = $this->state_manager->get_state();
+			$seo_intent = $this->harness->normalize_home_seo_intent( $payload );
+
+			if ( \is_wp_error( $seo_intent ) ) {
+				$this->state_manager->set_step_status( self::STEP, 'failed' );
+
+				return $seo_intent;
+			}
+
+			$state     = $this->state_manager->get_state();
 		$ai_config = is_array( $state['ai_config'] ?? null ) ? $state['ai_config'] : [];
 
 		if ( ! $this->has_ai_config( $ai_config ) ) {
@@ -88,17 +96,17 @@ class Step_Home_Page_Builder {
 		$prepared_sections      = [];
 		$prior_section_payloads = [];
 
-		foreach ( $section_rows as $row ) {
-			$section_key         = (string) $row['layout'];
-			$item_count          = (int) $row['item_count'];
-			$overrides           = $this->generate_section_overrides( $section_key, $item_count, $client_context, $ai_config, $prior_section_payloads );
-			$prepared_sections[] = $this->content_builder->prepare_image_fallbacks( $this->section_data( $section_key, $client_data, $overrides, $item_count ) );
-			$prior_section_payloads[] = [
-				'layout'     => $section_key,
-				'item_count' => $item_count,
-				'payload'    => $overrides,
-			];
-		}
+			foreach ( $section_rows as $row ) {
+				$section_key         = (string) $row['layout'];
+				$item_count          = (int) $row['item_count'];
+				$overrides           = $this->generate_section_overrides( $section_key, $item_count, $client_context, $ai_config, $prior_section_payloads, $seo_intent );
+				$prepared_sections[] = $this->content_builder->prepare_image_fallbacks( $this->section_data( $section_key, $client_data, $overrides, $item_count ) );
+				$prior_section_payloads[] = [
+					'layout'     => $section_key,
+					'item_count' => $item_count,
+					'payload'    => $overrides,
+				];
+			}
 
 		$post_id = $this->content_builder->build_page(
 			[
@@ -114,18 +122,20 @@ class Step_Home_Page_Builder {
 			return new \WP_Error( 'rms_wizard_home_page_save_failed', \__( 'Home page sections could not be saved.', 'simple-rms-theme' ), [ 'status' => 500 ] );
 		}
 
-		$state['selected_home_sections'] = $sections;
-		$state['home_section_rows']      = $section_rows;
-		$state['home_sections']          = $prepared_sections;
-		$state['canonical_sections']     = $this->first_write_canonical_sections( $prepared_sections );
+			$seo_state                       = $this->harness->persist_home_seo_intent( $seo_intent );
+			$state['selected_home_sections'] = $sections;
+			$state['home_section_rows']      = $section_rows;
+			$state['home_sections']          = $prepared_sections;
+			$state['home_seo_targeting']     = $seo_state;
+			$state['canonical_sections']     = $this->first_write_canonical_sections( $prepared_sections );
 
-		$this->state_manager->save_state( $state );
-		$this->state_manager->set_step_status( self::STEP, 'complete' );
-		$this->maybe_mark_completed();
-		$this->logger->log( 'info', 'Wizard Home page sections built.', [ 'post_id' => $post_id, 'sections' => $sections ] );
+			$this->state_manager->save_state( $state );
+			$this->state_manager->set_step_status( self::STEP, 'complete' );
+			$this->maybe_mark_completed();
+			$this->logger->log( 'info', 'Wizard Home page sections built.', [ 'post_id' => $post_id, 'sections' => $sections ] );
 
-		return [ 'post_id' => $post_id, 'sections' => $sections ];
-	}
+			return [ 'post_id' => $post_id, 'sections' => $sections, 'seo_targeting' => $seo_state ];
+		}
 
 	/**
 	 * First-write reusable prepared rows into the canonical store.
@@ -257,59 +267,67 @@ class Step_Home_Page_Builder {
 		return $post ? (int) $post->ID : 0;
 	}
 
-	private function generate_section_overrides( string $section_key, int $item_count, array $client_context, array $ai_config, array $prior_section_payloads = [] ): array {
-		$fillable = $this->harness->get_fillable_fields( $section_key );
+		private function generate_section_overrides( string $section_key, int $item_count, array $client_context, array $ai_config, array $prior_section_payloads = [], array $seo_intent = [] ): array {
+			$fillable = $this->harness->get_fillable_fields( $section_key );
 
-		// Layouts with no AI-editable text fields intentionally skip the provider call.
-		if ( [] === $fillable ) {
-			$this->logger->log( 'info', 'Skipping AI generation for layout with no fillable fields.', [ 'section' => $section_key ] );
+			// Layouts with no AI-editable text fields intentionally skip the provider call.
+			if ( [] === $fillable ) {
+				$this->logger->log( 'info', 'Skipping AI generation for layout with no fillable fields.', [ 'section' => $section_key ] );
 
-			return [];
+				return [];
+			}
+
+			$keywords      = $this->harness->home_seo_keywords_for_layout( $seo_intent, $section_key );
+			$review_priors = $this->harness->is_keyword_layout( $section_key )
+				? $prior_section_payloads
+				: $this->harness->filter_neutral_priors( $prior_section_payloads );
+			$provider      = \sanitize_key( (string) $ai_config['provider'] );
+			$model         = \sanitize_text_field( (string) $ai_config['model'] );
+			$system        = $this->harness->get_layer1() . "\n\n" . $this->harness->get_layer2( AI_Content_Harness::PAGE_HOME );
+			$prompt        = $this->harness->get_layer3( $section_key, $item_count, $client_context, AI_Content_Harness::PAGE_HOME, $keywords );
+			$result        = AI_Provider_Registry::make_provider( $provider )->generate(
+				$model,
+				$prompt,
+				[
+					'section_key' => $section_key,
+					'client_data' => $client_context,
+					'item_count'  => $item_count,
+				],
+				$system
+			);
+
+			if ( empty( $result['success'] ) || empty( $result['content'] ) ) {
+				$this->logger->log( 'warning', 'Wizard Home section AI generation failed; fallback content used.', [ 'section' => $section_key, 'error' => $result['error'] ?? '' ] );
+
+				return [];
+			}
+
+			$decoded = $this->decode_json_content( (string) $result['content'] );
+
+			if ( [] === $decoded ) {
+				return [];
+			}
+
+			$reviewed = $this->review_section_content( $section_key, $decoded, $review_priors, $ai_config, $client_context, $item_count, $keywords );
+
+			return $this->harness->validate_fields( $section_key, $reviewed );
 		}
 
-		$provider = \sanitize_key( (string) $ai_config['provider'] );
-		$model    = \sanitize_text_field( (string) $ai_config['model'] );
-		$system   = $this->harness->get_layer1() . "\n\n" . $this->harness->get_layer2( AI_Content_Harness::PAGE_HOME );
-		$prompt   = $this->harness->get_layer3( $section_key, $item_count, $client_context );
-		$result   = AI_Provider_Registry::make_provider( $provider )->generate(
-			$model,
-			$prompt,
-			[
-				'section_key' => $section_key,
-				'client_data' => $client_context,
-				'item_count'  => $item_count,
-			],
-			$system
-		);
+		private function review_section_content( string $section_key, array $decoded, array $prior_section_payloads, array $ai_config, array $client_context, int $item_count, array $keywords = [] ): array {
+			if ( ! $this->is_review_enabled() ) {
+				return $decoded;
+			}
 
-		if ( empty( $result['success'] ) || empty( $result['content'] ) ) {
-			$this->logger->log( 'warning', 'Wizard Home section AI generation failed; fallback content used.', [ 'section' => $section_key, 'error' => $result['error'] ?? '' ] );
+			$review_config                   = $ai_config;
+			$review_config['client_context'] = $client_context;
+			$review_config['item_count']     = $item_count;
 
-			return [];
-		}
+			if ( '' !== trim( (string) ( $keywords['primary_keyword'] ?? '' ) ) ) {
+				$review_config['keyword_intent'] = $keywords;
+			}
 
-		$decoded = $this->decode_json_content( (string) $result['content'] );
-
-		if ( [] === $decoded ) {
-			return [];
-		}
-
-		$reviewed = $this->review_section_content( $section_key, $decoded, $prior_section_payloads, $ai_config, $client_context, $item_count );
-
-		return $this->harness->validate_fields( $section_key, $reviewed );
-	}
-
-	private function review_section_content( string $section_key, array $decoded, array $prior_section_payloads, array $ai_config, array $client_context, int $item_count ): array {
-		if ( ! $this->is_review_enabled() ) {
-			return $decoded;
-		}
-
-		$review_config                   = $ai_config;
-		$review_config['client_context'] = $client_context;
-		$review_config['item_count']     = $item_count;
-
-		try {
-			$result = $this->reviewer()->review( $section_key, $decoded, $prior_section_payloads, $review_config );
+			try {
+				$result = $this->reviewer()->review( $section_key, $decoded, $prior_section_payloads, $review_config );
 		} catch ( \Throwable $error ) {
 			unset( $error );
 			$this->log_review_result(

--- a/tests/wizard-home-seo-targeting-harness.php
+++ b/tests/wizard-home-seo-targeting-harness.php
@@ -1,0 +1,332 @@
+<?php
+/**
+ * Focused production-path harness for issue #26 (homepage SEO targeting).
+ *
+ * No framework. Proves disabled neutrality, enabled Hero/SEO scope, validation,
+ * normalization, stale-intent clearing, reviewer isolation, and landing invariance.
+ *
+ * Usage: php tests/wizard-home-seo-targeting-harness.php
+ */
+
+if ( PHP_SAPI !== 'cli' ) {
+	fwrite( STDERR, "CLI only.\n" );
+	exit( 1 );
+}
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! class_exists( 'WP_Error', false ) ) {
+	class WP_Error {
+		public $code;
+		public $message;
+		public $data;
+
+		public function __construct( $code = '', $message = '', $data = '' ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+
+		public function get_error_code() {
+			return $this->code;
+		}
+
+		public function get_error_message() {
+			return $this->message;
+		}
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $str ) {
+		$str = preg_replace( '/[\r\n\t]+/', ' ', (string) $str );
+		$str = preg_replace( '/\s+/', ' ', is_string( $str ) ? $str : '' );
+
+		return trim( strip_tags( is_string( $str ) ? $str : '' ) );
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) {
+		return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) ) );
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $options = 0 ) {
+		return json_encode( $data, $options );
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = null ) {
+		unset( $domain );
+
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $thing ) {
+		return $thing instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value ) {
+		unset( $hook );
+
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'wp_kses_post' ) ) {
+	function wp_kses_post( $value ) {
+		return (string) $value;
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/wizard/class-ai-content-harness.php';
+require_once dirname( __DIR__ ) . '/inc/wizard/class-ai-content-reviewer.php';
+
+use Inc\Wizard\AI_Content_Harness;
+use Inc\Wizard\AI_Content_Reviewer;
+
+/**
+ * @param mixed $condition
+ */
+function rms_home_seo_assert( $condition, string $message ): void {
+	if ( ! $condition ) {
+		fwrite( STDERR, $message . "\n" );
+		exit( 1 );
+	}
+}
+
+$harness  = new AI_Content_Harness();
+$reviewer = new AI_Content_Reviewer( $harness );
+$passed   = 0;
+$client   = [ 'company_name' => 'Acme Builders' ];
+
+$disabled_intent = $harness->normalize_home_seo_intent(
+	[
+		'seo_targeting' => [
+			'enabled'            => false,
+			'primary_keyword'    => 'stale deck builder',
+			'secondary_keywords' => [ 'old secondary' ],
+		],
+	]
+);
+rms_home_seo_assert( ! is_wp_error( $disabled_intent ), 'disabled intent should not error' );
+rms_home_seo_assert( [ 'enabled' => false ] === $disabled_intent, 'disabled intent must drop stale keywords' );
+$disabled_persist = $harness->persist_home_seo_intent( $disabled_intent );
+rms_home_seo_assert( [ 'enabled' => false ] === $disabled_persist, 'disabled persist must contain only enabled=false' );
+rms_home_seo_assert( ! array_key_exists( 'primary_keyword', $disabled_persist ), 'disabled persist leaked primary_keyword' );
+rms_home_seo_assert( ! array_key_exists( 'secondary_keywords', $disabled_persist ), 'disabled persist leaked secondary_keywords' );
+
+$disabled_hero = $harness->get_layer3( 'hero', 1, $client );
+$disabled_seo  = $harness->get_layer3( 'seo-content', 1, $client );
+foreach ( [ $disabled_hero, $disabled_seo ] as $prompt ) {
+	rms_home_seo_assert( false === strpos( $prompt, 'KEYWORD CONTEXT' ), 'disabled prompt leaked landing keyword context' );
+	rms_home_seo_assert( false === strpos( $prompt, 'KEYWORD INTENT' ), 'disabled prompt leaked homepage keyword intent' );
+	rms_home_seo_assert( false === strpos( $prompt, 'stale deck builder' ), 'disabled prompt leaked stale keyword' );
+}
+echo "PASS disabled-neutral-no-keyword-context\n";
+$passed++;
+
+$enabled = $harness->normalize_home_seo_intent(
+	[
+		'seo_targeting' => [
+			'enabled'            => true,
+			'primary_keyword'    => '  deck   builder  ',
+			'secondary_keywords' => [ 'custom decks', 'DECK BUILDER', 'composite decking', '', 'Custom Decks' ],
+		],
+	]
+);
+rms_home_seo_assert( ! is_wp_error( $enabled ), 'enabled intent should normalize' );
+rms_home_seo_assert( 'deck builder' === $enabled['primary_keyword'], 'primary whitespace was not collapsed' );
+rms_home_seo_assert( [ 'custom decks', 'composite decking' ] === $enabled['secondary_keywords'], 'secondary dedupe/clamp/order failed' );
+
+$hero_keywords = $harness->home_seo_keywords_for_layout( $enabled, 'hero' );
+$seo_keywords  = $harness->home_seo_keywords_for_layout( $enabled, 'seo-content' );
+$about_kw      = $harness->home_seo_keywords_for_layout( $enabled, 'about-us' );
+$faq_kw        = $harness->home_seo_keywords_for_layout( $enabled, 'faq-v1' );
+$trust_kw      = $harness->home_seo_keywords_for_layout( $enabled, 'testimonials-v1' );
+$portfolio_kw  = $harness->home_seo_keywords_for_layout( $enabled, 'portfolio-v1' );
+rms_home_seo_assert( 'deck builder' === ( $hero_keywords['primary_keyword'] ?? '' ), 'hero did not receive primary' );
+rms_home_seo_assert( 'deck builder' === ( $seo_keywords['primary_keyword'] ?? '' ), 'seo-content did not receive primary' );
+rms_home_seo_assert( [] === $about_kw && [] === $faq_kw && [] === $trust_kw && [] === $portfolio_kw, 'non-target layouts received keyword directives' );
+
+$hero_prompt  = $harness->get_layer3( 'hero', 1, $client, AI_Content_Harness::PAGE_HOME, $hero_keywords );
+$seo_prompt   = $harness->get_layer3( 'seo-content', 1, $client, AI_Content_Harness::PAGE_HOME, $seo_keywords );
+$about_prompt = $harness->get_layer3( 'about-us', 1, $client, AI_Content_Harness::PAGE_HOME, $hero_keywords );
+foreach ( [ $hero_prompt, $seo_prompt ] as $prompt ) {
+	rms_home_seo_assert( false !== strpos( $prompt, 'KEYWORD INTENT (editorial only, this section only)' ), 'targeted prompt missing editorial keyword block' );
+	rms_home_seo_assert( false !== strpos( $prompt, 'deck builder' ), 'targeted prompt missing primary keyword' );
+	rms_home_seo_assert( false !== strpos( $prompt, 'never evidence' ), 'targeted prompt missing non-evidence rule' );
+	rms_home_seo_assert( false !== strpos( $prompt, 'credentials, guarantees, statistics' ), 'targeted prompt missing invention ban' );
+	rms_home_seo_assert( false === strpos( $prompt, 'KEYWORD CONTEXT (mandatory for this section only)' ), 'homepage reused landing keyword contract' );
+}
+rms_home_seo_assert( false === strpos( $about_prompt, 'KEYWORD INTENT' ), 'about-us received keyword intent' );
+rms_home_seo_assert( false === strpos( $about_prompt, 'deck builder' ), 'about-us prompt contained the keyword' );
+echo "PASS enabled-scopes-only-hero-seo\n";
+$passed++;
+
+$missing = $harness->normalize_home_seo_intent(
+	[
+		'seo_targeting' => [
+			'enabled'            => true,
+			'primary_keyword'    => '   ',
+			'secondary_keywords' => [ 'custom decks' ],
+		],
+	]
+);
+rms_home_seo_assert( is_wp_error( $missing ), 'empty primary must reject' );
+rms_home_seo_assert( 'rms_wizard_home_seo_primary_required' === $missing->get_error_code(), 'unexpected missing-primary error code' );
+echo "PASS missing-primary-rejects\n";
+$passed++;
+
+$normalized = $harness->normalize_home_seo_keywords(
+	[
+		'primary_keyword'    => "\tdeck\tbuilder\n",
+		'secondary_keywords' => [
+			'  one  ',
+			'Two',
+			'two',
+			'',
+			'THREE',
+			'three',
+			'four',
+			'five',
+			'six',
+			'seven',
+			'eight',
+			'nine',
+			'ten',
+			'eleven',
+			'twelve',
+		],
+	]
+);
+rms_home_seo_assert( 'deck builder' === $normalized['primary_keyword'], 'primary collapse failed' );
+rms_home_seo_assert(
+	[ 'one', 'Two', 'THREE', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten' ] === $normalized['subkeywords'],
+	'secondary normalize/dedupe/clamp/order failed: ' . implode( '|', $normalized['subkeywords'] )
+);
+echo "PASS normalize-dedupe-clamp\n";
+$passed++;
+
+$rerun_disabled = $harness->normalize_home_seo_intent(
+	[
+		'seo_targeting' => [
+			'enabled'         => 0,
+			'primary_keyword' => 'changed later',
+		],
+	]
+);
+$rerun_persist = $harness->persist_home_seo_intent( $rerun_disabled );
+$rerun_keywords = $harness->home_seo_keywords_for_layout(
+	array_merge( [ 'primary_keyword' => 'stale deck builder' ], $rerun_persist ),
+	'hero'
+);
+$rerun_prompt = $harness->get_layer3( 'hero', 1, $client, AI_Content_Harness::PAGE_HOME, $rerun_keywords );
+rms_home_seo_assert( [] === $rerun_keywords, 'disabled rerun still produced keyword payload' );
+rms_home_seo_assert( false === strpos( $rerun_prompt, 'stale deck builder' ), 'disabled rerun kept stale keyword in prompt' );
+rms_home_seo_assert( false === strpos( $rerun_prompt, 'changed later' ), 'disabled rerun leaked submitted keyword' );
+echo "PASS rerun-disabled-clears-stale-intent\n";
+$passed++;
+
+$changed = $harness->normalize_home_seo_intent(
+	[
+		'seo_targeting' => [
+			'enabled'         => true,
+			'primary_keyword' => 'composite decking contractor',
+		],
+	]
+);
+$changed_keywords = $harness->home_seo_keywords_for_layout( $changed, 'hero' );
+$changed_prompt   = $harness->get_layer3( 'hero', 1, $client, AI_Content_Harness::PAGE_HOME, $changed_keywords );
+rms_home_seo_assert( false !== strpos( $changed_prompt, 'composite decking contractor' ), 'changed keyword was not used' );
+rms_home_seo_assert( false === strpos( $changed_prompt, 'deck builder' ), 'old keyword remained after change' );
+echo "PASS changed-keyword-used\n";
+$passed++;
+
+$priors = [
+	[ 'layout' => 'hero', 'payload' => [ 'hero_title' => 'deck builder' ] ],
+	[ 'layout' => 'seo-content', 'payload' => [ 'seo_headline' => 'deck builder' ] ],
+	[ 'layout' => 'about-us', 'payload' => [ 'about_headline' => 'Our story' ] ],
+	[ 'layout' => 'faq-v1', 'payload' => [ 'faq_v1_headline' => 'Questions' ] ],
+];
+$neutral = $harness->filter_neutral_priors( $priors );
+rms_home_seo_assert( 2 === count( $neutral ), 'neutral prior filter count is wrong' );
+rms_home_seo_assert( 'about-us' === $neutral[0]['layout'] && 'faq-v1' === $neutral[1]['layout'], 'neutral priors kept keyword layouts' );
+rms_home_seo_assert( ! $harness->is_reusable_layout( 'hero' ), 'hero must stay non-canonical' );
+rms_home_seo_assert( ! $harness->is_reusable_layout( 'seo-content' ), 'seo-content must stay non-canonical' );
+rms_home_seo_assert( $harness->is_reusable_layout( 'about-us' ), 'about-us should remain reusable' );
+echo "PASS canonical-prior-context-clean\n";
+$passed++;
+
+$json_prompt = new ReflectionMethod( AI_Content_Reviewer::class, 'json_prompt' );
+$json_prompt->setAccessible( true );
+$scoped = $json_prompt->invoke(
+	$reviewer,
+	'Review this section and diagnose failures before any rewrite.',
+	'hero',
+	[ 'hero_title' => 'Reliable decks' ],
+	[ [ 'layout' => 'about-us', 'payload' => [ 'about_headline' => 'Our story' ] ] ],
+	[
+		'client_context' => $client,
+		'keyword_intent' => $hero_keywords,
+	],
+	[]
+);
+$unscoped = $json_prompt->invoke(
+	$reviewer,
+	'Review this section and diagnose failures before any rewrite.',
+	'about-us',
+	[ 'about_headline' => 'Our story' ],
+	$neutral,
+	[ 'client_context' => $client ],
+	[]
+);
+$scoped_data   = json_decode( $scoped, true );
+$unscoped_data = json_decode( $unscoped, true );
+rms_home_seo_assert( is_array( $scoped_data ) && isset( $scoped_data['declared_keyword_intent'] ), 'reviewer missing scoped keyword intent' );
+rms_home_seo_assert( 'deck builder' === $scoped_data['declared_keyword_intent']['primary_keyword'], 'reviewer scoped primary mismatch' );
+rms_home_seo_assert( false !== strpos( (string) $scoped_data['declared_keyword_intent']['role'], 'Not evidence' ), 'reviewer intent role missing non-evidence language' );
+rms_home_seo_assert( ! isset( $unscoped_data['declared_keyword_intent'] ), 'reviewer leaked keyword intent into a neutral section' );
+echo "PASS reviewer-context-scoped\n";
+$passed++;
+
+$landing_keywords = [
+	'primary_keyword' => 'kitchen remodel near me',
+	'subkeywords'     => [ 'Kitchen Remodel Near Me', 'cabinets', 'Kitchen Remodel Near Me' ],
+];
+$landing_normalized = $harness->normalize_keywords( $landing_keywords );
+rms_home_seo_assert( 'kitchen remodel near me' === $landing_normalized['primary_keyword'], 'landing primary changed' );
+rms_home_seo_assert(
+	[ 'Kitchen Remodel Near Me', 'cabinets', 'Kitchen Remodel Near Me' ] === $landing_normalized['subkeywords'],
+	'landing normalize_keywords behavior changed'
+);
+$landing_hero = $harness->get_layer3( 'hero', 1, $client, AI_Content_Harness::PAGE_LANDING, $landing_keywords );
+rms_home_seo_assert( false !== strpos( $landing_hero, 'KEYWORD CONTEXT (mandatory for this section only)' ), 'landing keyword contract changed' );
+rms_home_seo_assert( false !== strpos( $landing_hero, '- Primary keyword: {{primary_keyword}}' ), 'landing primary placeholder contract changed' );
+rms_home_seo_assert( false !== strpos( $landing_hero, '- Subkeywords: {{subkeywords}}' ), 'landing subkeyword placeholder contract changed' );
+rms_home_seo_assert( false === strpos( $landing_hero, 'KEYWORD INTENT (editorial only' ), 'landing prompt picked up homepage contract' );
+rms_home_seo_assert( false === strpos( $landing_hero, 'never evidence' ), 'landing prompt picked up homepage evidence language' );
+
+$home_source     = file_get_contents( dirname( __DIR__ ) . '/inc/wizard/class-step-home-page-builder.php' );
+$landing_source  = file_get_contents( dirname( __DIR__ ) . '/inc/wizard/class-step-landing-page-builder.php' );
+$reviewer_source = file_get_contents( dirname( __DIR__ ) . '/inc/wizard/class-ai-content-reviewer.php' );
+rms_home_seo_assert( is_string( $home_source ) && false !== strpos( $home_source, 'normalize_home_seo_intent' ), 'home builder is not wired to homepage SEO intent' );
+rms_home_seo_assert( is_string( $home_source ) && false !== strpos( $home_source, 'home_seo_keywords_for_layout' ), 'home builder does not scope keywords by layout' );
+rms_home_seo_assert( is_string( $home_source ) && false !== strpos( $home_source, 'filter_neutral_priors' ), 'home builder does not isolate neutral priors' );
+rms_home_seo_assert( is_string( $landing_source ) && false !== strpos( $landing_source, 'normalize_keywords' ), 'landing builder lost normalize_keywords' );
+rms_home_seo_assert( is_string( $landing_source ) && false === strpos( $landing_source, 'normalize_home_seo_intent' ), 'landing builder now depends on homepage SEO intent' );
+rms_home_seo_assert( is_string( $reviewer_source ) && false !== strpos( $reviewer_source, 'declared_keyword_intent' ), 'reviewer missing declared keyword intent helper' );
+echo "PASS landing-behavior-unchanged\n";
+$passed++;
+
+echo 'Harness passed: ' . $passed . " scenarios.\n";
+exit( 0 );


### PR DESCRIPTION
Closes #26

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Home Page Builder persists optional homepage SEO targeting into generation and review for Hero and SEO Content only.
- Disabled mode stays neutral and drops stale keywords; enabled mode requires a normalized primary keyword.
- Canonical reusable-section store and Landing Page Builder keyword contracts stay isolated.

## Changes

| File | Change |
|------|--------|
| `inc/wizard/class-ai-content-harness.php` | Homepage SEO intent normalize/persist/scope, Hero/SEO injection, neutral priors. |
| `inc/wizard/class-ai-content-reviewer.php` | Scoped `declared_keyword_intent` for targeted Home layouts. |
| `inc/wizard/class-step-home-page-builder.php` | Wire intent into Home generation without touching landing. |
| `inc/wizard/class-state-manager.php` | Default `home_seo_targeting: { enabled: false }`. |
| `docs/wizard-ai-content.md` | Homepage SEO targeting contract. |
| `tests/wizard-home-seo-targeting-harness.php` | Focused #26 PHP harness (9 scenarios). |

## Test Plan
- [x] `php -l` passed on authored PHP files.
- [x] `php tests/wizard-home-seo-targeting-harness.php` — 9/9 PASS.
- [x] Canonical/landing isolation: `canonical-prior-context-clean` and `landing-behavior-unchanged` PASS.
- [x] Diff against `fix/wizard-credential-dom` contains only the #26 backend slice (no wizard-init UI, wizard.ts, SCSS, or client harness).
- [x] Scripts run without errors: N/A — no shell scripts in this PR.

## size:exception

Review budget is **782 / 400**. Domain prompt/reviewer wiring and the 332-line PHP harness must travel together; UI/client is deferred to the next slice.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts: N/A — no shell scripts
- [x] Skills tested in at least one agent: N/A — wizard domain feature, not a skill change
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Chain Context

| Field | Value |
|-------|-------|
| Chain | wizard-setup beta issues #22–#29 |
| Tracker PR | Not needed — retained `feature/wizard-setup` @ `3205ee5` |
| Position | 7 of 11 |
| Base | `fix/wizard-credential-dom` |
| Depends on | PR #35 / #25 |
| Follow-up | Planned: `feat/home-seo-ui` (#26 UI) |
| Review budget | 782 / 400 (`size:exception` — domain prompts + PHP harness) |
| Starts at | `fix/wizard-credential-dom` |
| Ends with | Homepage SEO targeting persisted into Home generation |

### Chain Overview

```text
feature/wizard-setup
 └── #30 docs/vite-manifest-checklist  (#24)
      └── #31 fix/acf-inactive-frontend-guard  (#23)
           └── #32 fix/footer-variant-runtime  (#28)
                └── #33 fix/palette-runtime-css  (#29)
                     └── #34 fix/wizard-dependency-truth  (#22)
                          └── #35 fix/wizard-credential-dom  (#25)
                               └── 📍 feat/home-seo-backend  (#26 backend)
                                    └── planned feat/home-seo-ui  (#26 UI)
```

### Scope
- Includes: AI harness/reviewer, Home builder, state default, docs, PHP harness.
- Excludes: wizard-init UI, wizard.ts/client helper, admin SCSS, client harness, #27.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit
