### PR TITLE
feat(wizard): add homepage SEO targeting fields and hydration

### DIFF
--- a/inc/wizard/wizard-init.php
+++ b/inc/wizard/wizard-init.php
@@ -779,6 +779,29 @@ function rms_wizard_render_home_page_builder_form(): void {
 				<?php esc_html_e( 'Add Home page sections from the available ACF Flexible Content layouts. The wizard will use saved Client Data and the IA Generation configuration to draft the section copy.', 'simple-rms-theme' ); ?>
 			</p>
 
+			<fieldset class="rms-wizard-home-seo-targeting">
+				<legend><?php esc_html_e( 'Homepage SEO targeting', 'simple-rms-theme' ); ?></legend>
+				<label class="rms-wizard-home-seo-targeting__toggle" for="rms-wizard-home-seo-enabled">
+					<input id="rms-wizard-home-seo-enabled" type="checkbox" value="1" data-wizard-home-seo-enabled aria-controls="rms-wizard-home-seo-fields" aria-expanded="false">
+					<span><?php esc_html_e( 'Target this homepage for a search query', 'simple-rms-theme' ); ?></span>
+				</label>
+				<p class="rms-wizard-field__instructions" id="rms-wizard-home-seo-help">
+					<?php esc_html_e( 'Optional. Keywords are editorial intent for the Hero and SEO Content sections only. They do not write Yoast fields, change rankings, or authorize invented services, locations, credentials, guarantees, or statistics.', 'simple-rms-theme' ); ?>
+				</p>
+				<div id="rms-wizard-home-seo-fields" class="rms-wizard-home-seo-targeting__fields" data-wizard-home-seo-fields hidden>
+					<div class="rms-wizard-field">
+						<label for="rms-wizard-home-seo-primary"><?php esc_html_e( 'Primary keyword', 'simple-rms-theme' ); ?></label>
+						<input id="rms-wizard-home-seo-primary" type="text" name="seo_targeting[primary_keyword]" data-wizard-home-seo-primary disabled aria-required="false" aria-invalid="false" aria-describedby="rms-wizard-home-seo-help" placeholder="<?php esc_attr_e( 'deck builder near me', 'simple-rms-theme' ); ?>">
+						<p id="rms-wizard-home-seo-primary-error" class="rms-wizard-home-seo-targeting__error" data-wizard-home-seo-primary-error hidden role="alert"></p>
+					</div>
+					<div class="rms-wizard-field">
+						<label for="rms-wizard-home-seo-secondary"><?php esc_html_e( 'Secondary keywords (comma-separated, optional, max 10)', 'simple-rms-theme' ); ?></label>
+						<input id="rms-wizard-home-seo-secondary" type="text" name="seo_targeting[secondary_keywords]" data-wizard-home-seo-secondary disabled aria-describedby="rms-wizard-home-seo-help rms-wizard-home-seo-secondary-notice" placeholder="<?php esc_attr_e( 'custom decks, composite decking', 'simple-rms-theme' ); ?>">
+						<p id="rms-wizard-home-seo-secondary-notice" class="rms-wizard-home-seo-targeting__notice" data-wizard-home-seo-secondary-notice hidden role="status" aria-live="polite"></p>
+					</div>
+				</div>
+			</fieldset>
+
 			<div class="notice notice-warning inline rms-wizard-home-harness-warning" data-wizard-home-harness-warning hidden>
 				<p><?php esc_html_e( 'Home Page Builder requires saved Client Data before AI content can be generated.', 'simple-rms-theme' ); ?></p>
 			</div>

--- a/src/scss/admin/wizard.scss
+++ b/src/scss/admin/wizard.scss
@@ -371,6 +371,56 @@
   max-width: 86px;
 }
 
+.rms-wizard-home-seo-targeting {
+  display: grid;
+  gap: 10px;
+  margin: 0 0 16px;
+  padding: 14px 16px;
+  border: 1px solid var(--rms-wizard-border);
+  border-radius: 10px;
+}
+
+.rms-wizard-home-seo-targeting legend {
+  padding: 0 6px;
+  font-weight: 700;
+}
+
+.rms-wizard-home-seo-targeting__toggle {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  font-weight: 600;
+}
+
+.rms-wizard-home-seo-targeting__fields {
+  display: grid;
+  gap: 12px;
+}
+
+.rms-wizard-home-seo-targeting__fields[hidden] {
+  display: none;
+}
+
+.rms-wizard-home-seo-targeting__error,
+.rms-wizard-home-seo-targeting__notice {
+  margin: 6px 0 0;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.rms-wizard-home-seo-targeting__error {
+  color: var(--rms-wizard-error);
+}
+
+.rms-wizard-home-seo-targeting__notice {
+  color: var(--rms-wizard-muted);
+}
+
+.rms-wizard-home-seo-targeting__error[hidden],
+.rms-wizard-home-seo-targeting__notice[hidden] {
+  display: none;
+}
+
 .rms-wizard-home-harness-warning {
   margin: 0;
 }

--- a/src/ts/admin/wizard-home-seo.ts
+++ b/src/ts/admin/wizard-home-seo.ts
@@ -1,0 +1,355 @@
+export const HOME_SEO_PRIMARY_REQUIRED =
+  'Enter a primary keyword before generating with SEO targeting enabled.';
+
+export const HOME_SEO_SECONDARY_LIMIT = 10;
+
+export const HOME_SEO_SECONDARY_CLAMPED =
+  'Only the first 10 unique secondary keywords were kept. Extra keywords were ignored.';
+
+export const HOME_SEO_HELP_ID = 'rms-wizard-home-seo-help';
+export const HOME_SEO_PRIMARY_ERROR_ID = 'rms-wizard-home-seo-primary-error';
+export const HOME_PAGE_BUILDER_STEP = 'home-page-builder';
+
+export type HomeSeoStepFinish = {
+  step: string;
+  persisted?: boolean;
+  validationBlocked?: boolean;
+};
+
+export function createHomeSeoValidationError(message = HOME_SEO_PRIMARY_REQUIRED): Error {
+  const error = new Error(message) as Error & { homeSeoValidation: true };
+  error.name = 'HomeSeoValidationError';
+  error.homeSeoValidation = true;
+  return error;
+}
+
+export function isHomeSeoValidationError(error: unknown): boolean {
+  return Boolean(
+    error
+    && typeof error === 'object'
+    && 'homeSeoValidation' in error
+    && (error as { homeSeoValidation?: boolean }).homeSeoValidation
+  );
+}
+
+export function shouldReloadWizardStateOnStepFinish(input: Pick<HomeSeoStepFinish, 'validationBlocked'>): boolean {
+  return !input.validationBlocked;
+}
+
+export function shouldReplaceHomeSeoOnStepFinish(input: HomeSeoStepFinish): boolean {
+  return Boolean(input.persisted)
+    && !input.validationBlocked
+    && input.step === HOME_PAGE_BUILDER_STEP;
+}
+
+export type HomeSeoTargetingInput = {
+  enabled: boolean;
+  primaryKeyword?: string;
+  secondaryKeywords?: string | string[];
+};
+
+export type HomeSeoTargetingDisabled = {
+  enabled: false;
+};
+
+export type HomeSeoTargetingEnabled = {
+  enabled: true;
+  primary_keyword: string;
+  secondary_keywords: string[];
+};
+
+export type HomeSeoTargetingPayload = HomeSeoTargetingDisabled | HomeSeoTargetingEnabled;
+
+export type HomeSeoSecondaryAnalysis = {
+  keywords: string[];
+  uniqueCount: number;
+  clamped: boolean;
+};
+
+export type HomeSeoCollectResult =
+  | {
+      payload: HomeSeoTargetingDisabled;
+      secondaryClamped: false;
+    }
+  | {
+      payload: HomeSeoTargetingEnabled;
+      secondaryClamped: boolean;
+    }
+  | {
+      payload: { enabled: true };
+      error: 'primary_required';
+      message: string;
+      secondaryClamped: boolean;
+    };
+
+export function normalizeHomeKeyword(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+export function analyzeHomeSecondaryKeywords(raw: string | string[], primary = ''): HomeSeoSecondaryAnalysis {
+  const items = Array.isArray(raw) ? raw : raw.split(/[\n,]+/);
+  const seen = new Set<string>();
+  const primaryKey = normalizeHomeKeyword(primary).toLowerCase();
+  const keywords: string[] = [];
+  let uniqueCount = 0;
+
+  items.forEach((item) => {
+    const next = normalizeHomeKeyword(String(item));
+
+    if (!next) {
+      return;
+    }
+
+    const key = next.toLowerCase();
+
+    if (key === primaryKey || seen.has(key)) {
+      return;
+    }
+
+    seen.add(key);
+    uniqueCount += 1;
+
+    if (keywords.length < HOME_SEO_SECONDARY_LIMIT) {
+      keywords.push(next);
+    }
+  });
+
+  return {
+    keywords,
+    uniqueCount,
+    clamped: uniqueCount > HOME_SEO_SECONDARY_LIMIT,
+  };
+}
+
+export function normalizeHomeSecondaryKeywords(raw: string | string[], primary = ''): string[] {
+  return analyzeHomeSecondaryKeywords(raw, primary).keywords;
+}
+
+export function buildHomeSeoTargetingPayload(input: HomeSeoTargetingInput): HomeSeoTargetingPayload {
+  if (!input.enabled) {
+    return { enabled: false };
+  }
+
+  const primaryKeyword = normalizeHomeKeyword(input.primaryKeyword ?? '');
+
+  if (!primaryKeyword) {
+    throw new Error(HOME_SEO_PRIMARY_REQUIRED);
+  }
+
+  return {
+    enabled: true,
+    primary_keyword: primaryKeyword,
+    secondary_keywords: analyzeHomeSecondaryKeywords(input.secondaryKeywords ?? [], primaryKeyword).keywords,
+  };
+}
+
+export function persistHomeSeoTargeting(payload: HomeSeoTargetingPayload): HomeSeoTargetingPayload {
+  if (!payload.enabled) {
+    return { enabled: false };
+  }
+
+  return {
+    enabled: true,
+    primary_keyword: payload.primary_keyword,
+    secondary_keywords: [...payload.secondary_keywords],
+  };
+}
+
+export function markHomeSeoDirty(form: HTMLElement): void {
+  form.dataset.wizardHomeSeoDirty = '1';
+}
+
+export function clearHomeSeoDirty(form: HTMLElement): void {
+  delete form.dataset.wizardHomeSeoDirty;
+}
+
+export function isHomeSeoDirty(form: HTMLElement): boolean {
+  return form.dataset.wizardHomeSeoDirty === '1';
+}
+
+export function applyHomeSeoTargetingUi(
+  form: HTMLElement,
+  enabled: boolean,
+  values?: { primary?: string; secondary?: string[] }
+): void {
+  const toggle = form.querySelector<HTMLInputElement>('[data-wizard-home-seo-enabled]');
+  const fields = form.querySelector<HTMLElement>('[data-wizard-home-seo-fields]');
+  const primary = form.querySelector<HTMLInputElement>('[data-wizard-home-seo-primary]');
+  const secondary = form.querySelector<HTMLInputElement | HTMLTextAreaElement>('[data-wizard-home-seo-secondary]');
+
+  if (toggle) {
+    toggle.checked = enabled;
+    toggle.setAttribute('aria-expanded', enabled ? 'true' : 'false');
+  }
+
+  if (fields) {
+    fields.hidden = !enabled;
+  }
+
+  if (primary) {
+    primary.disabled = !enabled;
+    primary.required = enabled;
+    primary.setAttribute('aria-required', enabled ? 'true' : 'false');
+
+    if (!enabled) {
+      primary.value = '';
+    } else if (values?.primary !== undefined) {
+      primary.value = values.primary;
+    }
+  }
+
+  if (secondary) {
+    secondary.disabled = !enabled;
+
+    if (!enabled) {
+      secondary.value = '';
+    } else if (values?.secondary !== undefined) {
+      secondary.value = values.secondary.join(', ');
+    }
+  }
+
+  if (!enabled) {
+    clearHomeSeoFeedback(form);
+  }
+}
+
+export function collectHomeSeoTargetingFromForm(form: HTMLElement): HomeSeoCollectResult {
+  const enabled = Boolean(form.querySelector<HTMLInputElement>('[data-wizard-home-seo-enabled]')?.checked);
+  const primaryKeyword = form.querySelector<HTMLInputElement>('[data-wizard-home-seo-primary]')?.value ?? '';
+  const secondaryKeywords = form.querySelector<HTMLInputElement | HTMLTextAreaElement>('[data-wizard-home-seo-secondary]')?.value ?? '';
+  const normalizedPrimary = normalizeHomeKeyword(primaryKeyword);
+  const analysis = analyzeHomeSecondaryKeywords(secondaryKeywords, normalizedPrimary);
+
+  if (!enabled) {
+    return {
+      payload: { enabled: false },
+      secondaryClamped: false,
+    };
+  }
+
+  if (!normalizedPrimary) {
+    return {
+      payload: { enabled: true },
+      error: 'primary_required',
+      message: HOME_SEO_PRIMARY_REQUIRED,
+      secondaryClamped: analysis.clamped,
+    };
+  }
+
+  return {
+    payload: {
+      enabled: true,
+      primary_keyword: normalizedPrimary,
+      secondary_keywords: analysis.keywords,
+    },
+    secondaryClamped: analysis.clamped,
+  };
+}
+
+export function presentHomeSeoCollectionResult(
+  form: HTMLElement,
+  result: HomeSeoCollectResult,
+  options?: { focus?: boolean }
+): void {
+  if (result.payload.enabled) {
+    applyHomeSeoTargetingUi(form, true);
+
+    if (!('error' in result) && result.secondaryClamped) {
+      const secondary = form.querySelector<HTMLInputElement | HTMLTextAreaElement>('[data-wizard-home-seo-secondary]');
+
+      if (secondary) {
+        secondary.value = result.payload.secondary_keywords.join(', ');
+      }
+    }
+  } else {
+    applyHomeSeoTargetingUi(form, false);
+  }
+
+  if ('error' in result && result.error === 'primary_required') {
+    setHomeSeoPrimaryInvalid(form, options?.focus !== false);
+  } else {
+    clearHomeSeoPrimaryInvalid(form);
+  }
+
+  setHomeSeoSecondaryClampNotice(form, Boolean(result.payload.enabled && result.secondaryClamped));
+}
+
+export function hydrateHomeSeoTargeting(
+  form: HTMLElement,
+  raw: unknown,
+  options?: { force?: boolean }
+): void {
+  if (!options?.force && isHomeSeoDirty(form)) {
+    return;
+  }
+
+  if (options?.force) {
+    clearHomeSeoDirty(form);
+  }
+
+  const state = isRecord(raw) ? raw : {};
+  const enabled = Boolean(state.enabled);
+  const primary = typeof state.primary_keyword === 'string' ? state.primary_keyword : '';
+  const secondary = Array.isArray(state.secondary_keywords)
+    ? state.secondary_keywords.filter((item): item is string => typeof item === 'string')
+    : [];
+
+  applyHomeSeoTargetingUi(form, enabled, { primary, secondary });
+  clearHomeSeoFeedback(form);
+}
+
+export function clearHomeSeoFeedback(form: HTMLElement): void {
+  clearHomeSeoPrimaryInvalid(form);
+  setHomeSeoSecondaryClampNotice(form, false);
+}
+
+export function setHomeSeoPrimaryInvalid(form: HTMLElement, focus = true): void {
+  const primary = form.querySelector<HTMLInputElement>('[data-wizard-home-seo-primary]');
+  const error = form.querySelector<HTMLElement>('[data-wizard-home-seo-primary-error]');
+
+  applyHomeSeoTargetingUi(form, true);
+
+  if (primary) {
+    primary.setAttribute('aria-invalid', 'true');
+    primary.setAttribute('aria-describedby', `${HOME_SEO_HELP_ID} ${HOME_SEO_PRIMARY_ERROR_ID}`);
+
+    if (focus && typeof primary.focus === 'function') {
+      primary.focus();
+    }
+  }
+
+  if (error) {
+    error.hidden = false;
+    error.textContent = HOME_SEO_PRIMARY_REQUIRED;
+  }
+}
+
+export function clearHomeSeoPrimaryInvalid(form: HTMLElement): void {
+  const primary = form.querySelector<HTMLInputElement>('[data-wizard-home-seo-primary]');
+  const error = form.querySelector<HTMLElement>('[data-wizard-home-seo-primary-error]');
+
+  if (primary) {
+    primary.setAttribute('aria-invalid', 'false');
+    primary.setAttribute('aria-describedby', HOME_SEO_HELP_ID);
+  }
+
+  if (error) {
+    error.hidden = true;
+    error.textContent = '';
+  }
+}
+
+export function setHomeSeoSecondaryClampNotice(form: HTMLElement, visible: boolean): void {
+  const notice = form.querySelector<HTMLElement>('[data-wizard-home-seo-secondary-notice]');
+
+  if (!notice) {
+    return;
+  }
+
+  notice.hidden = !visible;
+  notice.textContent = visible ? HOME_SEO_SECONDARY_CLAMPED : '';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/ts/admin/wizard.ts
+++ b/src/ts/admin/wizard.ts
@@ -3,6 +3,18 @@ import {
   presentStepOutcome,
   summarizeDependencyResult,
 } from './wizard-helpers';
+import {
+  applyHomeSeoTargetingUi,
+  clearHomeSeoDirty,
+  collectHomeSeoTargetingFromForm,
+  createHomeSeoValidationError,
+  hydrateHomeSeoTargeting,
+  isHomeSeoValidationError,
+  markHomeSeoDirty,
+  presentHomeSeoCollectionResult,
+  shouldReloadWizardStateOnStepFinish,
+  shouldReplaceHomeSeoOnStepFinish,
+} from './wizard-home-seo';
 
 type StepStatus = 'pending' | 'running' | 'complete' | 'failed';
 
@@ -109,6 +121,11 @@ interface WizardState {
     configured_at?: string;
   };
   generated_pages?: GeneratedPage[];
+  home_seo_targeting?: {
+    enabled?: boolean;
+    primary_keyword?: string;
+    secondary_keywords?: string[];
+  };
   landing_pages?: LandingPageState[];
   locked?: boolean;
   unlocked?: boolean;
@@ -382,13 +399,14 @@ declare global {
     syncLandingSkipAllUi();
   };
 
-  const render = (): void => {
+  const render = (options?: { replaceHomeSeo?: boolean }): void => {
     const nextStep = state.current_step && steps.some((step) => step.slug === state.current_step)
       ? state.current_step
       : activeStep;
 
     renderGeneratedPageControls();
     hydrateIaGenerationForm();
+    hydrateHomeSeoTargetingForm(options?.replaceHomeSeo);
     hydrateLandingRowsFromState();
     renderLandingReplaceOptions();
     syncGuidedControlState();
@@ -439,11 +457,20 @@ declare global {
     throw lastError ?? new Error('Request failed.');
   };
 
-  const loadState = async (): Promise<void> => {
+  const loadState = async (options?: { replaceHomeSeo?: boolean }): Promise<void> => {
     setHydrating(true);
     try {
       state = await request<WizardState>('state', { method: 'GET' }, 1);
-      render();
+
+      if (options?.replaceHomeSeo) {
+        const form = root.querySelector<HTMLFormElement>('[data-wizard-home-page-builder-form]');
+
+        if (form) {
+          clearHomeSeoDirty(form);
+        }
+      }
+
+      render({ replaceHomeSeo: Boolean(options?.replaceHomeSeo) });
     } catch (error) {
       handleStateLoadError(error);
     } finally {
@@ -472,6 +499,9 @@ declare global {
     setStepActionStatus(step, 'Running step...', 'info');
     setNotice('Running setup wizard step. Keep this page open.', 'info');
 
+    let persisted = false;
+    let validationBlocked = false;
+
     try {
       const payload = collectPayload(step);
 
@@ -492,6 +522,7 @@ declare global {
         state = response.state;
       }
 
+      persisted = true;
       const stepStatus = statusFor(step);
       const responseSuccess = response.success !== false;
       const outcome = presentStepOutcome(stepStatus, responseSuccess);
@@ -532,6 +563,7 @@ declare global {
       }
     } catch (error) {
       const message = errorMessage(error);
+      validationBlocked = isHomeSeoValidationError(error);
 
       if (step === 'home-page-builder' && message.includes('Missing required client data:')) {
         setHomeHarnessWarning(message, 'error');
@@ -541,7 +573,18 @@ declare global {
       setNotice(message, 'error');
     } finally {
       runningStep = null;
-      await loadState();
+
+      if (shouldReloadWizardStateOnStepFinish({ validationBlocked })) {
+        await loadState({
+          replaceHomeSeo: shouldReplaceHomeSeoOnStepFinish({
+            step,
+            persisted,
+            validationBlocked,
+          }),
+        });
+      } else {
+        updateButtons();
+      }
     }
   };
 
@@ -742,7 +785,19 @@ declare global {
 
     setHomeHarnessWarning('', 'info');
 
-    return { sections };
+    markHomeSeoDirty(form);
+    const seoResult = collectHomeSeoTargetingFromForm(form);
+    presentHomeSeoCollectionResult(form, seoResult);
+
+    if ('error' in seoResult && seoResult.error) {
+      setHomeHarnessWarning(seoResult.message, 'error');
+      throw createHomeSeoValidationError(seoResult.message);
+    }
+
+    return {
+      sections,
+      seo_targeting: seoResult.payload,
+    };
   };
 
   const ensureDestructiveConfirmation = async (step: string, payload: StepPayload): Promise<boolean> => {
@@ -1920,6 +1975,16 @@ declare global {
     }
   };
 
+  const hydrateHomeSeoTargetingForm = (replace = false): void => {
+    const form = root.querySelector<HTMLFormElement>('[data-wizard-home-page-builder-form]');
+
+    if (!form) {
+      return;
+    }
+
+    hydrateHomeSeoTargeting(form, state.home_seo_targeting, { force: replace });
+  };
+
   const setHomeHarnessWarning = (message: string, tone: 'info' | 'error'): void => {
     const warning = root.querySelector<HTMLElement>('[data-wizard-home-harness-warning]');
     const target = warning?.querySelector<HTMLElement>('p') ?? warning;
@@ -2528,6 +2593,21 @@ declare global {
         }
       }
 
+      if (
+        target instanceof HTMLInputElement
+        && target.matches('[data-wizard-home-seo-primary], [data-wizard-home-seo-secondary]')
+      ) {
+        const form = target.closest<HTMLFormElement>('[data-wizard-home-page-builder-form]');
+
+        if (form) {
+          markHomeSeoDirty(form);
+
+          if (target.matches('[data-wizard-home-seo-primary]') && target.value.trim() !== '') {
+            presentHomeSeoCollectionResult(form, collectHomeSeoTargetingFromForm(form), { focus: false });
+          }
+        }
+      }
+
       if (target instanceof HTMLInputElement && target.matches('[data-wizard-landing-primary-keyword]')) {
         const row = target.closest<HTMLElement>('[data-wizard-landing-row]');
 
@@ -2573,6 +2653,17 @@ declare global {
 
       if (target instanceof HTMLSelectElement && target.matches('[data-wizard-home-section-select]')) {
         syncGuidedControlState();
+        return;
+      }
+
+      if (target instanceof HTMLInputElement && target.matches('[data-wizard-home-seo-enabled]')) {
+        const form = target.closest<HTMLFormElement>('[data-wizard-home-page-builder-form]');
+
+        if (form) {
+          markHomeSeoDirty(form);
+          applyHomeSeoTargetingUi(form, target.checked);
+        }
+
         return;
       }
 
@@ -2792,7 +2883,7 @@ declare global {
   });
 
   refreshButton?.addEventListener('click', () => {
-    void loadState();
+    void loadState({ replaceHomeSeo: true });
   });
 
   completeButton?.addEventListener('click', () => {
@@ -2800,7 +2891,7 @@ declare global {
   });
 
   render();
-  void loadState();
+  void loadState({ replaceHomeSeo: true });
 })();
 
 function getSettings(root: HTMLElement | null): WizardSettings | undefined {

--- a/tests/wizard-home-seo-targeting-client-harness.mjs
+++ b/tests/wizard-home-seo-targeting-client-harness.mjs
@@ -1,0 +1,320 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+
+const require = createRequire(import.meta.url);
+const here = dirname(fileURLToPath(import.meta.url));
+const themeRoot = resolve(here, '..');
+let ts;
+try {
+  ts = require('typescript');
+} catch (_error) {
+  const sibling = resolve(here, '../../simple-rms-theme/node_modules/typescript');
+  ts = require(sibling);
+}
+const helperSource = readFileSync(resolve(themeRoot, 'src/ts/admin/wizard-home-seo.ts'), 'utf8');
+const transpiled = ts.transpileModule(helperSource, {
+  compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ESNext },
+}).outputText;
+const helperPath = resolve(tmpdir(), 'rms-wizard-home-seo-harness.mjs');
+writeFileSync(helperPath, transpiled);
+const {
+  HOME_SEO_PRIMARY_ERROR_ID,
+  HOME_SEO_PRIMARY_REQUIRED,
+  HOME_SEO_SECONDARY_CLAMPED,
+  analyzeHomeSecondaryKeywords,
+  applyHomeSeoTargetingUi,
+  buildHomeSeoTargetingPayload,
+  clearHomeSeoDirty,
+  collectHomeSeoTargetingFromForm,
+  createHomeSeoValidationError,
+  hydrateHomeSeoTargeting,
+  isHomeSeoDirty,
+  isHomeSeoValidationError,
+  markHomeSeoDirty,
+  normalizeHomeKeyword,
+  normalizeHomeSecondaryKeywords,
+  persistHomeSeoTargeting,
+  presentHomeSeoCollectionResult,
+  shouldReloadWizardStateOnStepFinish,
+  shouldReplaceHomeSeoOnStepFinish,
+} = await import('file:///' + helperPath.replace(/\\/g, '/'));
+
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+let passed = 0;
+
+assert(normalizeHomeKeyword('  deck   builder  ') === 'deck builder', 'primary whitespace collapse failed');
+assert(
+  JSON.stringify(normalizeHomeSecondaryKeywords(['  one  ', 'Two', 'two', '', 'THREE', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten', 'eleven'], 'deck builder'))
+    === JSON.stringify(['one', 'Two', 'THREE', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten']),
+  'client secondary normalize/dedupe/clamp failed'
+);
+const eleven = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten', 'eleven'];
+const analysis = analyzeHomeSecondaryKeywords(eleven, 'deck builder');
+assert(analysis.clamped === true, 'eleven unique secondaries must report clamped');
+assert(analysis.uniqueCount === 11, 'unique count must include extras');
+assert(analysis.keywords.length === 10, 'clamp must keep first 10');
+console.log('PASS client-normalize-dedupe-clamp');
+passed += 1;
+
+const disabled = buildHomeSeoTargetingPayload({
+  enabled: false,
+  primaryKeyword: 'stale deck builder',
+  secondaryKeywords: 'old secondary',
+});
+assert(JSON.stringify(disabled) === JSON.stringify({ enabled: false }), 'disabled payload kept stale keywords');
+assert(JSON.stringify(persistHomeSeoTargeting(disabled)) === JSON.stringify({ enabled: false }), 'disabled persist kept stale keywords');
+console.log('PASS client-disabled-omits-stale-intent');
+passed += 1;
+
+const enabled = buildHomeSeoTargetingPayload({
+  enabled: true,
+  primaryKeyword: '  deck   builder  ',
+  secondaryKeywords: 'custom decks, DECK BUILDER, composite decking,, Custom Decks',
+});
+assert(enabled.enabled === true, 'enabled payload must stay enabled');
+assert(enabled.enabled && enabled.primary_keyword === 'deck builder', 'enabled primary was not normalized');
+assert(enabled.enabled && JSON.stringify(enabled.secondary_keywords) === JSON.stringify(['custom decks', 'composite decking']), 'enabled secondaries were not normalized');
+console.log('PASS client-enabled-normalizes');
+passed += 1;
+
+let rejected = false;
+try {
+  buildHomeSeoTargetingPayload({ enabled: true, primaryKeyword: '   ' });
+} catch (error) {
+  rejected = error instanceof Error && error.message === HOME_SEO_PRIMARY_REQUIRED;
+}
+assert(rejected, 'missing primary did not reject on the client');
+console.log('PASS client-missing-primary-rejects');
+passed += 1;
+
+const changed = buildHomeSeoTargetingPayload({
+  enabled: true,
+  primaryKeyword: 'composite decking contractor',
+});
+assert(changed.enabled && changed.primary_keyword === 'composite decking contractor', 'changed keyword was not used');
+assert(changed.enabled && !changed.primary_keyword.includes('deck builder'), 'old keyword remained after change');
+console.log('PASS client-changed-keyword-used');
+passed += 1;
+
+const field = (name, value = '', extras = {}) => ({
+  name,
+  value,
+  disabled: false,
+  required: false,
+  checked: false,
+  hidden: false,
+  focused: false,
+  textContent: extras.textContent ?? '',
+  attrs: {},
+  dataset: {},
+  setAttribute(key, next) {
+    this.attrs[key] = next;
+  },
+  focus() {
+    this.focused = true;
+  },
+  matches(selector) {
+    return selector.split(',').some((part) => part.trim().includes(name));
+  },
+  ...extras,
+});
+
+const createForm = () => {
+  const form = {
+    dataset: {},
+    toggle: field('enabled'),
+    fields: { hidden: true },
+    primary: field('primary', '', { attrs: { 'aria-describedby': 'rms-wizard-home-seo-help' } }),
+    secondary: field('secondary'),
+    error: field('primary-error', '', { hidden: true }),
+    notice: field('secondary-notice', '', { hidden: true }),
+    querySelector(selector) {
+      if (selector.includes('home-seo-enabled')) return this.toggle;
+      if (selector.includes('home-seo-fields') && !selector.includes('primary') && !selector.includes('secondary')) return this.fields;
+      if (selector.includes('home-seo-primary-error')) return this.error;
+      if (selector.includes('home-seo-primary')) return this.primary;
+      if (selector.includes('home-seo-secondary-notice')) return this.notice;
+      if (selector.includes('home-seo-secondary')) return this.secondary;
+      return null;
+    },
+  };
+  return form;
+};
+
+const form = createForm();
+
+hydrateHomeSeoTargeting(form, {
+  enabled: true,
+  primary_keyword: 'deck builder',
+  secondary_keywords: ['custom decks'],
+});
+assert(form.toggle.checked === true, 'hydrate did not enable the control');
+assert(form.fields.hidden === false, 'hydrate left keyword fields hidden');
+assert(form.primary.disabled === false && form.primary.value === 'deck builder', 'hydrate did not restore primary');
+assert(form.secondary.value === 'custom decks', 'hydrate did not restore secondaries');
+
+applyHomeSeoTargetingUi(form, false);
+assert(form.toggle.checked === false, 'disable did not uncheck the control');
+assert(form.fields.hidden === true, 'disable did not hide keyword fields');
+assert(form.primary.disabled === true && form.primary.value === '', 'disable did not clear/disable primary');
+assert(form.secondary.disabled === true && form.secondary.value === '', 'disable did not clear/disable secondary');
+assert(form.toggle.attrs['aria-expanded'] === 'false', 'disable did not update aria-expanded');
+assert(form.error.hidden === true && form.error.textContent === '', 'disable left primary error visible');
+assert(form.notice.hidden === true, 'disable left clamp notice visible');
+
+form.toggle.checked = false;
+const collectedDisabled = collectHomeSeoTargetingFromForm(form);
+assert(collectedDisabled.payload.enabled === false, 'disabled form collection leaked keywords');
+assert(!('primary_keyword' in collectedDisabled.payload), 'disabled collection included primary');
+console.log('PASS client-ui-conditional-state');
+passed += 1;
+
+const dirtyForm = createForm();
+hydrateHomeSeoTargeting(dirtyForm, { enabled: false });
+dirtyForm.toggle.checked = true;
+dirtyForm.fields.hidden = false;
+dirtyForm.primary.disabled = false;
+dirtyForm.primary.value = '';
+markHomeSeoDirty(dirtyForm);
+assert(isHomeSeoDirty(dirtyForm), 'dirty flag was not set');
+hydrateHomeSeoTargeting(dirtyForm, { enabled: false });
+assert(dirtyForm.toggle.checked === true, 'generic hydrate clobbered unsaved enabled mode');
+assert(dirtyForm.primary.value === '', 'generic hydrate clobbered unsaved primary');
+hydrateHomeSeoTargeting(dirtyForm, { enabled: false }, { force: true });
+assert(isHomeSeoDirty(dirtyForm) === false, 'forced hydrate must reset dirty');
+assert(dirtyForm.toggle.checked === false, 'forced persist/reload hydrate did not restore persisted disabled state');
+assert(dirtyForm.primary.value === '', 'forced hydrate must still clear disabled values');
+console.log('PASS client-edit-preservation');
+passed += 1;
+
+const invalidForm = createForm();
+invalidForm.toggle.checked = true;
+invalidForm.primary.value = '   ';
+const invalidResult = collectHomeSeoTargetingFromForm(invalidForm);
+assert(invalidResult.error === 'primary_required', 'enabled empty primary must be a collect error');
+assert(invalidResult.message === HOME_SEO_PRIMARY_REQUIRED, 'missing primary message drifted');
+presentHomeSeoCollectionResult(invalidForm, invalidResult);
+assert(invalidForm.toggle.checked === true, 'missing primary hid the targeting mode');
+assert(invalidForm.fields.hidden === false, 'missing primary hid the keyword fields');
+assert(invalidForm.primary.attrs['aria-invalid'] === 'true', 'missing primary did not set aria-invalid');
+assert(String(invalidForm.primary.attrs['aria-describedby'] || '').includes(HOME_SEO_PRIMARY_ERROR_ID), 'missing primary did not associate the error');
+assert(invalidForm.error.hidden === false, 'missing primary error is not visible');
+assert(invalidForm.error.textContent === HOME_SEO_PRIMARY_REQUIRED, 'missing primary error text is wrong');
+assert(invalidForm.primary.focused === true, 'missing primary did not move focus');
+invalidForm.primary.value = 'deck builder';
+presentHomeSeoCollectionResult(invalidForm, collectHomeSeoTargetingFromForm(invalidForm), { focus: false });
+assert(invalidForm.primary.attrs['aria-invalid'] === 'false', 'corrected primary left aria-invalid');
+assert(invalidForm.error.hidden === true, 'corrected primary left the error visible');
+console.log('PASS client-validation-focus-aria');
+passed += 1;
+
+const clampForm = createForm();
+clampForm.toggle.checked = true;
+clampForm.primary.value = 'deck builder';
+clampForm.secondary.value = eleven.join(', ');
+const clampResult = collectHomeSeoTargetingFromForm(clampForm);
+assert(clampResult.secondaryClamped === true, 'collect must surface the clamp');
+assert(clampResult.payload.enabled && clampResult.payload.secondary_keywords.length === 10, 'collect must keep first 10');
+presentHomeSeoCollectionResult(clampForm, clampResult);
+assert(clampForm.notice.hidden === false, 'clamp notice stayed hidden');
+assert(clampForm.notice.textContent === HOME_SEO_SECONDARY_CLAMPED, 'clamp notice text is wrong');
+assert(!String(clampForm.notice.textContent).includes('eleven'), 'clamp notice dumped a raw keyword');
+assert(clampForm.secondary.value === clampResult.payload.secondary_keywords.join(', '), 'secondary field was not reduced to the kept 10');
+console.log('PASS client-clamp-notice');
+passed += 1;
+
+const successForm = createForm();
+markHomeSeoDirty(successForm);
+successForm.toggle.checked = true;
+successForm.primary.value = 'unsaved draft';
+assert(shouldReplaceHomeSeoOnStepFinish({ step: 'home-page-builder', persisted: true }) === true, 'Home success must force replace');
+hydrateHomeSeoTargeting(successForm, {
+  enabled: true,
+  primary_keyword: 'composite decking contractor',
+  secondary_keywords: ['custom decks'],
+}, { force: shouldReplaceHomeSeoOnStepFinish({ step: 'home-page-builder', persisted: true }) });
+assert(successForm.primary.value === 'composite decking contractor', 'successful Home persist did not reset to saved values');
+assert(isHomeSeoDirty(successForm) === false, 'successful Home persist left dirty set');
+clearHomeSeoDirty(successForm);
+applyHomeSeoTargetingUi(successForm, false);
+assert(successForm.primary.value === '', 'disabled clear must still empty values');
+console.log('PASS client-home-success-reset');
+passed += 1;
+
+const crossStepForm = createForm();
+crossStepForm.toggle.checked = true;
+crossStepForm.primary.value = 'unsaved draft';
+markHomeSeoDirty(crossStepForm);
+assert(shouldReplaceHomeSeoOnStepFinish({ step: 'dependencies', persisted: true }) === false, 'Dependency success must not force replace');
+assert(shouldReplaceHomeSeoOnStepFinish({ step: 'ia-generation', persisted: true }) === false, 'IA success must not force replace');
+assert(shouldReplaceHomeSeoOnStepFinish({ step: 'landing-page-builder', persisted: true }) === false, 'Landing success must not force replace');
+hydrateHomeSeoTargeting(crossStepForm, { enabled: false }, {
+  force: shouldReplaceHomeSeoOnStepFinish({ step: 'landing-page-builder', persisted: true }),
+});
+assert(isHomeSeoDirty(crossStepForm) === true, 'cross-step success cleared dirty');
+assert(crossStepForm.toggle.checked === true && crossStepForm.primary.value === 'unsaved draft', 'cross-step success clobbered Home SEO draft');
+console.log('PASS client-cross-step-success-preservation');
+passed += 1;
+
+const refreshForm = createForm();
+refreshForm.toggle.checked = true;
+refreshForm.primary.value = 'unsaved draft';
+markHomeSeoDirty(refreshForm);
+hydrateHomeSeoTargeting(refreshForm, { enabled: false }, { force: true });
+assert(isHomeSeoDirty(refreshForm) === false, 'explicit refresh must reset dirty');
+assert(refreshForm.toggle.checked === false, 'explicit refresh must replace Home SEO');
+console.log('PASS client-refresh-replacement');
+passed += 1;
+
+const failureForm = createForm();
+failureForm.toggle.checked = true;
+failureForm.primary.value = '';
+markHomeSeoDirty(failureForm);
+const validationError = createHomeSeoValidationError(HOME_SEO_PRIMARY_REQUIRED);
+assert(isHomeSeoValidationError(validationError) === true, 'validation error flag missing');
+assert(isHomeSeoValidationError(new Error(HOME_SEO_PRIMARY_REQUIRED)) === false, 'plain message must not count as validation flag');
+assert(shouldReloadWizardStateOnStepFinish({ validationBlocked: true }) === false, 'Home validation failure must not reload state');
+assert(shouldReplaceHomeSeoOnStepFinish({ step: 'home-page-builder', persisted: false, validationBlocked: true }) === false, 'Home validation failure must not force replace');
+assert(shouldReplaceHomeSeoOnStepFinish({ step: 'home-page-builder', persisted: false }) === false, 'failed Home request must not force replace');
+hydrateHomeSeoTargeting(failureForm, { enabled: false }, {
+  force: shouldReplaceHomeSeoOnStepFinish({ step: 'home-page-builder', persisted: false, validationBlocked: true }),
+});
+assert(failureForm.toggle.checked === true, 'failed Home validation clobbered enabled mode');
+assert(failureForm.primary.value === '', 'failed Home validation clobbered the invalid primary field');
+console.log('PASS client-failure-preservation');
+passed += 1;
+
+const wizardSource = readFileSync(resolve(themeRoot, 'src/ts/admin/wizard.ts'), 'utf8');
+const initSource = readFileSync(resolve(themeRoot, 'inc/wizard/wizard-init.php'), 'utf8');
+assert(wizardSource.includes("from './wizard-home-seo'"), 'wizard.ts must import homepage SEO helpers');
+assert(wizardSource.includes('collectHomeSeoTargetingFromForm'), 'wizard.ts must collect homepage SEO targeting');
+assert(wizardSource.includes('hydrateHomeSeoTargeting'), 'wizard.ts must hydrate homepage SEO targeting');
+assert(wizardSource.includes('markHomeSeoDirty'), 'wizard.ts must mark unsaved Home SEO edits');
+assert(wizardSource.includes('presentHomeSeoCollectionResult'), 'wizard.ts must present helper validation/clamp UI');
+assert(wizardSource.includes('replaceHomeSeo'), 'wizard.ts must distinguish forced Home SEO replacement');
+assert(wizardSource.includes('shouldReplaceHomeSeoOnStepFinish'), 'wizard.ts must use the helper replacement decision');
+assert(wizardSource.includes('createHomeSeoValidationError'), 'wizard.ts must throw the explicit Home SEO validation flag');
+assert(wizardSource.includes('isHomeSeoValidationError'), 'wizard.ts must detect Home SEO validation without message matching');
+assert(wizardSource.includes("step: 'home-page-builder'") === false || wizardSource.includes('shouldReplaceHomeSeoOnStepFinish'), 'Home replacement must go through the helper');
+assert(wizardSource.includes('loadState({ replaceHomeSeo: persisted })') === false, 'any-step persisted success must not force Home SEO replacement');
+assert(!wizardSource.includes('message !== HOME_SEO_PRIMARY_REQUIRED'), 'runStep must not use message-exact Home SEO control');
+assert(initSource.includes('data-wizard-home-seo-enabled'), 'wizard-init.php must expose the SEO targeting control');
+assert(initSource.includes('data-wizard-home-seo-primary-error'), 'wizard-init.php must expose the primary error element');
+assert(initSource.includes('role="alert"'), 'primary error must be a live alert');
+assert(initSource.includes('data-wizard-home-seo-secondary-notice'), 'wizard-init.php must expose the clamp notice');
+assert(initSource.includes('role="status"'), 'clamp notice must use a polite status live region');
+assert(initSource.includes('editorial intent'), 'wizard-init.php must describe keywords as editorial intent');
+assert(!initSource.toLowerCase().includes('guarantees rankings'), 'UI must not claim ranking guarantees');
+assert(!initSource.toLowerCase().includes('writes yoast'), 'UI must not claim Yoast writes');
+console.log('PASS client-production-wiring');
+passed += 1;
+
+console.log(`Harness passed: ${passed} scenarios.`);


### PR DESCRIPTION
Closes #26

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds the Homepage SEO targeting fieldset with dirty-aware hydration, explicit validation/focus, and secondary-keyword clamp notices.
- Merges Home SEO collection into existing #22/#25 wizard.ts without dropping dependency-truth or credential-clearing behavior.
- Client harness covers 14 UI/helper scenarios; prior PHP/client harnesses stay green.

## Changes

| File | Change |
|------|--------|
| `inc/wizard/wizard-init.php` | Homepage SEO targeting fieldset markup. |
| `src/ts/admin/wizard-home-seo.ts` | Dirty-aware collect/hydrate/validate/clamp helpers. |
| `src/ts/admin/wizard.ts` | Wire Home SEO into run/load/collect without dropping #22/#25. |
| `src/scss/admin/wizard.scss` | Targeting fieldset styles. |
| `tests/wizard-home-seo-targeting-client-harness.mjs` | Focused #26 client harness (14 scenarios). |

## Test Plan
- [x] `node tests/wizard-home-seo-targeting-client-harness.mjs` — 14/14 PASS.
- [x] `php tests/wizard-home-seo-targeting-harness.php` — 9/9 PASS.
- [x] `php tests/wizard-dependency-truth-harness.php` — 10/10 PASS.
- [x] `php tests/wizard-credential-dom-safety-harness.php` — 3/3 PASS.
- [x] `node tests/wizard-client-truth-harness.mjs` — 8/8 PASS.
- [x] `npm run build` (`tsc && vite build`) passed.
- [x] Diff against `feat/home-seo-backend` contains only the #26 UI slice.
- [x] Scripts run without errors: N/A — no shell scripts in this PR.

## size:exception

Review budget is **853 / 400**. The 355-line helper and 320-line client harness must travel with the fieldset and wizard.ts wiring.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts: N/A — no shell scripts
- [x] Skills tested in at least one agent: N/A — wizard UI feature, not a skill change
- [x] Docs updated if behavior changed: backend docs landed in the previous slice
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Chain Context

| Field | Value |
|-------|-------|
| Chain | wizard-setup beta issues #22–#29 |
| Tracker PR | Not needed — retained `feature/wizard-setup` @ `3205ee5` |
| Position | 8 of 11 |
| Base | `feat/home-seo-backend` |
| Depends on | PR #36 / #26 backend |
| Follow-up | Planned: #27 backend |
| Review budget | 853 / 400 (`size:exception` — helper + client harness) |
| Starts at | `feat/home-seo-backend` |
| Ends with | Homepage SEO targeting fields, hydration, and client validation |

### Chain Overview

```text
feature/wizard-setup
 └── #30 docs/vite-manifest-checklist  (#24)
      └── #31 fix/acf-inactive-frontend-guard  (#23)
           └── #32 fix/footer-variant-runtime  (#28)
                └── #33 fix/palette-runtime-css  (#29)
                     └── #34 fix/wizard-dependency-truth  (#22)
                          └── #35 fix/wizard-credential-dom  (#25)
                               └── #36 feat/home-seo-backend  (#26 backend)
                                    └── 📍 feat/home-seo-ui  (#26 UI)
                                         └── planned #27 backend
```

### Scope
- Includes: Home SEO fieldset, helper, dirty-aware validation/focus/clamp, admin SCSS, client harness, wizard.ts merge.
- Excludes: #27 landing runtime, mutation fence.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit
