### PR TITLE
fix(wizard): checkpoint landing runs so batches can resume

### DIFF
--- a/inc/wizard/class-landing-run-orchestrator.php
+++ b/inc/wizard/class-landing-run-orchestrator.php
@@ -1,0 +1,1219 @@
+<?php
+/**
+ * Landing run orchestrator — resumable, one-item-per-request execution.
+ *
+ * @package Simple_RMS_Theme
+ */
+
+namespace Inc\Wizard;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manages the persisted landing run plan and bounded per-item processing.
+ *
+ * Orchestration state only — does not duplicate state.landing_pages.
+ * Owns: normalized run plan, per-item status, atomic mutex lease,
+ * stale recovery, and atomic checkpoint coordination.
+ */
+class Landing_Run_Orchestrator {
+
+		private const STATE_KEY      = 'landing_run';
+		private const SCHEMA_VERSION  = 1;
+		private const ITEM_EXECUTION_BUDGET = 1200;
+		private const LEASE_MARGIN           = 60;
+		private const START_FENCE_OPTION     = 'rms_landing_start_fence';
+		private const START_FENCE_TTL        = 60;
+
+	public const ITEM_PENDING     = 'pending';
+	public const ITEM_RUNNING     = 'running';
+	public const ITEM_COMPLETED   = 'completed';
+	public const ITEM_INTERRUPTED = 'interrupted';
+	public const ITEM_FAILED      = 'failed';
+
+	public const RUN_PENDING     = 'pending';
+	public const RUN_RUNNING     = 'running';
+	public const RUN_COMPLETED   = 'completed';
+	public const RUN_INTERRUPTED = 'interrupted';
+	public const RUN_FAILED      = 'failed';
+
+	/** Items that still need work (not completed). */
+	public const ACTIVE_STATUSES = [ self::ITEM_PENDING, self::ITEM_RUNNING, self::ITEM_INTERRUPTED, self::ITEM_FAILED ];
+	/** Items that can be picked up by get_next_item. */
+	public const PROCESSABLE_STATUSES = [ self::ITEM_PENDING, self::ITEM_INTERRUPTED ];
+
+	private $state_manager;
+	private $logger;
+
+	public function __construct(
+		?State_Manager $state_manager = null,
+		?Logger $logger = null
+	) {
+		$this->state_manager = $state_manager ?? new State_Manager();
+		$this->logger        = $logger ?? new Logger();
+	}
+
+	/**
+	 * Get the current persisted run plan (normalized), or null when absent.
+	 *
+	 * @return array<string,mixed>|null
+	 */
+		public function get_run(): ?array {
+			$state = $this->state_manager->get_state();
+			$run   = is_array( $state[ self::STATE_KEY ] ?? null ) ? $state[ self::STATE_KEY ] : null;
+
+			if ( null === $run ) {
+				return null;
+			}
+
+			return $this->normalize_run( $run );
+		}
+
+		/**
+		 * Whether a valid execution lease is currently held.
+		 */
+		public function has_active_lease( ?array $run = null ): bool {
+			return null !== $this->active_lease_expires_at( $run );
+		}
+
+		/**
+		 * Expiry timestamp of a still-valid lease, or null when none is active.
+		 *
+		 * @param array<string,mixed>|null $run
+		 */
+		public function active_lease_expires_at( ?array $run = null ): ?int {
+			$run = is_array( $run ) ? $run : $this->get_run();
+
+			if ( null === $run ) {
+				return null;
+			}
+
+			$run_id = (string) ( $run['run_id'] ?? '' );
+
+			if ( '' === $run_id ) {
+				return null;
+			}
+
+			$lease = $this->read_lease_record( $this->lease_option_name( $run_id ) );
+
+			if ( null === $lease || ! is_array( $lease['value'] ) ) {
+				return null;
+			}
+
+			$expires = (int) ( $lease['value']['expires_at'] ?? 0 );
+
+			if ( $expires > time() || 0 === $expires ) {
+				return $expires;
+			}
+
+			return null;
+		}
+
+		/**
+		 * Whether start must refuse because a valid lease or unfinished run exists.
+		 *
+		 * Only a completed run (or no run) may be replaced by a genuinely new start.
+		 * Pending, running, interrupted, and failed runs must be resumed.
+		 */
+		public function has_blocking_run(): bool {
+			if ( $this->has_active_lease() ) {
+				return true;
+			}
+
+			return $this->has_incomplete_run();
+		}
+
+		/**
+		 * Whether a persisted run still has work and must not be replaced.
+		 */
+		public function has_incomplete_run(): bool {
+			$run = $this->get_run();
+
+			if ( null === $run ) {
+				return false;
+			}
+
+			$items  = is_array( $run['items'] ?? null ) ? $run['items'] : [];
+			$status = (string) ( $run['status'] ?? '' );
+
+			if ( self::RUN_COMPLETED === $status ) {
+				return $this->has_active_items( $items );
+			}
+
+			if ( in_array( $status, [ self::RUN_PENDING, self::RUN_RUNNING, self::RUN_INTERRUPTED, self::RUN_FAILED ], true ) ) {
+				return true;
+			}
+
+			return $this->has_active_items( $items );
+		}
+
+		/**
+		 * Public run view for the admin client. Never includes lease_owner.
+		 *
+		 * @return array<string,mixed>|null
+		 */
+		public function get_public_run(): ?array {
+			$run = $this->get_run();
+
+			if ( null === $run ) {
+				return null;
+			}
+
+			return $this->public_run_view( $run );
+		}
+
+		/**
+		 * Build a public view of a run plan.
+		 *
+		 * @param array<string,mixed> $run
+		 *
+		 * @return array<string,mixed>
+		 */
+		public function public_run_view( array $run ): array {
+			$expires = $this->active_lease_expires_at( $run );
+
+			return [
+				'run_id'            => (string) ( $run['run_id'] ?? '' ),
+				'status'            => (string) ( $run['status'] ?? '' ),
+				'total'             => (int) ( $run['total'] ?? 0 ),
+				'completed'         => (int) ( $run['completed'] ?? 0 ),
+				'current_index'     => (int) ( $run['current_index'] ?? -1 ),
+				'processing_active' => null !== $expires,
+				'lease_expires_at'  => $expires,
+				'items'             => array_map(
+					static function ( $item ): array {
+						$item = is_array( $item ) ? $item : [];
+
+						return [
+							'key'             => (string) ( $item['key'] ?? '' ),
+							'landing_key'     => (string) ( $item['landing_key'] ?? $item['key'] ?? '' ),
+							'id'              => (int) ( $item['post_id'] ?? $item['id'] ?? 0 ),
+							'title'           => (string) ( $item['title'] ?? '' ),
+							'slug'            => (string) ( $item['slug'] ?? '' ),
+							'landing_type'    => (string) ( $item['landing_type'] ?? 'seo' ),
+							'menu_eligible'   => ! empty( $item['menu_eligible'] ),
+							'primary_keyword' => (string) ( $item['primary_keyword'] ?? '' ),
+							'subkeywords'     => is_array( $item['subkeywords'] ?? null ) ? array_values( $item['subkeywords'] ) : [],
+							'sections'        => is_array( $item['sections'] ?? null ) ? $item['sections'] : [],
+							'status'          => (string) ( $item['status'] ?? 'pending' ),
+							'post_id'         => (int) ( $item['post_id'] ?? 0 ),
+							'error_code'      => (string) ( $item['error_code'] ?? '' ),
+							'error_message'   => (string) ( $item['error_message'] ?? '' ),
+						];
+					},
+					is_array( $run['items'] ?? null ) ? $run['items'] : []
+				),
+			];
+		}
+
+		/**
+		 * Start a new run plan from submitted landing rows.
+		 *
+		 * Classifies existing unchanged entries as already complete.
+		 * Persists the full plan before any AI work begins.
+		 * Serializes check + persist behind an atomic start fence so two
+		 * concurrent starts cannot both mint a plan. Incomplete runs are
+		 * never overwritten; recovery goes through process/Resume.
+		 *
+		 * @param array<int,array<string,mixed>>         $rows             Parsed landing rows.
+		 * @param array<string,array<string,mixed>>       $existing_landings Keyed by landing_key.
+		 * @param array<string,bool>                      $replace_map       Per-layout replacement choices.
+		 *
+		 * @return array<string,mixed>|\WP_Error
+		 */
+		public function start_run( array $rows, array $existing_landings, array $replace_map ) {
+			$fence_owner = $this->acquire_start_fence();
+
+			if ( \is_wp_error( $fence_owner ) ) {
+				return $fence_owner;
+			}
+
+			try {
+				if ( $this->has_blocking_run() ) {
+					return new \WP_Error(
+						'rms_wizard_landing_run_active',
+						\__( 'A landing run is already active or incomplete. Use Resume to continue the persisted plan.', 'simple-rms-theme' ),
+						[ 'status' => 409 ]
+					);
+				}
+
+				$run_id = $this->mint_run_id();
+				$items  = [];
+				$now    = time();
+
+		foreach ( $rows as $row ) {
+			$key          = (string) ( $row['landing_key'] ?? '' );
+			$existing_id  = (int) ( $row['id'] ?? 0 );
+			$existing_row = '' !== $key ? ( $existing_landings[ $key ] ?? null ) : null;
+
+			$status = self::ITEM_PENDING;
+
+			// Classify unchanged existing entries as already complete.
+			// Per-item replace check: only layouts in replace_map that the item uses invalidate it.
+			$item_replace_active = $this->item_has_replace( $row, $replace_map );
+
+			if ( is_array( $existing_row ) && $existing_id > 0 && $this->landing_unchanged( $row, $existing_row ) && ! $item_replace_active ) {
+				$status = self::ITEM_COMPLETED;
+			}
+
+			$items[] = [
+				'key'             => $key,
+				'landing_key'      => $key,
+				'id'              => $existing_id,
+				'title'           => (string) ( $row['title'] ?? '' ),
+				'slug'            => (string) ( $row['slug'] ?? '' ),
+				'landing_type'    => (string) ( $row['landing_type'] ?? 'seo' ),
+				'menu_eligible'   => ! empty( $row['menu_eligible'] ),
+				'primary_keyword' => (string) ( $row['primary_keyword'] ?? '' ),
+				'subkeywords'     => is_array( $row['subkeywords'] ?? null ) ? array_values( $row['subkeywords'] ) : [],
+				'sections'        => is_array( $row['sections'] ?? null ) ? $row['sections'] : [],
+				'status'          => $status,
+				'post_id'         => $existing_id,
+				'error_code'      => '',
+				'error_message'   => '',
+				'started_at'      => null,
+				'completed_at'    => self::ITEM_COMPLETED === $status ? $now : null,
+			];
+		}
+
+		$completed = count( array_filter( $items, static fn( $i ): bool => self::ITEM_COMPLETED === $i['status'] ) );
+
+		$run = [
+			'run_id'         => $run_id,
+			'schema_version' => self::SCHEMA_VERSION,
+			'status'          => self::RUN_PENDING,
+			'items'           => $items,
+			'total'           => count( $items ),
+			'completed'       => $completed,
+			'current_index'    => $this->first_pending_index( $items ),
+			'replace_map'      => $replace_map,
+			'created_at'      => $now,
+			'updated_at'      => $now,
+		];
+
+		if ( ! $this->persist_run( $run ) ) {
+			return new \WP_Error(
+				'rms_wizard_landing_run_persist_failed',
+				\__( 'The landing run plan could not be persisted before processing.', 'simple-rms-theme' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+				$this->logger->log(
+					'info',
+					'Landing run plan persisted.',
+					[ 'run_id' => $run_id, 'total' => $run['total'], 'completed' => $run['completed'] ]
+				);
+
+				return $run;
+			} finally {
+				$this->release_start_fence( (string) $fence_owner );
+			}
+		}
+
+	/**
+	 * Acquire an atomic mutex for processing one item.
+	 *
+	 * Uses a direct INSERT IGNORE against the unique option_name index.
+	 * WordPress add_option() cannot be used as a mutex because its duplicate-key
+	 * update may report success to two concurrent contenders.
+	 *
+	 * @return bool|\WP_Error
+	 */
+	public function acquire_lease() {
+		$run = $this->get_run();
+
+		if ( null === $run ) {
+			return new \WP_Error(
+				'rms_wizard_landing_no_run',
+				\__( 'No landing run is active. Start a run first.', 'simple-rms-theme' ),
+				[ 'status' => 409 ]
+			);
+		}
+
+		if ( self::RUN_COMPLETED === $run['status'] ) {
+			return new \WP_Error(
+				'rms_wizard_landing_run_complete',
+				\__( 'The landing run is already complete.', 'simple-rms-theme' ),
+				[ 'status' => 409 ]
+			);
+		}
+
+		$option_name = $this->lease_option_name( $run['run_id'] );
+
+		// Clean up an expired mutex from a previous dead worker using a
+		// compare-and-delete, so a contender cannot delete a replacement lease.
+		$existing = $this->read_lease_record( $option_name );
+
+		if ( null !== $existing ) {
+			$expires = is_array( $existing['value'] ) ? (int) ( $existing['value']['expires_at'] ?? 0 ) : 0;
+
+			if ( $expires > time() || 0 === $expires ) {
+				return new \WP_Error(
+					'rms_wizard_landing_lease_active',
+					\__( 'Another landing process request is already running. Wait for it to finish or expire.', 'simple-rms-theme' ),
+					[ 'status' => 409 ]
+				);
+			}
+
+			if ( ! $this->delete_lease_record( $option_name, $existing['raw'] ) ) {
+				return new \WP_Error(
+					'rms_wizard_landing_lease_active',
+					\__( 'Another landing process request acquired the execution lease.', 'simple-rms-theme' ),
+					[ 'status' => 409 ]
+				);
+			}
+		}
+
+		$budget = $this->configure_execution_budget();
+
+		if ( \is_wp_error( $budget ) ) {
+			return $budget;
+		}
+
+		$owner   = $this->mint_owner_token();
+		$ttl     = $budget + self::LEASE_MARGIN;
+		$now     = time();
+		$payload = [
+			'owner'        => $owner,
+			'acquired_at'  => $now,
+			'expires_at'   => $now + $ttl,
+		];
+
+		$acquired = $this->insert_lease_record( $option_name, $payload );
+
+		if ( ! $acquired ) {
+			// Race lost — another worker got the mutex.
+			return new \WP_Error(
+				'rms_wizard_landing_lease_active',
+				\__( 'Another landing process request is already running. Wait for it to finish or expire.', 'simple-rms-theme' ),
+				[ 'status' => 409 ]
+			);
+		}
+
+		// Mirror safe metadata into run state (atomic option is authority).
+		$run['lease_owner']     = $owner;
+		$run['lease_expires_at'] = $now + $ttl;
+		$run['updated_at']      = $now;
+		$this->persist_run( $run );
+
+		return $owner;
+	}
+
+	/**
+	 * Release the mutex lease — only by the owner.
+	 *
+	 * @param string $owner The owner token from acquire_lease.
+	 */
+	public function release_lease( string $owner ): void {
+		$run = $this->get_run();
+
+		if ( null === $run ) {
+			return;
+		}
+
+		$option_name = $this->lease_option_name( $run['run_id'] );
+		$existing    = $this->read_lease_record( $option_name );
+
+		if (
+			null !== $existing
+			&& is_array( $existing['value'] )
+			&& (string) ( $existing['value']['owner'] ?? '' ) === $owner
+			&& $this->delete_lease_record( $option_name, $existing['raw'] )
+		) {
+			unset( $run['lease_owner'], $run['lease_expires_at'] );
+			$run['updated_at'] = time();
+			$this->persist_run( $run );
+		}
+	}
+
+	/**
+	 * Acquire the site-wide start fence so check + plan persist are serialized.
+	 *
+	 * Uses the same INSERT IGNORE / exact-value CAS delete as the processing lease.
+	 * TTL is finite; a crashed starter cannot block new starts forever.
+	 *
+	 * @return string|\WP_Error Owner token on success.
+	 */
+	public function acquire_start_fence() {
+		$option_name = self::START_FENCE_OPTION;
+		$existing    = $this->read_lease_record( $option_name );
+
+		if ( null !== $existing ) {
+			$expires = is_array( $existing['value'] ) ? (int) ( $existing['value']['expires_at'] ?? 0 ) : 0;
+
+			if ( $expires > time() || 0 === $expires ) {
+				return new \WP_Error(
+					'rms_wizard_landing_start_fence_active',
+					\__( 'Another landing start request is already initializing a run.', 'simple-rms-theme' ),
+					[ 'status' => 409 ]
+				);
+			}
+
+			if ( ! $this->delete_lease_record( $option_name, $existing['raw'] ) ) {
+				return new \WP_Error(
+					'rms_wizard_landing_start_fence_active',
+					\__( 'Another landing start request acquired the initialization fence.', 'simple-rms-theme' ),
+					[ 'status' => 409 ]
+				);
+			}
+		}
+
+		$owner   = $this->mint_owner_token();
+		$now     = time();
+		$payload = [
+			'owner'       => $owner,
+			'acquired_at' => $now,
+			'expires_at'  => $now + self::START_FENCE_TTL,
+		];
+
+		if ( ! $this->insert_lease_record( $option_name, $payload ) ) {
+			return new \WP_Error(
+				'rms_wizard_landing_start_fence_active',
+				\__( 'Another landing start request is already initializing a run.', 'simple-rms-theme' ),
+				[ 'status' => 409 ]
+			);
+		}
+
+		return $owner;
+	}
+
+	/**
+	 * Release the start fence — only by the exact owner token.
+	 */
+	public function release_start_fence( string $owner ): void {
+		if ( '' === $owner ) {
+			return;
+		}
+
+		$option_name = self::START_FENCE_OPTION;
+		$existing    = $this->read_lease_record( $option_name );
+
+		if (
+			null !== $existing
+			&& is_array( $existing['value'] )
+			&& (string) ( $existing['value']['owner'] ?? '' ) === $owner
+		) {
+			$this->delete_lease_record( $option_name, $existing['raw'] );
+		}
+	}
+
+	/**
+	 * Recover stale/expired lease: convert running items to interrupted.
+	 *
+	 * Called on state load / process entry to clean up after a dead process.
+	 * Checks the atomic mutex option, not run state mirrors.
+	 */
+	public function recover_stale_lease(): void {
+		$run = $this->get_run();
+
+		if ( null === $run ) {
+			return;
+		}
+
+		$now     = time();
+		$changed  = false;
+		$mutex_is_gone = false;
+		$run_id   = (string) ( $run['run_id'] ?? '' );
+
+		// Check the atomic mutex — only recover if it has expired.
+		if ( '' !== $run_id ) {
+			$option_name = $this->lease_option_name( $run_id );
+			$lease       = $this->read_lease_record( $option_name );
+
+			if ( null !== $lease && is_array( $lease['value'] ) ) {
+				$expires = (int) ( $lease['value']['expires_at'] ?? 0 );
+
+				if ( $expires > 0 && $expires <= $now && $this->delete_lease_record( $option_name, $lease['raw'] ) ) {
+					unset( $run['lease_owner'], $run['lease_expires_at'] );
+					$changed = true;
+					$mutex_is_gone = true;
+				}
+			} elseif ( null === $lease ) {
+				$mutex_is_gone = true;
+				// No mutex option — clear stale mirror if present.
+				if ( isset( $run['lease_owner'] ) || isset( $run['lease_expires_at'] ) ) {
+					unset( $run['lease_owner'], $run['lease_expires_at'] );
+					$changed = true;
+				}
+			}
+		}
+
+			// A live mutex means a worker is still authoritative. Only recover item
+			// state after the mutex is proven absent or its exact expired value was removed.
+			if ( $mutex_is_gone ) {
+				$interrupted_running = false;
+
+				foreach ( $run['items'] as &$item ) {
+					if ( self::ITEM_RUNNING === $item['status'] ) {
+						$item['status']        = self::ITEM_INTERRUPTED;
+						$item['error_message'] = \__( 'The previous process request was interrupted.', 'simple-rms-theme' );
+						$changed               = true;
+						$interrupted_running   = true;
+					}
+				}
+				unset( $item );
+
+				if ( $interrupted_running && in_array( (string) ( $run['status'] ?? '' ), [ self::RUN_PENDING, self::RUN_RUNNING ], true ) ) {
+					$run['status'] = self::RUN_INTERRUPTED;
+					$changed       = true;
+				}
+			}
+
+		// Update run status based on remaining items.
+		if ( self::RUN_RUNNING === $run['status'] ) {
+			$has_active = $this->has_active_items( $run['items'] );
+
+			if ( ! $has_active && $run['completed'] !== $run['total'] ) {
+				$run['status'] = self::RUN_INTERRUPTED;
+				$changed       = true;
+			}
+		}
+
+		if ( $changed ) {
+			$run['updated_at'] = $now;
+			$this->persist_run( $run );
+
+			$this->logger->log(
+				'warning',
+				'Landing run stale lease recovered; running items marked interrupted.',
+				[ 'run_id' => $run_id ]
+			);
+		}
+	}
+
+	/**
+	 * Mark an item as running before work begins.
+	 *
+	 * @param string $item_key Landing key of the item.
+	 *
+	 * @return array<string,mixed>|\WP_Error The item to process, or WP_Error.
+	 */
+	public function mark_item_running( string $item_key ) {
+		$run = $this->get_run();
+
+		if ( null === $run ) {
+			return new \WP_Error( 'rms_wizard_landing_no_run', \__( 'No landing run is active.', 'simple-rms-theme' ), [ 'status' => 409 ] );
+		}
+
+		$found = false;
+
+		foreach ( $run['items'] as &$item ) {
+			if ( $item['key'] === $item_key ) {
+				if ( self::ITEM_COMPLETED === $item['status'] ) {
+					return new \WP_Error(
+						'rms_wizard_landing_item_completed',
+						\__( 'This landing item is already completed.', 'simple-rms-theme' ),
+						[ 'status' => 409 ]
+					);
+				}
+
+				$item['status']     = self::ITEM_RUNNING;
+				$item['started_at'] = time();
+				$found              = true;
+				break;
+			}
+		}
+		unset( $item );
+
+		if ( ! $found ) {
+			return new \WP_Error( 'rms_wizard_landing_item_not_found', \__( 'The landing item was not found in the run plan.', 'simple-rms-theme' ), [ 'status' => 404 ] );
+		}
+
+		$run['status']        = self::RUN_RUNNING;
+		$run['current_index']  = $this->index_of( $run['items'], $item_key );
+		$run['updated_at']     = time();
+
+		if ( ! $this->persist_run( $run ) ) {
+			return new \WP_Error( 'rms_wizard_landing_run_persist_failed', \__( 'Could not persist the running item status.', 'simple-rms-theme' ), [ 'status' => 500 ] );
+		}
+
+		return $run['items'][ $run['current_index'] ];
+	}
+
+	/**
+	 * Checkpoint a completed item: persist entry to state.landing_pages and mark item complete.
+	 *
+	 * Atomically saves run + landing_pages in one save_state() call.
+	 *
+	 * @param string                 $item_key      Landing key.
+	 * @param array<string,mixed>    $entry         Landing page entry.
+	 * @param array<string,array<string,mixed>> $landing_pages Current state.landing_pages keyed by landing_key.
+	 *
+	 * @return array<string,mixed>|\WP_Error Updated landing_pages (keyed), or WP_Error.
+	 */
+	public function checkpoint_item( string $item_key, array $entry, array $landing_pages ) {
+		$run = $this->get_run();
+
+		if ( null === $run ) {
+			return new \WP_Error( 'rms_wizard_landing_no_run', \__( 'No landing run is active.', 'simple-rms-theme' ), [ 'status' => 409 ] );
+		}
+
+		$now = time();
+
+		foreach ( $run['items'] as &$item ) {
+			if ( $item['key'] === $item_key ) {
+				$item['status']       = self::ITEM_COMPLETED;
+				$item['post_id']       = (int) ( $entry['id'] ?? 0 );
+				$item['completed_at']  = $now;
+				$item['error_code']    = '';
+				$item['error_message'] = '';
+				break;
+			}
+		}
+		unset( $item );
+
+		$run['completed']    = count( array_filter( $run['items'], static fn( $i ): bool => self::ITEM_COMPLETED === $i['status'] ) );
+		$run['current_index'] = $this->first_pending_index( $run['items'] );
+
+		if ( ! $this->has_active_items( $run['items'] ) && $run['completed'] === $run['total'] ) {
+			$run['status'] = self::RUN_COMPLETED;
+		}
+
+		$run['updated_at'] = $now;
+
+		// Persist run plan + landing_pages atomically in one save.
+		$state                     = $this->state_manager->get_state();
+		$landing_pages[ $item_key ] = $entry;
+		$state['landing_pages']    = array_values( $landing_pages );
+		$state[ self::STATE_KEY ]  = $run;
+
+		$saved = $this->state_manager->save_state( $state );
+
+		if ( ! $saved ) {
+			// Verify by re-reading and comparing normalized content.
+			$reloaded = $this->state_manager->get_state();
+			$actual_run = is_array( $reloaded[ self::STATE_KEY ] ?? null ) ? $reloaded[ self::STATE_KEY ] : [];
+			$actual_pages = is_array( $reloaded['landing_pages'] ?? null ) ? $reloaded['landing_pages'] : [];
+
+			if ( ! $this->checkpoint_matches( $run, $actual_run, $state['landing_pages'], $actual_pages ) ) {
+				return new \WP_Error( 'rms_wizard_landing_checkpoint_failed', \__( 'The landing checkpoint could not be persisted.', 'simple-rms-theme' ), [ 'status' => 500 ] );
+			}
+		}
+
+		return $landing_pages;
+	}
+
+	/**
+	 * Mark an item as failed or interrupted (distinguished by $status).
+	 *
+	 * @param string $item_key      Landing key.
+	 * @param string $status        interrupted | failed.
+	 * @param string $error_code    Error code.
+	 * @param string $error_message Error message.
+	 *
+	 * @return bool
+	 */
+	public function mark_item_error( string $item_key, string $status, string $error_code, string $error_message ): bool {
+		$run = $this->get_run();
+
+		if ( null === $run ) {
+			return false;
+		}
+
+		$valid_status = in_array( $status, [ self::ITEM_INTERRUPTED, self::ITEM_FAILED ], true ) ? $status : self::ITEM_FAILED;
+
+		foreach ( $run['items'] as &$item ) {
+			if ( $item['key'] === $item_key ) {
+				$item['status']       = $valid_status;
+				$item['error_code']    = $error_code;
+				$item['error_message'] = $error_message;
+				break;
+			}
+		}
+		unset( $item );
+
+		// Run status: failed if any item failed, interrupted otherwise.
+		$run['status']     = self::ITEM_FAILED === $valid_status ? self::RUN_FAILED : self::RUN_INTERRUPTED;
+		$run['updated_at'] = time();
+
+		return $this->persist_run( $run );
+	}
+
+	/**
+	 * Transition failed items back to interrupted so Resume retries the same keys.
+	 *
+	 * Does not rebuild the persisted plan. Error attribution stays on the item
+	 * until a later successful checkpoint.
+	 */
+	public function rearm_failed_items_for_resume(): bool {
+		$run = $this->get_run();
+
+		if ( null === $run ) {
+			return false;
+		}
+
+		$changed = false;
+
+		foreach ( $run['items'] as &$item ) {
+			if ( self::ITEM_FAILED === ( $item['status'] ?? '' ) ) {
+				$item['status'] = self::ITEM_INTERRUPTED;
+				$changed        = true;
+			}
+		}
+		unset( $item );
+
+		if ( ! $changed ) {
+			return true;
+		}
+
+		if ( in_array( (string) ( $run['status'] ?? '' ), [ self::RUN_FAILED, self::RUN_COMPLETED ], true ) ) {
+			$run['status'] = self::RUN_INTERRUPTED;
+		}
+
+		$run['updated_at'] = time();
+
+		return $this->persist_run( $run );
+	}
+
+	/**
+	 * Get the first pending or interrupted item to process.
+	 *
+	 * @return array<string,mixed>|null
+	 */
+	public function get_next_item(): ?array {
+		$run = $this->get_run();
+
+		if ( null === $run ) {
+			return null;
+		}
+
+		foreach ( $run['items'] as $item ) {
+			if ( in_array( $item['status'], self::PROCESSABLE_STATUSES, true ) ) {
+				return $item;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Determine whether the run is truly complete: all items completed, no active items.
+	 */
+	public function is_run_complete(): bool {
+		$run = $this->get_run();
+
+		if ( null === $run ) {
+			return false;
+		}
+
+		if ( self::RUN_COMPLETED !== $run['status'] ) {
+			return false;
+		}
+
+		// Defense in depth: verify no active items remain.
+		return ! $this->has_active_items( $run['items'] );
+	}
+
+	/**
+	 * Determine whether any items are still pending/running/interrupted/failed.
+	 *
+	 * @param array<int,array<string,mixed>> $items
+	 */
+	private function has_active_items( array $items ): bool {
+		foreach ( $items as $item ) {
+			if ( in_array( $item['status'], self::ACTIVE_STATUSES, true ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get the index of the first pending/interrupted item, or -1.
+	 *
+	 * @param array<int,array<string,mixed>> $items
+	 */
+	private function first_pending_index( array $items ): int {
+		foreach ( $items as $index => $item ) {
+			if ( in_array( $item['status'], self::PROCESSABLE_STATUSES, true ) ) {
+				return $index;
+			}
+		}
+
+		return -1;
+	}
+
+	/**
+	 * Get the index of an item by key.
+	 *
+	 * @param array<int,array<string,mixed>> $items
+	 */
+	private function index_of( array $items, string $key ): int {
+		foreach ( $items as $index => $item ) {
+			if ( $item['key'] === $key ) {
+				return $index;
+			}
+		}
+
+		return -1;
+	}
+
+	/**
+	 * Compare a submitted row against an existing state entry.
+	 *
+	 * Returns true when identity/type/title/slug/keyword/sections/menu inputs are unchanged.
+	 * Entries without sections (e.g. manually recovered) compare unchanged when
+	 * identity/type/title/slug/keywords match and the row has default sections.
+	 *
+	 * @param array<string,mixed> $row    Submitted row.
+	 * @param array<string,mixed> $existing Existing state entry.
+	 */
+	private function landing_unchanged( array $row, array $existing ): bool {
+		$fields = [ 'title', 'slug', 'landing_type', 'primary_keyword' ];
+
+		foreach ( $fields as $field ) {
+			if ( (string) ( $row[ $field ] ?? '' ) !== (string) ( $existing[ $field ] ?? '' ) ) {
+				return false;
+			}
+		}
+
+		// Compare subkeywords (order-insensitive bag).
+		$row_sub      = is_array( $row['subkeywords'] ?? null ) ? array_values( $row['subkeywords'] ) : [];
+		$existing_sub = is_array( $existing['subkeywords'] ?? null ) ? array_values( $existing['subkeywords'] ) : [];
+
+		sort( $row_sub, SORT_STRING );
+		sort( $existing_sub, SORT_STRING );
+
+		if ( $row_sub !== $existing_sub ) {
+			return false;
+		}
+
+		// Compare menu_eligible.
+		$row_menu    = ! empty( $row['menu_eligible'] );
+		$existing_menu = ! empty( $existing['menu_eligible'] );
+
+		if ( $row_menu !== $existing_menu ) {
+			return false;
+		}
+
+		// Compare normalized sections when both sides have them.
+		// Recovered entries may lack sections — treat as unchanged when absent.
+		$row_sections      = is_array( $row['sections'] ?? null ) ? $row['sections'] : [];
+		$existing_sections = is_array( $existing['sections'] ?? null ) ? $existing['sections'] : null;
+
+		if ( null !== $existing_sections && [] !== $existing_sections ) {
+			$row_norm      = $this->normalize_sections_for_compare( $row_sections );
+			$existing_norm = $this->normalize_sections_for_compare( $existing_sections );
+
+			if ( $row_norm !== $existing_norm ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Normalize section rows for order-sensitive comparison.
+	 *
+	 * @param array<int,array<string,mixed>> $sections
+	 *
+	 * @return array<int,array{layout:string,item_count:int,override_canonical:bool}>
+	 */
+	private function normalize_sections_for_compare( array $sections ): array {
+		$norm = [];
+
+		foreach ( $sections as $section ) {
+			if ( ! is_array( $section ) ) {
+				continue;
+			}
+
+			$norm[] = [
+				'layout'             => (string) ( $section['layout'] ?? '' ),
+				'item_count'         => (int) ( $section['item_count'] ?? 0 ),
+				'override_canonical' => ! empty( $section['override_canonical'] ),
+			];
+		}
+
+		return $norm;
+	}
+
+	/**
+	 * Check whether a row uses any layout in the replace_map (per-item invalidation).
+	 *
+	 * @param array<string,mixed> $row
+	 * @param array<string,bool>  $replace_map
+	 */
+	private function item_has_replace( array $row, array $replace_map ): bool {
+		if ( empty( $replace_map ) ) {
+			return false;
+		}
+
+		$sections = is_array( $row['sections'] ?? null ) ? $row['sections'] : [];
+
+		foreach ( $sections as $section ) {
+			if ( ! is_array( $section ) ) {
+				continue;
+			}
+
+			$layout = (string) ( $section['layout'] ?? '' );
+
+			if ( '' !== $layout && ! empty( $replace_map[ $layout ] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Normalize a persisted run for backward compatibility.
+	 * Validates items shape; logs and discards unsupported schemas.
+	 */
+	private function normalize_run( array $run ): ?array {
+		$version = (int) ( $run['schema_version'] ?? 0 );
+
+		if ( $version > self::SCHEMA_VERSION ) {
+			$this->logger->log(
+				'error',
+				'Landing run schema version is newer than supported; run discarded.',
+				[ 'schema_version' => $version, 'max_supported' => self::SCHEMA_VERSION ]
+			);
+
+			return null;
+		}
+
+		$defaults = [
+			'run_id'          => '',
+			'schema_version'  => self::SCHEMA_VERSION,
+			'status'          => self::RUN_PENDING,
+			'items'           => [],
+			'total'           => 0,
+			'completed'       => 0,
+			'current_index'   => -1,
+			'replace_map'     => [],
+			'created_at'      => 0,
+			'updated_at'      => 0,
+		];
+
+		$normalized = array_replace_recursive( $defaults, $run );
+
+		// Validate items shape.
+		if ( ! is_array( $normalized['items'] ) ) {
+			$this->logger->log( 'error', 'Landing run items is not an array; run discarded.', [ 'run_id' => $normalized['run_id'] ] );
+			return null;
+		}
+
+		$valid_items = [];
+		foreach ( $normalized['items'] as $index => $item ) {
+			if ( ! is_array( $item ) || ! isset( $item['key'] ) || '' === (string) $item['key'] ) {
+				$this->logger->log( 'error', 'Landing run item has no key; item skipped.', [ 'run_id' => $normalized['run_id'], 'index' => $index ] );
+				continue;
+			}
+
+			$valid_items[] = $item;
+		}
+
+		$normalized['items'] = $valid_items;
+		$normalized['total'] = count( $valid_items );
+		$normalized['completed'] = count(
+			array_filter(
+				$valid_items,
+				static fn( array $item ): bool => self::ITEM_COMPLETED === ( $item['status'] ?? '' )
+			)
+		);
+
+		return $normalized;
+	}
+
+	/**
+	 * Persist the run plan into wizard state.
+	 */
+	private function persist_run( array $run ): bool {
+		$state                 = $this->state_manager->get_state();
+		$state[ self::STATE_KEY ] = $run;
+
+		return $this->state_manager->save_state( $state );
+	}
+
+	/**
+	 * Enforce a finite execution budget for one landing request.
+	 *
+	 * A finite environment limit is never increased. Unlimited environments are
+	 * reduced to the bounded item budget so the lease can safely outlive the worker.
+	 *
+	 * @return int|\WP_Error Effective execution budget in seconds.
+	 */
+	private function configure_execution_budget() {
+		$max_exec = 0;
+
+		if ( function_exists( 'ini_get' ) ) {
+			$raw = \ini_get( 'max_execution_time' );
+			$max_exec = false !== $raw ? (int) $raw : 0;
+		}
+
+		$budget = $max_exec > 0
+			? min( $max_exec, self::ITEM_EXECUTION_BUDGET )
+			: self::ITEM_EXECUTION_BUDGET;
+
+		if ( function_exists( 'set_time_limit' ) ) {
+			$result = @\set_time_limit( $budget );
+
+			if ( false === $result && $max_exec <= 0 ) {
+				return new \WP_Error(
+					'rms_wizard_landing_execution_budget_unavailable',
+					\__( 'Landing processing requires a finite PHP execution limit to guarantee safe recovery.', 'simple-rms-theme' ),
+					[ 'status' => 500 ]
+				);
+			}
+		} elseif ( $max_exec <= 0 ) {
+			return new \WP_Error(
+				'rms_wizard_landing_execution_budget_unavailable',
+				\__( 'Landing processing requires a finite PHP execution limit to guarantee safe recovery.', 'simple-rms-theme' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		return $budget;
+	}
+
+	/**
+	 * Read the exact serialized lease row from wp_options, bypassing option cache.
+	 *
+	 * @return array{raw:string,value:mixed}|null
+	 */
+	private function read_lease_record( string $option_name ): ?array {
+		global $wpdb;
+
+		$raw = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s LIMIT 1",
+				$option_name
+			)
+		);
+
+		if ( null === $raw ) {
+			return null;
+		}
+
+		return [
+			'raw'   => (string) $raw,
+			'value' => \maybe_unserialize( $raw ),
+		];
+	}
+
+	/**
+	 * Atomically insert a lease. The unique option_name index admits one owner.
+	 */
+	private function insert_lease_record( string $option_name, array $payload ): bool {
+		global $wpdb;
+
+		$inserted = $wpdb->query(
+			$wpdb->prepare(
+				"INSERT IGNORE INTO {$wpdb->options} (option_name, option_value, autoload) VALUES (%s, %s, %s)",
+				$option_name,
+				\maybe_serialize( $payload ),
+				'no'
+			)
+		);
+
+		if ( 1 !== $inserted ) {
+			return false;
+		}
+
+		\wp_cache_delete( $option_name, 'options' );
+
+		return true;
+	}
+
+	/**
+	 * Delete only the exact lease value previously read (compare-and-delete).
+	 */
+	private function delete_lease_record( string $option_name, string $raw_value ): bool {
+		global $wpdb;
+
+		$deleted = $wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->options} WHERE option_name = %s AND option_value = %s",
+				$option_name,
+				$raw_value
+			)
+		);
+
+		if ( 1 !== $deleted ) {
+			return false;
+		}
+
+		\wp_cache_delete( $option_name, 'options' );
+
+		return true;
+	}
+
+	/**
+	 * Generate a stable run identifier.
+	 */
+	private function mint_run_id(): string {
+		if ( function_exists( 'wp_generate_uuid4' ) ) {
+			return 'run_' . str_replace( '-', '', \wp_generate_uuid4() );
+		}
+
+		return 'run_' . \sanitize_key( uniqid( '', true ) );
+	}
+
+	/**
+	 * Generate a unique owner token for the lease.
+	 */
+	private function mint_owner_token(): string {
+		if ( function_exists( 'wp_generate_uuid4' ) ) {
+			return \wp_generate_uuid4();
+		}
+
+		return uniqid( 'owner_', true );
+	}
+
+	/**
+	 * Build the wp_options name for a run's atomic mutex.
+	 */
+	private function lease_option_name( string $run_id ): string {
+		return 'rms_landing_lease_' . \sanitize_key( $run_id );
+	}
+
+	/**
+	 * Verify that a checkpoint was persisted correctly by comparing
+	 * normalized content and keys, not just count.
+	 *
+	 * @param array<string,mixed> $expected_run
+	 * @param array<string,mixed> $actual_run
+	 * @param array<int,array<string,mixed>> $expected_pages
+	 * @param array<int,array<string,mixed>> $actual_pages
+	 */
+	private function checkpoint_matches( array $expected_run, array $actual_run, array $expected_pages, array $actual_pages ): bool {
+		// Compare run item statuses (the critical state that changed).
+		$expected_statuses = [];
+		foreach ( is_array( $expected_run['items'] ?? [] ) as $item ) {
+			if ( is_array( $item ) && isset( $item['key'] ) ) {
+				$expected_statuses[ $item['key'] ] = $item['status'] ?? '';
+			}
+		}
+
+		$actual_statuses = [];
+		foreach ( is_array( $actual_run['items'] ?? [] ) as $item ) {
+			if ( is_array( $item ) && isset( $item['key'] ) ) {
+				$actual_statuses[ $item['key'] ] = $item['status'] ?? '';
+			}
+		}
+
+		if ( $expected_statuses !== $actual_statuses ) {
+			return false;
+		}
+
+		// Compare landing page keys.
+		$expected_keys = [];
+		foreach ( $expected_pages as $page ) {
+			if ( is_array( $page ) && isset( $page['landing_key'] ) ) {
+				$expected_keys[ $page['landing_key'] ] = (int) ( $page['id'] ?? 0 );
+			}
+		}
+
+		$actual_keys = [];
+		foreach ( $actual_pages as $page ) {
+			if ( is_array( $page ) && isset( $page['landing_key'] ) ) {
+				$actual_keys[ $page['landing_key'] ] = (int) ( $page['id'] ?? 0 );
+			}
+		}
+
+		return $expected_keys === $actual_keys;
+	}
+}

--- a/inc/wizard/class-state-manager.php
+++ b/inc/wizard/class-state-manager.php
@@ -38,6 +38,7 @@ class State_Manager {
             'home_sections'          => [],
             'home_seo_targeting'     => [ 'enabled' => false ],
             'landing_pages'          => [],
+            'landing_run'             => null,
             'canonical_sections'     => [],
             'logs'                   => self::LOG_OPTION,
             'locks'                  => [],

--- a/inc/wizard/class-step-controller.php
+++ b/inc/wizard/class-step-controller.php
@@ -129,6 +129,18 @@ class Step_Controller {
 		$state['unlocked_by']          = (int) \get_option( Wizard_Unlock_Controller::UNLOCKED_BY_OPTION, 0 );
 		$state['logs']                 = $this->logger->all();
 
+		// Recover stale landing run lease and expose the public run view only.
+		if ( class_exists( __NAMESPACE__ . '\\Landing_Run_Orchestrator' ) ) {
+			$orchestrator = new Landing_Run_Orchestrator( $this->state_manager, $this->logger );
+			$orchestrator->recover_stale_lease();
+
+			$run = $orchestrator->get_public_run();
+
+			if ( null !== $run ) {
+				$state['landing_run'] = $run;
+			}
+		}
+
 		return $state;
 	}
 
@@ -163,11 +175,27 @@ class Step_Controller {
 			return new \WP_Error( 'rms_wizard_busy', \__( 'Another setup wizard action is already running.', 'simple-rms-theme' ), [ 'status' => 409 ] );
 		}
 
+		// Orchestrated landing actions manage their own per-landing mutex lease.
+		// Release the global step lock immediately so it does not expire
+		// during a 5-6 minute per-landing build. The orchestrator's atomic
+		// mutex option (scoped to run id + owner token) is the concurrency boundary.
+		$is_landing_orchestrated = false;
+
+		if ( 'landing-page-builder' === $step ) {
+			$landing_action = \sanitize_key( (string) ( $payload['landing_action'] ?? '' ) );
+
+			if ( in_array( $landing_action, [ 'start', 'process' ], true ) ) {
+				$is_landing_orchestrated = true;
+				$this->state_manager->release_lock( self::LOCK_NAME );
+			}
+		}
+
 		$progress_status_written = false;
 
 		try {
 			// Pseudo-steps (unlock/relock) must not pollute current_step or step_status.
-			if ( ! $this->is_completed_gate_allowlisted( $step ) ) {
+			// Landing start/process keep step_status under the orchestrator, not this lock.
+			if ( ! $this->is_completed_gate_allowlisted( $step ) && ! $is_landing_orchestrated ) {
 				$this->state_manager->set_current_step( $step );
 				$this->state_manager->set_step_status( $step, 'running' );
 				$progress_status_written = true;
@@ -235,7 +263,9 @@ class Step_Controller {
 				[ 'status' => 500 ]
 			);
 		} finally {
-			$this->state_manager->release_lock( self::LOCK_NAME );
+			if ( ! $is_landing_orchestrated ) {
+				$this->state_manager->release_lock( self::LOCK_NAME );
+			}
 		}
 	}
 

--- a/inc/wizard/class-step-landing-page-builder.php
+++ b/inc/wizard/class-step-landing-page-builder.php
@@ -44,6 +44,7 @@ class Step_Landing_Page_Builder {
 	private $canonical_store;
 	private $menu_builder;
 	private $yoast_meta_writer;
+	private $run_orchestrator;
 
 	public function __construct(
 		?Logger $logger = null,
@@ -54,7 +55,8 @@ class Step_Landing_Page_Builder {
 		?AI_Content_Reviewer $reviewer = null,
 		?Canonical_Section_Store $canonical_store = null,
 		?Menu_Builder $menu_builder = null,
-		?Yoast_Meta_Writer $yoast_meta_writer = null
+		?Yoast_Meta_Writer $yoast_meta_writer = null,
+		?Landing_Run_Orchestrator $run_orchestrator = null
 	) {
 		$this->logger            = $logger ?? new Logger();
 		$this->state_manager     = $state_manager ?? new State_Manager();
@@ -65,98 +67,148 @@ class Step_Landing_Page_Builder {
 		$this->canonical_store   = $canonical_store ?? new Canonical_Section_Store();
 		$this->menu_builder      = $menu_builder ?? new Menu_Builder( $this->logger );
 		$this->yoast_meta_writer = $yoast_meta_writer ?? new Yoast_Meta_Writer( $this->logger );
+		$this->run_orchestrator  = $run_orchestrator ?? new Landing_Run_Orchestrator( $this->state_manager, $this->logger );
 	}
 
 	/**
-	 * Run the Landing page builder.
+	 * Run the Landing page builder — orchestrated resumable execution.
+	 *
+	 * API contract: landing_action must be "start" or "process".
+	 *   start  — validate, persist run plan, process first pending item.
+	 *   process — process one pending/interrupted item with lease + checkpoint.
+	 * skip_all is handled via run_skip_all() when landing_action is absent and skip_all=true.
+	 * No landing_action without skip_all → 400 contract error (legacy batch removed).
 	 *
 	 * @param array<string,mixed> $payload Step payload.
 	 *
 	 * @return array<string,mixed>|\WP_Error
 	 */
 	public function run( array $payload ) {
-		if ( $this->truthy( $payload['skip_all'] ?? false ) ) {
-			$state             = $this->state_manager->get_state();
-			$existing_landings = $this->normalize_state_landings(
-				is_array( $state['landing_pages'] ?? null ) ? $state['landing_pages'] : []
-			);
+		$landing_action = \sanitize_key( (string) ( $payload['landing_action'] ?? '' ) );
 
-			// Existing landings must still receive final-state robots/menu reconciliation.
-			// No existing landings → skip-all is a pure no-op complete.
-			if ( [] !== $existing_landings ) {
-				foreach ( $existing_landings as $landing_key => $row ) {
-					if ( ! is_array( $row ) ) {
-						continue;
-					}
-
-					$post_id     = (int) ( $row['id'] ?? 0 );
-					$slug        = (string) ( $row['slug'] ?? '' );
-					$log_context = [
-						'landing_key' => (string) ( $row['landing_key'] ?? $landing_key ),
-						'slug'        => $slug,
-						'skip_all'    => true,
-					];
-
-					if ( $post_id <= 0 || 'page' !== \get_post_type( $post_id ) ) {
-						$post_id = $this->recover_build_page_post_id( $post_id, $slug );
-					}
-
-					if ( $post_id <= 0 || 'page' !== \get_post_type( $post_id ) ) {
-						$this->mark_step_status( 'failed' );
-
-						return new \WP_Error(
-							'rms_wizard_landing_skip_all_missing_post',
-							sprintf(
-								/* translators: %s: landing key or slug. */
-								\__( 'Skip-all could not reconcile landing "%s": page not found.', 'simple-rms-theme' ),
-								'' !== (string) ( $row['landing_key'] ?? '' )
-									? (string) $row['landing_key']
-									: ( '' !== $slug ? $slug : (string) $landing_key )
-							),
-							array_merge( [ 'status' => 500 ], $log_context )
-						);
-					}
-
-					$final_state = $this->sync_landing_final_state( $post_id, $row, $log_context );
-
-					if ( \is_wp_error( $final_state ) ) {
-						$this->mark_step_status( 'failed' );
-						$this->logger->log(
-							'error',
-							'Skip-all final-state sync failed; step not marked complete.',
-							array_merge(
-								$log_context,
-								[
-									'post_id'       => $post_id,
-									'error_code'    => $final_state->get_error_code(),
-									'error_message' => $final_state->get_error_message(),
-								]
-							)
-						);
-
-						return $final_state;
-					}
-				}
-			}
-
-			if ( ! $this->mark_step_status( 'complete' ) ) {
-				return new \WP_Error(
-					'rms_wizard_landing_status_persist_failed',
-					\__( 'Landing step completed but status could not be persisted.', 'simple-rms-theme' ),
-					[ 'status' => 500 ]
-				);
-			}
-			$this->maybe_mark_completed();
-			$state = $this->state_manager->get_state();
-
-			return [
-				'skipped'       => true,
-				'landing_pages' => is_array( $state['landing_pages'] ?? null ) ? $state['landing_pages'] : [],
-			];
+		if ( 'start' === $landing_action ) {
+			return $this->orchestrate_start( $payload );
 		}
 
-		$state     = $this->state_manager->get_state();
-		$ai_config = is_array( $state['ai_config'] ?? null ) ? $state['ai_config'] : [];
+		if ( 'process' === $landing_action ) {
+			return $this->orchestrate_process();
+		}
+
+		// skip_all without landing_action → focused skip-all handler.
+		if ( $this->truthy( $payload['skip_all'] ?? false ) ) {
+			return $this->run_skip_all();
+		}
+
+		// No landing_action and no skip_all → contract error.
+		$this->mark_step_status( 'failed' );
+
+		return new \WP_Error(
+			'rms_wizard_landing_action_required',
+			\__( 'A landing_action (start or process) is required.', 'simple-rms-theme' ),
+			[ 'status' => 400 ]
+		);
+	}
+
+	/**
+	 * Skip-all: complete the landing step without generating new pages.
+	 *
+	 * Existing landings (if any) receive final-state robots/menu reconciliation.
+	 */
+	private function run_skip_all() {
+		$state             = $this->state_manager->get_state();
+		$existing_landings = $this->normalize_state_landings(
+			is_array( $state['landing_pages'] ?? null ) ? $state['landing_pages'] : []
+		);
+
+		if ( [] !== $existing_landings ) {
+			foreach ( $existing_landings as $landing_key => $row ) {
+				if ( ! is_array( $row ) ) {
+					continue;
+				}
+
+				$post_id     = (int) ( $row['id'] ?? 0 );
+				$slug        = (string) ( $row['slug'] ?? '' );
+				$log_context = [
+					'landing_key' => (string) ( $row['landing_key'] ?? $landing_key ),
+					'slug'        => $slug,
+					'skip_all'    => true,
+				];
+
+				if ( $post_id <= 0 || 'page' !== \get_post_type( $post_id ) ) {
+					$post_id = $this->recover_build_page_post_id( $post_id, $slug );
+				}
+
+				if ( $post_id <= 0 || 'page' !== \get_post_type( $post_id ) ) {
+					$this->mark_step_status( 'failed' );
+
+					return new \WP_Error(
+						'rms_wizard_landing_skip_all_missing_post',
+						sprintf(
+							/* translators: %s: landing key or slug. */
+							\__( 'Skip-all could not reconcile landing "%s": page not found.', 'simple-rms-theme' ),
+							'' !== (string) ( $row['landing_key'] ?? '' )
+								? (string) $row['landing_key']
+								: ( '' !== $slug ? $slug : (string) $landing_key )
+						),
+						array_merge( [ 'status' => 500 ], $log_context )
+					);
+				}
+
+				$final_state = $this->sync_landing_final_state( $post_id, $row, $log_context );
+
+				if ( \is_wp_error( $final_state ) ) {
+					$this->mark_step_status( 'failed' );
+					$this->logger->log( 'error', 'Skip-all final-state sync failed; step not marked complete.',
+						array_merge( $log_context, [ 'post_id' => $post_id, 'error_code' => $final_state->get_error_code(), 'error_message' => $final_state->get_error_message() ] )
+					);
+
+					return $final_state;
+				}
+			}
+		}
+
+		if ( ! $this->mark_step_status( 'complete' ) ) {
+			return new \WP_Error(
+				'rms_wizard_landing_status_persist_failed',
+				\__( 'Landing step completed but status could not be persisted.', 'simple-rms-theme' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		$this->maybe_mark_completed();
+		$state = $this->state_manager->get_state();
+
+		return [
+			'skipped'       => true,
+			'landing_pages' => is_array( $state['landing_pages'] ?? null ) ? $state['landing_pages'] : [],
+		];
+	}
+
+	/**
+	 * Start a new landing run plan.
+	 *
+	 * Validates AI config, client data, parses rows, classifies unchanged
+	 * existing entries as complete, persists the plan, then processes first item.
+	 *
+	 * @param array<string,mixed> $payload
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+		private function orchestrate_start( array $payload ) {
+			if ( $this->truthy( $payload['skip_all'] ?? false ) ) {
+				return $this->run_skip_all();
+			}
+
+			if ( $this->run_orchestrator->has_blocking_run() ) {
+				return new \WP_Error(
+					'rms_wizard_landing_run_active',
+					\__( 'A landing run is already active. Wait for it to finish or expire before starting a new run.', 'simple-rms-theme' ),
+					[ 'status' => 409 ]
+				);
+			}
+
+			$state     = $this->state_manager->get_state();
+			$ai_config = is_array( $state['ai_config'] ?? null ) ? $state['ai_config'] : [];
 
 		if ( ! $this->has_ai_config( $ai_config ) ) {
 			$this->mark_step_status( 'failed' );
@@ -204,110 +256,530 @@ class Step_Landing_Page_Builder {
 			);
 		}
 
-		$required_layouts = $this->collect_required_reusable_layouts( $rows );
-		$bootstrap        = $this->ensure_canonical_reusables( $required_layouts, $state, $client_data, $ai_config );
+			// Persist the complete normalized plan before any AI/bootstrap work.
+			$run = $this->run_orchestrator->start_run( $rows, $existing_landings, $replace_map );
 
-		if ( \is_wp_error( $bootstrap ) ) {
+			if ( \is_wp_error( $run ) ) {
+				if ( ! $this->is_start_conflict_error( $run ) ) {
+					$this->mark_step_status( 'failed' );
+				}
+
+				return $run;
+			}
+
+			$this->mark_step_status( 'running' );
+
+			$required_layouts = $this->collect_required_reusable_layouts( $rows );
+			$bootstrap        = $this->ensure_canonical_reusables( $required_layouts, $state, $client_data, $ai_config );
+
+			if ( \is_wp_error( $bootstrap ) ) {
+				$this->mark_step_status( 'failed' );
+
+				return $bootstrap;
+			}
+
+		// Immediately process the first pending item if one exists.
+		$next = $this->run_orchestrator->get_next_item();
+
+		if ( null !== $next ) {
+			return $this->orchestrate_process();
+		}
+
+		// All items already complete (e.g. all unchanged).
+		return $this->orchestrate_finalize();
+	}
+
+	/**
+	 * Process at most one pending/interrupted item.
+	 *
+	 * Flow: recover stale → acquire lease → pre-build reconcile →
+	 * mark running → build → checkpoint → release lease.
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function orchestrate_process() {
+		// Recover stale lease from a prior dead process.
+		$this->run_orchestrator->recover_stale_lease();
+
+		$state     = $this->state_manager->get_state();
+		$ai_config = is_array( $state['ai_config'] ?? null ) ? $state['ai_config'] : [];
+
+		if ( ! $this->has_ai_config( $ai_config ) ) {
 			$this->mark_step_status( 'failed' );
 
-			return $bootstrap;
+			return new \WP_Error( 'rms_wizard_ai_config_required', \__( 'AI configuration required. Complete the IA Generation step first.', 'simple-rms-theme' ), [ 'status' => 400 ] );
 		}
 
-		$client_context = $this->harness->get_harness_context( $client_data );
-		$landing_pages  = $existing_landings;
-		$built          = [];
-		$prior_payloads = [];
-		$built_ids      = [];
+		$client_data = is_array( $state['client_data'] ?? null ) ? $state['client_data'] : [];
+		$missing     = $this->harness->validate_required_context( $client_data );
 
-		foreach ( $rows as $row ) {
-			try {
-				$result = $this->build_one_landing( $row, $replace_map, $client_data, $client_context, $ai_config, $landing_pages, $prior_payloads );
-			} catch ( \Throwable $exception ) {
-				// Convert thrown failures so partial persistence still runs before returning.
-				$landing_key = (string) ( $row['landing_key'] ?? '' );
-				$slug        = (string) ( $row['slug'] ?? '' );
-
-				$this->logger->log(
-					'error',
-					'Wizard landing build threw an exception.',
-					[
-						'landing_key'     => $landing_key,
-						'slug'            => $slug,
-						'exception_class' => get_class( $exception ),
-						'message'         => $exception->getMessage(),
-					]
-				);
-
-				$result = new \WP_Error(
-					'rms_wizard_landing_build_exception',
-					sprintf(
-						/* translators: 1: landing slug or key, 2: exception message. */
-						\__( 'Landing "%1$s" failed unexpectedly: %2$s', 'simple-rms-theme' ),
-						'' !== $slug ? $slug : $landing_key,
-						$exception->getMessage()
-					),
-					[
-						'status'          => 500,
-						'landing_key'     => $landing_key,
-						'slug'            => $slug,
-						'exception_class' => get_class( $exception ),
-					]
-				);
-			}
-
-			if ( \is_wp_error( $result ) ) {
-				// Persist successful landings before failing so partial progress is not lost.
-				$this->persist_partial_landing_progress( $state, $landing_pages, $built_ids, $result );
-
-				return $result;
-			}
-
-			$landing_pages[ $result['landing_key'] ] = $result['entry'];
-			$built[]                                 = $result['entry'];
-			$built_ids[]                             = (int) ( $result['entry']['id'] ?? 0 );
-			$prior_payloads                          = array_merge( $prior_payloads, $result['prior_payloads'] );
-		}
-
-		$state['landing_pages']      = array_values( $landing_pages );
-		$state['canonical_sections'] = $this->canonical_store->summary();
-
-		if ( ! $this->persist_wizard_state( $state, 'full success' ) ) {
+		if ( [] !== $missing ) {
 			$this->mark_step_status( 'failed' );
 
 			return new \WP_Error(
-				'rms_wizard_landing_state_persist_failed',
-				\__( 'Landing pages were built but wizard state could not be persisted.', 'simple-rms-theme' ),
-				[
-					'status'    => 500,
-					'post_ids'  => array_values( array_filter( $built_ids ) ),
-					'built'     => count( $built ),
-				]
+				'rms_wizard_landing_required_client_data_missing',
+				sprintf(
+					/* translators: %s: comma-separated missing client data keys. */
+					\__( 'Missing required client data: %s. Complete your client profile before generating.', 'simple-rms-theme' ),
+					implode( ', ', $missing )
+				),
+				[ 'status' => 400 ]
 			);
 		}
+
+		// Reject concurrent process requests for the same run.
+		$lease_result = $this->run_orchestrator->acquire_lease();
+
+		if ( \is_wp_error( $lease_result ) ) {
+			if ( ! $this->is_lease_conflict_error( $lease_result ) ) {
+				$this->mark_step_status( 'failed' );
+			}
+
+			return $lease_result;
+		}
+
+		/** @var string $lease_owner */
+		$lease_owner = $lease_result;
+
+		$run = $this->run_orchestrator->get_run();
+
+		if ( null === $run ) {
+			$this->run_orchestrator->release_lease( $lease_owner );
+			$this->mark_step_status( 'failed' );
+
+			return new \WP_Error( 'rms_wizard_landing_no_run', \__( 'No landing run is active. Start a run first.', 'simple-rms-theme' ), [ 'status' => 409 ] );
+		}
+
+		if ( ! $this->run_orchestrator->rearm_failed_items_for_resume() ) {
+			$this->run_orchestrator->release_lease( $lease_owner );
+			$this->mark_step_status( 'failed' );
+
+			return new \WP_Error(
+				'rms_wizard_landing_run_persist_failed',
+				\__( 'The persisted landing run could not be prepared for resume.', 'simple-rms-theme' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		$replace_map = is_array( $run['replace_map'] ?? null ) ? $run['replace_map'] : [];
+		$item        = $this->run_orchestrator->get_next_item();
+
+		if ( null === $item ) {
+			$this->run_orchestrator->release_lease( $lease_owner );
+
+			// No more processable items — finalize if truly complete.
+			return $this->orchestrate_finalize();
+		}
+
+		$item_key = (string) ( $item['key'] ?? '' );
+
+		// Pre-build reconciliation: if the item is interrupted (from a prior crash)
+		// and a post already exists by ID/key/slug with landing meta, reconcile it
+		// instead of calling build_one_landing again (no duplicate creation).
+		$checkpointed_post_id = (int) ( $item['post_id'] ?? 0 );
+
+		if ( Landing_Run_Orchestrator::ITEM_INTERRUPTED === $item['status'] && $checkpointed_post_id <= 0 ) {
+			$recovered_id = $this->recover_build_page_post_id( (int) ( $item['id'] ?? 0 ), (string) ( $item['slug'] ?? '' ) );
+
+			if ( $recovered_id > 0 && $this->page_has_landing_type( $recovered_id ) ) {
+				$row_for_reconcile = $this->item_to_row( $item );
+				$landing_pages     = $this->normalize_state_landings( is_array( $state['landing_pages'] ?? null ) ? $state['landing_pages'] : [] );
+				$reconciled        = $this->reconcile_post_created_before_checkpoint( $recovered_id, $row_for_reconcile );
+
+				if ( \is_wp_error( $reconciled ) ) {
+					$this->logger->log(
+						'error',
+						'Pre-build reconciliation found an existing landing but finalization failed; refusing duplicate creation.',
+						[ 'item_key' => $item_key, 'recovered_id' => $recovered_id, 'error_code' => $reconciled->get_error_code() ]
+					);
+					$this->run_orchestrator->mark_item_error( $item_key, 'failed', $reconciled->get_error_code(), $reconciled->get_error_message() );
+					$this->run_orchestrator->release_lease( $lease_owner );
+					$this->mark_step_status( 'failed' );
+
+					return $reconciled;
+				}
+
+				// Atomically checkpoint the reconciled entry before finalize.
+				$landing_pages = $this->run_orchestrator->checkpoint_item( $item_key, $reconciled, $landing_pages );
+
+				if ( \is_wp_error( $landing_pages ) ) {
+					$this->run_orchestrator->release_lease( $lease_owner );
+					$this->mark_step_status( 'failed' );
+
+					return $landing_pages;
+				}
+
+				$this->run_orchestrator->release_lease( $lease_owner );
+
+				if ( $this->run_orchestrator->is_run_complete() ) {
+					return $this->orchestrate_finalize();
+				}
+
+				return $this->build_progress_response();
+			}
+		}
+
+		// Mark item running before work.
+		$running_item = $this->run_orchestrator->mark_item_running( $item_key );
+
+		if ( \is_wp_error( $running_item ) ) {
+			$this->run_orchestrator->release_lease( $lease_owner );
+			$this->mark_step_status( 'failed' );
+
+			return $running_item;
+		}
+
+		$client_context = $this->harness->get_harness_context( $client_data );
+		$landing_pages   = $this->normalize_state_landings( is_array( $state['landing_pages'] ?? null ) ? $state['landing_pages'] : [] );
+		$row             = $this->item_to_row( $item );
+
+		try {
+			$result = $this->build_one_landing( $row, $replace_map, $client_data, $client_context, $ai_config, $landing_pages, [] );
+		} catch ( \Throwable $exception ) {
+			$landing_key = (string) ( $row['landing_key'] ?? $item_key );
+			$slug        = (string) ( $row['slug'] ?? '' );
+
+			$this->logger->log(
+				'error',
+				'Wizard landing build threw an exception during orchestrated processing.',
+				[ 'landing_key' => $landing_key, 'slug' => $slug, 'exception_class' => get_class( $exception ), 'message' => $exception->getMessage() ]
+			);
+
+			// Attempt post-exception recovery by ID/key/slug.
+			$recovered_id = $this->recover_build_page_post_id( (int) ( $row['id'] ?? 0 ), (string) ( $row['slug'] ?? '' ) );
+
+			if ( $recovered_id > 0 && $this->page_has_landing_type( $recovered_id ) ) {
+				$reconciled = $this->reconcile_post_created_before_checkpoint( $recovered_id, $row );
+
+				if ( ! \is_wp_error( $reconciled ) ) {
+					$landing_pages = $this->run_orchestrator->checkpoint_item( $item_key, $reconciled, $landing_pages );
+
+					if ( \is_wp_error( $landing_pages ) ) {
+						$this->run_orchestrator->release_lease( $lease_owner );
+						$this->mark_step_status( 'failed' );
+
+						return $landing_pages;
+					}
+
+					$this->run_orchestrator->release_lease( $lease_owner );
+
+					if ( $this->run_orchestrator->is_run_complete() ) {
+						return $this->orchestrate_finalize();
+					}
+
+					return $this->build_progress_response();
+				}
+			}
+
+			$result = new \WP_Error(
+				'rms_wizard_landing_build_exception',
+				sprintf(
+					/* translators: 1: landing slug or key, 2: exception message. */
+					\__( 'Landing "%1$s" failed unexpectedly: %2$s', 'simple-rms-theme' ),
+					'' !== $slug ? $slug : $landing_key,
+					$exception->getMessage()
+				),
+				[ 'status' => 500, 'landing_key' => $landing_key, 'slug' => $slug, 'exception_class' => get_class( $exception ) ]
+			);
+		}
+
+		if ( \is_wp_error( $result ) ) {
+			$error_status = $this->classify_error( $result );
+
+			$this->run_orchestrator->mark_item_error( $item_key, 'failed', $result->get_error_code(), $result->get_error_message() );
+			$this->run_orchestrator->release_lease( $lease_owner );
+			$this->mark_step_status( 'failed' );
+
+			// Preserve provider/status attribution in the error data.
+			$error_data = $result->get_error_data();
+
+			if ( is_array( $error_data ) ) {
+				$error_data['attribution'] = $error_status;
+				$result->add_data( $error_data );
+			}
+
+			return $result;
+		}
+
+		/** @var array{entry:array<string,mixed>,landing_key:string,prior_payloads:array<int,array<string,mixed>>} $result */
+		$entry = $result['entry'];
+
+		// Atomic checkpoint: persist entry + mark item complete.
+		$landing_pages = $this->run_orchestrator->checkpoint_item( $item_key, $entry, $landing_pages );
+
+		if ( \is_wp_error( $landing_pages ) ) {
+			$this->run_orchestrator->release_lease( $lease_owner );
+			$this->mark_step_status( 'failed' );
+
+			return $landing_pages;
+		}
+
+		$this->run_orchestrator->release_lease( $lease_owner );
+
+		if ( $this->run_orchestrator->is_run_complete() ) {
+			return $this->orchestrate_finalize();
+		}
+
+		return $this->build_progress_response();
+	}
+
+	/**
+	 * Convert a run plan item array into a build row.
+	 *
+	 * @param array<string,mixed> $item
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function item_to_row( array $item ): array {
+		return [
+			'id'              => (int) ( $item['post_id'] ?? $item['id'] ?? 0 ),
+			'landing_key'     => (string) ( $item['landing_key'] ?? $item['key'] ?? '' ),
+			'title'           => (string) ( $item['title'] ?? '' ),
+			'slug'            => (string) ( $item['slug'] ?? '' ),
+			'landing_type'    => (string) ( $item['landing_type'] ?? 'seo' ),
+			'menu_eligible'   => ! empty( $item['menu_eligible'] ),
+			'primary_keyword' => (string) ( $item['primary_keyword'] ?? '' ),
+			'subkeywords'     => is_array( $item['subkeywords'] ?? null ) ? array_values( $item['subkeywords'] ) : [],
+			'sections'        => is_array( $item['sections'] ?? null ) ? $item['sections'] : [],
+		];
+	}
+
+	/**
+	 * Build a progress response from current run state.
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function build_progress_response() {
+		$run  = $this->run_orchestrator->get_run();
+
+		if ( null === $run ) {
+			$this->mark_step_status( 'failed' );
+
+			return new \WP_Error( 'rms_wizard_landing_run_lost', \__( 'The landing run plan was lost after checkpoint.', 'simple-rms-theme' ), [ 'status' => 500 ] );
+		}
+
+		$completed     = $run['completed'];
+		$total         = $run['total'];
+		$next_item     = $this->run_orchestrator->get_next_item();
+		$current_title = $next_item ? (string) ( $next_item['title'] ?? '' ) : '';
+
+		$this->logger->log(
+			'info',
+			sprintf( 'Landing run progress: %d of %d completed.', $completed, $total ),
+			[ 'run_id' => $run['run_id'], 'completed' => $completed, 'total' => $total ]
+		);
+
+		$state = $this->state_manager->get_state();
+
+		return [
+			'landing_run'   => $this->public_run_view( $run ),
+			'completed'     => $completed,
+			'total'         => $total,
+			'current_title' => $current_title,
+			'landing_pages' => is_array( $state['landing_pages'] ?? null ) ? $state['landing_pages'] : [],
+		];
+	}
+
+	/**
+	 * Reconcile a post that was created before checkpoint (crash recovery).
+	 *
+	 * Verifies the post exists, has landing meta, syncs final state,
+	 * and constructs the entry without duplicate creation.
+	 *
+	 * @param int                 $post_id
+	 * @param array<string,mixed> $row
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function reconcile_post_created_before_checkpoint( int $post_id, array $row ) {
+		if ( $post_id <= 0 || ! $this->page_has_landing_type( $post_id ) ) {
+			return new \WP_Error(
+				'rms_wizard_landing_reconcile_failed',
+				\__( 'Could not reconcile the landing page after an interrupted process.', 'simple-rms-theme' ),
+				[ 'status' => 500, 'post_id' => $post_id ]
+			);
+		}
+
+		$log_context = [
+			'landing_key'  => (string) ( $row['landing_key'] ?? '' ),
+			'slug'         => (string) ( $row['slug'] ?? '' ),
+			'title'        => (string) ( $row['title'] ?? '' ),
+			'landing_type' => (string) ( $row['landing_type'] ?? 'seo' ),
+		];
+
+		$meta_ok = $this->ensure_landing_meta( $post_id, (string) ( $row['landing_type'] ?? 'seo' ), $log_context );
+
+		if ( \is_wp_error( $meta_ok ) ) {
+			return $meta_ok;
+		}
+
+		$final_state = $this->sync_landing_final_state( $post_id, $row, $log_context );
+
+		if ( \is_wp_error( $final_state ) ) {
+			return $final_state;
+		}
+
+		$this->logger->log(
+			'info',
+			'Landing page reconciled after interrupted process (post created before checkpoint).',
+			array_merge( [ 'post_id' => $post_id ], $log_context )
+		);
+
+		return [
+			'id'              => $post_id,
+			'landing_key'     => (string) ( $row['landing_key'] ?? '' ),
+			'title'           => (string) ( $row['title'] ?? '' ),
+			'slug'            => (string) ( $row['slug'] ?? '' ),
+			'landing_type'    => (string) ( $row['landing_type'] ?? 'seo' ),
+			'menu_eligible'   => ! empty( $row['menu_eligible'] ),
+			'primary_keyword' => (string) ( $row['primary_keyword'] ?? '' ),
+			'subkeywords'     => is_array( $row['subkeywords'] ?? null ) ? array_values( $row['subkeywords'] ) : [],
+			'keywords'        => [
+				'primary_keyword' => (string) ( $row['primary_keyword'] ?? '' ),
+				'subkeywords'     => is_array( $row['subkeywords'] ?? null ) ? array_values( $row['subkeywords'] ) : [],
+			],
+			'generated_at'   => \current_time( 'mysql', true ),
+			'reconciled'     => true,
+		];
+	}
+
+	/**
+	 * Finalize a completed run.
+	 *
+	 * Refuses completion unless the orchestrator confirms all items completed
+	 * and no failed/running/pending/interrupted items remain.
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function orchestrate_finalize() {
+		// B4: Refuse completion unless truly complete.
+		if ( ! $this->run_orchestrator->is_run_complete() ) {
+			$run = $this->run_orchestrator->get_run();
+
+			$has_failed = false;
+
+			if ( null !== $run ) {
+				foreach ( $run['items'] as $item ) {
+					if ( Landing_Run_Orchestrator::ITEM_FAILED === $item['status'] ) {
+						$has_failed = true;
+						break;
+					}
+				}
+			}
+
+			$this->mark_step_status( $has_failed ? 'failed' : 'running' );
+
+			if ( $has_failed ) {
+				return new \WP_Error(
+					'rms_wizard_landing_run_not_complete',
+					\__( 'The landing run cannot be finalized because one or more items failed.', 'simple-rms-theme' ),
+					[ 'status' => 409 ]
+				);
+			}
+
+			return $this->build_progress_response();
+		}
+
+		$state = $this->state_manager->get_state();
+		$state['canonical_sections'] = $this->canonical_store->summary();
+		$this->state_manager->save_state( $state );
 
 		if ( ! $this->mark_step_status( 'complete' ) ) {
 			return new \WP_Error(
 				'rms_wizard_landing_status_persist_failed',
 				\__( 'Landing pages were saved but step status could not be marked complete.', 'simple-rms-theme' ),
-				[ 'status' => 500, 'post_ids' => array_values( array_filter( $built_ids ) ) ]
+				[ 'status' => 500 ]
 			);
 		}
 
 		$this->maybe_mark_completed();
+
+		$run = $this->run_orchestrator->get_run();
+
 		$this->logger->log(
 			'info',
-			'Wizard landing pages built.',
-			[
-				'count'    => count( $built ),
-				'post_ids' => array_values( array_filter( $built_ids ) ),
-			]
+			'Wizard landing run completed.',
+			[ 'run_id' => $run['run_id'] ?? '', 'total' => $run['total'] ?? 0, 'completed' => $run['completed'] ?? 0 ]
 		);
 
 		return [
-			'landing_pages'      => array_values( $landing_pages ),
-			'built'              => $built,
-			'canonical_sections' => $state['canonical_sections'],
+			'landing_run'   => $this->public_run_view( $run ?? [] ),
+			'completed'     => $run['completed'] ?? 0,
+			'total'         => $run['total'] ?? 0,
+			'current_title' => '',
+			'landing_pages' => is_array( $state['landing_pages'] ?? null ) ? $state['landing_pages'] : [],
 		];
+	}
+
+	/**
+	 * Classify a WP_Error into an attribution string for the client.
+	 *
+	 * Preserves provider HTTP errors with provider name/status.
+	 * A client-side empty/non-JSON proxy error is described as an
+	 * interrupted server request, not mislabeled as provider HTTP 405.
+	 */
+	private function classify_error( \WP_Error $error ): string {
+		$code        = $error->get_error_code();
+		$data        = $error->get_error_data();
+		$http_status = is_array( $data ) ? (int) ( $data['status'] ?? 0 ) : 0;
+
+		if ( 502 === $http_status || false !== strpos( $code, 'ai_failed' ) || false !== strpos( $code, 'keyword_' ) ) {
+			$provider = is_array( $data ) ? (string) ( $data['provider'] ?? '' ) : '';
+
+			return '' !== $provider
+				? sprintf( 'provider_error (%s, HTTP %d)', $provider, $http_status )
+				: sprintf( 'provider_error (HTTP %d)', $http_status );
+		}
+
+		if ( false !== strpos( $code, 'exception' ) || false !== strpos( $code, 'build' ) ) {
+			return 'interrupted_server_request';
+		}
+
+		return 'server_error';
+	}
+
+	/**
+	 * Build a public view of the run plan for the frontend.
+	 *
+	 * Exposes safe item fields needed for hydration plus a processing flag.
+	 * Never includes lease_owner.
+	 *
+	 * @param array<string,mixed> $run
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function public_run_view( array $run ): array {
+		return $this->run_orchestrator->public_run_view( $run );
+	}
+
+	/**
+	 * Lease-conflict / already-processing responses must keep the step running.
+	 */
+	private function is_lease_conflict_error( \WP_Error $error ): bool {
+		return in_array(
+			$error->get_error_code(),
+			[
+				'rms_wizard_landing_lease_active',
+				'rms_wizard_landing_run_complete',
+				'rms_wizard_landing_run_active',
+				'rms_wizard_landing_start_fence_active',
+			],
+			true
+		);
+	}
+
+	/**
+	 * Start must not mark the step failed when another starter already owns the plan.
+	 */
+	private function is_start_conflict_error( \WP_Error $error ): bool {
+		return in_array(
+			$error->get_error_code(),
+			[
+				'rms_wizard_landing_run_active',
+				'rms_wizard_landing_start_fence_active',
+			],
+			true
+		);
 	}
 
 	/**
@@ -1456,7 +1928,7 @@ class Step_Landing_Page_Builder {
 						\__( 'Keyword section "%s" could not be generated. Landing was not published with placeholder copy.', 'simple-rms-theme' ),
 						$section_key
 					),
-					array_merge( [ 'status' => 502 ], $context )
+					array_merge( [ 'status' => 502, 'provider' => $provider ], $context )
 				);
 			}
 
@@ -1485,7 +1957,7 @@ class Step_Landing_Page_Builder {
 						\__( 'Keyword section "%s" returned invalid JSON. Landing was not published with placeholder copy.', 'simple-rms-theme' ),
 						$section_key
 					),
-					array_merge( [ 'status' => 502 ], $context )
+					array_merge( [ 'status' => 502, 'provider' => $provider ], $context )
 				);
 			}
 
@@ -1980,84 +2452,6 @@ class Step_Landing_Page_Builder {
 	}
 
 	/**
-	 * Persist wizard state and verify landing_pages post-state when critical.
-	 *
-	 * update_option() can return false for identical values, so we re-read.
-	 *
-	 * @param array<string,mixed> $state
-	 */
-	private function persist_wizard_state( array $state, string $reason ): bool {
-		$expected = is_array( $state['landing_pages'] ?? null ) ? array_values( $state['landing_pages'] ) : [];
-		$saved    = $this->state_manager->save_state( $state );
-
-		if ( $saved ) {
-			return true;
-		}
-
-		$reloaded = $this->state_manager->get_state();
-		$actual   = is_array( $reloaded['landing_pages'] ?? null ) ? array_values( $reloaded['landing_pages'] ) : [];
-
-		if ( $this->landing_pages_equivalent( $expected, $actual ) ) {
-			return true;
-		}
-
-		$this->logger->log(
-			'error',
-			'Wizard landing state persistence failed.',
-			[
-				'reason'           => $reason,
-				'expected_count'   => count( $expected ),
-				'actual_count'     => count( $actual ),
-				'expected_post_ids'=> $this->collect_landing_post_ids( $expected ),
-				'actual_post_ids'  => $this->collect_landing_post_ids( $actual ),
-			]
-		);
-
-		return false;
-	}
-
-	/**
-	 * On multi-landing partial failure: save successful landings, then mark failed.
-	 *
-	 * @param array<string,mixed>               $state
-	 * @param array<string,array<string,mixed>> $landing_pages
-	 * @param int[]                             $built_ids
-	 * @param \WP_Error                         $error
-	 */
-	private function persist_partial_landing_progress( array $state, array $landing_pages, array $built_ids, \WP_Error $error ): void {
-		$successful = array_values( array_filter( $built_ids ) );
-		$state['landing_pages']      = array_values( $landing_pages );
-		$state['canonical_sections'] = $this->canonical_store->summary();
-
-		$persisted = $this->persist_wizard_state( $state, 'partial failure recovery' );
-
-		$this->logger->log(
-			$persisted ? 'warning' : 'error',
-			$persisted
-				? 'Wizard landing run failed after partial success; successful landings persisted.'
-				: 'Wizard landing run failed after partial success; could not persist successful landings.',
-			[
-				'successful_count' => count( $successful ),
-				'post_ids'         => $successful,
-				'error_code'       => $error->get_error_code(),
-				'error_message'    => $error->get_error_message(),
-			]
-		);
-
-		// Mark failed only after persistence is attempted.
-		if ( ! $this->mark_step_status( 'failed' ) ) {
-			$this->logger->log(
-				'error',
-				'Wizard landing could not mark step status failed after partial failure.',
-				[
-					'post_ids'   => $successful,
-					'error_code' => $error->get_error_code(),
-				]
-			);
-		}
-	}
-
-	/**
 	 * @param string $status pending|running|complete|failed
 	 */
 	private function mark_step_status( string $status ): bool {
@@ -2321,77 +2715,6 @@ class Step_Landing_Page_Builder {
 	}
 
 	/**
-	 * Compare meaningful persisted landing state (not only identity fields).
-	 *
-	 * Used when save_state() returns false so identical-but-unordered or
-	 * stale/partial snapshots are not treated as successful persistence.
-	 *
-	 * @param array<int,array<string,mixed>> $left
-	 * @param array<int,array<string,mixed>> $right
-	 */
-	private function landing_pages_equivalent( array $left, array $right ): bool {
-		if ( count( $left ) !== count( $right ) ) {
-			return false;
-		}
-
-		$normalize = function ( array $rows ): array {
-			$map = [];
-
-			foreach ( $rows as $row ) {
-				if ( ! is_array( $row ) ) {
-					continue;
-				}
-
-				$key = \sanitize_key( (string) ( $row['landing_key'] ?? '' ) );
-
-				if ( '' === $key ) {
-					$key = 'id_' . (int) ( $row['id'] ?? 0 );
-				}
-
-				$keywords       = is_array( $row['keywords'] ?? null ) ? $row['keywords'] : [];
-				$primary        = (string) ( $row['primary_keyword'] ?? ( $keywords['primary_keyword'] ?? '' ) );
-				$subkeywords    = is_array( $row['subkeywords'] ?? null )
-					? $row['subkeywords']
-					: ( is_array( $keywords['subkeywords'] ?? null ) ? $keywords['subkeywords'] : [] );
-				$subkeywords    = array_values(
-					array_filter(
-						array_map(
-							static function ( $value ): string {
-								return \sanitize_text_field( (string) $value );
-							},
-							$subkeywords
-						),
-						static function ( string $value ): bool {
-							return '' !== $value;
-						}
-					)
-				);
-				// Order-insensitive keyword bag — payload order is not meaningful state.
-				sort( $subkeywords, SORT_STRING );
-
-				$map[ $key ] = [
-					'id'              => (int) ( $row['id'] ?? 0 ),
-					'landing_key'     => \sanitize_key( (string) ( $row['landing_key'] ?? '' ) ),
-					'title'           => \sanitize_text_field( (string) ( $row['title'] ?? '' ) ),
-					'slug'            => \sanitize_title( (string) ( $row['slug'] ?? '' ) ),
-					'landing_type'    => \sanitize_key( (string) ( $row['landing_type'] ?? '' ) ),
-					'menu_eligible'   => ! empty( $row['menu_eligible'] ),
-					'primary_keyword' => \sanitize_text_field( $primary ),
-					'subkeywords'     => $subkeywords,
-					'generated_at'    => \sanitize_text_field( (string) ( $row['generated_at'] ?? '' ) ),
-					'preserved'       => ! empty( $row['preserved'] ),
-				];
-			}
-
-			ksort( $map );
-
-			return $map;
-		};
-
-		return $normalize( $left ) === $normalize( $right );
-	}
-
-	/**
 	 * Best-effort post ID recovery when build_page throws after create/update.
 	 */
 	private function recover_build_page_post_id( int $existing_id, string $slug ): int {
@@ -2412,29 +2735,6 @@ class Step_Landing_Page_Builder {
 		}
 
 		return 0;
-	}
-
-	/**
-	 * @param array<int,array<string,mixed>> $landings
-	 *
-	 * @return int[]
-	 */
-	private function collect_landing_post_ids( array $landings ): array {
-		$ids = [];
-
-		foreach ( $landings as $landing ) {
-			if ( ! is_array( $landing ) ) {
-				continue;
-			}
-
-			$id = (int) ( $landing['id'] ?? 0 );
-
-			if ( $id > 0 ) {
-				$ids[] = $id;
-			}
-		}
-
-		return $ids;
 	}
 }
 

--- a/scripts/test-landing-run-orchestrator.php
+++ b/scripts/test-landing-run-orchestrator.php
@@ -1,0 +1,1151 @@
+<?php
+/**
+ * Integration harness for landing run orchestration — calls public
+ * Step_Landing_Page_Builder::run() with deterministic injected stubs.
+ *
+ * Run with: php scripts/test-landing-run-orchestrator.php
+ *
+ * Tests execute the real public run() path (start, repeated process),
+ * not direct helper calls. A true fatal cannot be caught in-process;
+ * we model the post-fatal persisted facts (item running/interrupted +
+ * post exists + no checkpoint) then invoke the real next public process.
+ */
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', true );
+	}
+	if ( ! defined( 'OBJECT' ) ) {
+		define( 'OBJECT', 'OBJECT' );
+	}
+	if ( ! defined( 'WP_Error' ) ) {
+		// WP_Error class is defined below.
+	}
+
+	function __( $text, $domain = 'default' ) { return $text; }
+	function sanitize_key( $key ) { return strtolower( preg_replace( '/[^a-z0-9_-]+/', '-', (string) $key ) ); }
+	function sanitize_text_field( $value ) { return is_scalar( $value ) ? (string) $value : ''; }
+	function sanitize_title( $value ) { return strtolower( preg_replace( '/[^a-z0-9-]+/', '-', (string) $value ) ); }
+	function absint( $value ) { return abs( (int) $value ); }
+	function current_time( $type, $gmt = false ) { return date( 'Y-m-d H:i:s' ); }
+	function wp_generate_uuid4() { return sprintf( '%04x%04x-%04x-%04x-%04x-%04x%04x%04x', mt_rand(0,0xffff), mt_rand(0,0xffff), mt_rand(0,0xffff), mt_rand(0,0x0fff)|0x4000, mt_rand(0,0x3fff)|0x8000, mt_rand(0,0xffff), mt_rand(0,0xffff), mt_rand(0,0xffff) ); }
+	function get_option( $name, $default = false ) { return $GLOBALS['_options'][$name] ?? $default; }
+	function update_option( $name, $value, $autoload = null ) {
+		// Simulate add_option uniqueness: return false if option exists and this is add.
+		if ( isset( $GLOBALS['_options'][$name] ) && ( func_get_arg(2) ?? null ) === false && ! isset( $GLOBALS['_options_added'][$name] ) ) {
+			// This is a raw update, not add_option.
+		}
+		$GLOBALS['_options'][$name] = $value;
+		return true;
+	}
+	function add_option( $name, $value, $deprecated = '', $autoload = 'yes' ) {
+		if ( isset( $GLOBALS['_options'][$name] ) ) {
+			return false; // Atomic: option already exists.
+		}
+		$GLOBALS['_options'][$name] = $value;
+		$GLOBALS['_options_added'][$name] = true;
+		return true;
+	}
+	function delete_option( $name ) { unset( $GLOBALS['_options'][$name], $GLOBALS['_options_added'][$name] ); return true; }
+	function wp_kses_post( $value ) { return (string) $value; }
+	function get_post_type( $id ) { return isset( $GLOBALS['_posts'][$id] ) ? 'page' : false; }
+	function get_post_meta( $id, $key, $single = false ) { return $GLOBALS['_post_meta'][$id][$key] ?? ''; }
+	function update_post_meta( $id, $key, $value ) {
+		if ( ! empty( $GLOBALS['_fail_landing_meta'] ) ) {
+			$GLOBALS['_post_meta'][ $id ][ $key ] = 'invalid-meta';
+			return true;
+		}
+		$GLOBALS['_post_meta'][$id][$key] = $value;
+		return true;
+	}
+	function delete_post_meta( $id, $key, $value = '' ) { unset( $GLOBALS['_post_meta'][$id][$key] ); return true; }
+	function get_post_status( $id ) { return isset( $GLOBALS['_posts'][$id] ) ? 'publish' : false; }
+	function get_page_by_path( $slug, $output = \OBJECT, $type = 'page' ) { return $GLOBALS['_pages_by_slug'][$slug] ?? null; }
+	function get_post( $id ) {
+		if ( ! isset( $GLOBALS['_posts'][ $id ] ) ) {
+			return null;
+		}
+
+		$stored = $GLOBALS['_posts'][ $id ];
+		if ( $stored instanceof \WP_Post ) {
+			return $stored;
+		}
+
+		if ( ! is_array( $stored ) ) {
+			$stored = [];
+		}
+
+		return new \WP_Post( [
+			'ID'           => (int) $id,
+			'post_type'    => (string) ( $stored['post_type'] ?? 'page' ),
+			'post_title'   => (string) ( $stored['post_title'] ?? '' ),
+			'post_name'    => (string) ( $stored['post_name'] ?? '' ),
+			'post_status'  => (string) ( $stored['post_status'] ?? 'publish' ),
+			'post_content' => (string) ( $stored['post_content'] ?? '' ),
+		] );
+	}
+	function wp_update_post( $args, $err = false ) {
+		$id = (int) ( $args['ID'] ?? 0 );
+		$GLOBALS['_updated_posts'][] = $id;
+
+		if ( $id > 0 ) {
+			$current = isset( $GLOBALS['_posts'][ $id ] ) && is_array( $GLOBALS['_posts'][ $id ] )
+				? $GLOBALS['_posts'][ $id ]
+				: [ 'ID' => $id, 'post_type' => 'page', 'post_content' => '' ];
+			$GLOBALS['_posts'][ $id ] = array_merge(
+				$current,
+				[
+					'post_title'   => $args['post_title'] ?? ( $current['post_title'] ?? '' ),
+					'post_name'    => $args['post_name'] ?? ( $current['post_name'] ?? '' ),
+					'post_status'  => $args['post_status'] ?? ( $current['post_status'] ?? 'publish' ),
+					'post_content' => $args['post_content'] ?? ( $current['post_content'] ?? '' ),
+					'post_type'    => 'page',
+				]
+			);
+		}
+
+		return $id;
+	}
+	function is_wp_error( $thing ) { return $thing instanceof \WP_Error; }
+	function wp_insert_post( $args, $err = false, $return = 'WP_Error' ) {
+		$GLOBALS['_insert_post_calls'] = ( $GLOBALS['_insert_post_calls'] ?? 0 ) + 1;
+		$GLOBALS['_post_counter'] = ( $GLOBALS['_post_counter'] ?? 1000 ) + 1;
+		$id = $GLOBALS['_post_counter'];
+		$GLOBALS['_posts'][$id] = [
+			'ID'           => $id,
+			'post_type'    => 'page',
+			'post_title'   => (string) ( $args['post_title'] ?? '' ),
+			'post_name'    => (string) ( $args['post_name'] ?? '' ),
+			'post_status'  => (string) ( $args['post_status'] ?? 'publish' ),
+			'post_content' => (string) ( $args['post_content'] ?? '' ),
+		];
+		$GLOBALS['_pages_by_slug'][ $args['post_name'] ?? '' ] = new \WP_Post( [
+			'ID'           => $id,
+			'post_type'    => 'page',
+			'post_title'   => (string) ( $args['post_title'] ?? '' ),
+			'post_name'    => (string) ( $args['post_name'] ?? '' ),
+			'post_status'  => (string) ( $args['post_status'] ?? 'publish' ),
+			'post_content' => (string) ( $args['post_content'] ?? '' ),
+		] );
+		$GLOBALS['_post_meta'][$id]['rms_landing_type'] = $args['meta_input']['rms_landing_type'] ?? 'seo';
+		$GLOBALS['_post_meta'][$id]['_wp_page_template'] = $args['meta_input']['_wp_page_template'] ?? '';
+		return $id;
+	}
+	function get_page_template_slug( $id ) { return $GLOBALS['_post_meta'][$id]['_wp_page_template'] ?? ''; }
+	function get_theme_mod( $name, $default = false ) { return $default; }
+	function get_field( $name, $id, $raw = false ) { return $GLOBALS['_acf_fields'][$id][$name] ?? false; }
+	function wp_create_nonce( $action = -1 ) { return 'nonce'; }
+	function wp_verify_nonce( $nonce, $action = -1 ) { return true; }
+	function current_user_can( $cap ) { return true; }
+	function esc_html( $v ) { return (string) $v; }
+	function esc_attr( $v ) { return (string) $v; }
+	function esc_url( $v ) { return (string) $v; }
+	function esc_url_raw( $v ) { return (string) $v; }
+	function esc_textarea( $v ) { return (string) $v; }
+	function selected( $a, $b, $echo = true ) { return $a === $b ? ' selected' : ''; }
+	function checked( $a, $b, $echo = true ) { return $a === $b ? ' checked' : ''; }
+	function sanitize_hex_color( $v ) { return $v; }
+	function wp_get_attachment_image_url( $id, $size ) { return ''; }
+	function trailingslashit( $v ) { return rtrim( $v, '/\\' ) . '/'; }
+	function get_template_directory() { return __DIR__ . '/..'; }
+	function get_template_directory_uri() { return ''; }
+	function rest_url( $v = '' ) { return ''; }
+	function apply_filters( $tag, $value ) { return $value; }
+	function do_action( $tag, ...$args ) {}
+	function get_the_ID() { return 0; }
+	function is_page() { return false; }
+	function get_queried_object_id() { return 0; }
+	function add_query_arg( ...$args ) { return ''; }
+	function admin_url( $v = '' ) { return ''; }
+	function wp_safe_redirect( $v ) {}
+	function wp_die( $v ) { throw new \Exception( (string) $v ); }
+	function submit_button( $v, $type = '', $name = '', $echo = true ) { return ''; }
+	function wp_nonce_field( $action, $name = null ) {}
+	function wp_enqueue_script( ...$args ) {}
+	function wp_enqueue_style( ...$args ) {}
+	function wp_enqueue_media( ...$args ) {}
+	function wp_script_is( ...$args ) { return false; }
+	function wp_add_inline_script( ...$args ) {}
+	function wp_json_encode( $data, $flags = 0 ) { return \json_encode( $data, $flags ); }
+	function maybe_serialize( $value ) { return is_array( $value ) || is_object( $value ) ? serialize( $value ) : (string) $value; }
+	function maybe_unserialize( $value ) {
+		if ( ! is_string( $value ) ) { return $value; }
+		$decoded = @unserialize( $value );
+		return false === $decoded && 'b:0;' !== $value ? $value : $decoded;
+	}
+	function wp_cache_delete( $key, $group = '' ) { return true; }
+	function get_permalink( $id ) { return ''; }
+	function add_theme_page( ...$args ) {}
+	function add_action( ...$args ) {}
+	function add_filter( ...$args ) {}
+	function register_rest_route( ...$args ) {}
+
+	$GLOBALS['_options'] = [];
+	$GLOBALS['_options_added'] = [];
+	$GLOBALS['_posts'] = [];
+	$GLOBALS['_updated_posts'] = [];
+	$GLOBALS['_post_meta'] = [];
+	$GLOBALS['_pages_by_slug'] = [];
+	$GLOBALS['_acf_fields'] = [];
+	$GLOBALS['_post_counter'] = 1000;
+	$GLOBALS['_insert_post_calls'] = 0;
+	$GLOBALS['_fail_landing_meta'] = false;
+	$GLOBALS['_ai_fail'] = false;
+
+	class Fake_WPDB {
+		public $options = 'wp_options';
+
+		public function prepare( $query, ...$args ) {
+			return [ 'query' => $query, 'args' => $args ];
+		}
+
+		public function get_var( $prepared ) {
+			$name = (string) ( $prepared['args'][0] ?? '' );
+			return array_key_exists( $name, $GLOBALS['_options'] )
+				? maybe_serialize( $GLOBALS['_options'][ $name ] )
+				: null;
+		}
+
+		public function query( $prepared ) {
+			$query = (string) ( $prepared['query'] ?? '' );
+			$args  = $prepared['args'] ?? [];
+			$name  = (string) ( $args[0] ?? '' );
+
+			if ( 0 === stripos( ltrim( $query ), 'INSERT IGNORE' ) ) {
+				if ( array_key_exists( $name, $GLOBALS['_options'] ) ) {
+					return 0;
+				}
+
+				$GLOBALS['_options'][ $name ] = maybe_unserialize( (string) ( $args[1] ?? '' ) );
+				return 1;
+			}
+
+			if ( 0 === stripos( ltrim( $query ), 'DELETE FROM' ) ) {
+				if ( ! array_key_exists( $name, $GLOBALS['_options'] ) ) {
+					return 0;
+				}
+
+				$current = maybe_serialize( $GLOBALS['_options'][ $name ] );
+				if ( $current !== (string) ( $args[1] ?? '' ) ) {
+					return 0;
+				}
+
+				unset( $GLOBALS['_options'][ $name ] );
+				return 1;
+			}
+
+			return 0;
+		}
+	}
+
+	$GLOBALS['wpdb'] = new Fake_WPDB();
+
+	class WP_Post {
+		public $ID;
+		public $post_type = 'page';
+		public $post_title = '';
+		public $post_name = '';
+		public $post_status = 'publish';
+		public $post_content = '';
+
+		public function __construct( $data = [] ) {
+			foreach ( (array) $data as $key => $value ) {
+				$this->{$key} = $value;
+			}
+		}
+	}
+
+	class WP_Error {
+		private $code;
+		private $message;
+		private $data;
+		public function __construct( $code = '', $message = '', $data = '' ) {
+			$this->code = $code;
+			$this->message = $message;
+			$this->data = $data;
+		}
+		public function get_error_code() { return $this->code; }
+		public function get_error_message() { return $this->message; }
+		public function get_error_data() { return $this->data; }
+		public function add_data( $data ) { $this->data = $data; }
+	}
+
+	class WP_REST_Server { const READABLE = 'GET'; const CREATABLE = 'POST'; }
+	class WP_REST_Request { public $step; }
+	class WP_REST_Response {
+		public function __construct( $data, $code = 200 ) {}
+	}
+	class WP_Query {
+		public $posts = [];
+		public function __construct( $args = [] ) {}
+	}
+
+	class TestRunner {
+		private $pass = 0;
+		private $fail = 0;
+		public function assert( $condition, string $label ): void {
+			if ( $condition ) { echo "  PASS: {$label}\n"; $this->pass++; }
+			else { echo "  FAIL: {$label}\n"; $this->fail++; }
+		}
+		public function assertEqual( $expected, $actual, string $label ): void {
+			$this->assert( $expected === $actual, "{$label} (expected: " . json_encode( $expected ) . ", actual: " . json_encode( $actual ) . ")" );
+		}
+		public function results(): void {
+			echo "\n  Results: {$this->pass} passed, {$this->fail} failed\n";
+			if ( $this->fail > 0 ) { exit( 1 ); }
+		}
+	}
+
+	function reset_state(): void {
+		global $_options, $_options_added, $_posts, $_updated_posts, $_post_meta, $_pages_by_slug, $_acf_fields, $_post_counter, $_insert_post_calls, $_fail_landing_meta, $_ai_fail;
+		$_options = [];
+		$_options_added = [];
+		$_posts = [];
+		$_updated_posts = [];
+		$_post_meta = [];
+		$_pages_by_slug = [];
+		$_acf_fields = [];
+		$_post_counter = 1000;
+		$_insert_post_calls = 0;
+		$_fail_landing_meta = false;
+		$_ai_fail = false;
+	}
+
+	function make_landing_payload_item( string $key, string $title, int $id = 0 ): array {
+		return [
+			'id' => $id > 0 ? (string) $id : '',
+			'landing_key' => $key,
+			'title' => $title,
+			'slug' => sanitize_title( $title ),
+			'landing_type' => 'seo',
+			'primary_keyword' => $title . ' keyword',
+			'subkeywords' => '',
+			// Use only non-keyword sections to avoid AI generation in integration tests.
+			// hero and seo-content are keyword layouts that require AI; badges and portfolio-v1 are reusable.
+			'sections' => [
+				[ 'layout' => 'badges' ],
+				[ 'layout' => 'portfolio-v1' ],
+			],
+		];
+	}
+
+	function make_existing_entry( string $key, string $title, int $id ): array {
+		return [
+			'id' => $id,
+			'landing_key' => $key,
+			'title' => $title,
+			'slug' => sanitize_title( $title ),
+			'landing_type' => 'seo',
+			'menu_eligible' => true,
+			'primary_keyword' => $title . ' keyword',
+			'subkeywords' => [],
+			'generated_at' => date( 'Y-m-d H:i:s' ),
+		];
+	}
+
+	function make_existing_entry_no_sections( string $key, string $title, int $id ): array {
+		return make_existing_entry( $key, $title, $id );
+	}
+
+	// Include required classes.
+	require_once __DIR__ . '/../inc/wizard/class-logger.php';
+	require_once __DIR__ . '/../inc/wizard/class-state-manager.php';
+	require_once __DIR__ . '/../inc/wizard/class-landing-run-orchestrator.php';
+	require_once __DIR__ . '/../inc/wizard/class-canonical-section-store.php';
+	require_once __DIR__ . '/../inc/wizard/class-flexible-content-layouts.php';
+	require_once __DIR__ . '/../inc/wizard/class-ai-content-harness.php';
+	require_once __DIR__ . '/../inc/wizard/class-ai-content-reviewer.php';
+	require_once __DIR__ . '/../inc/wizard/class-yoast-meta-writer.php';
+	require_once __DIR__ . '/../inc/wizard/class-menu-builder.php';
+	require_once __DIR__ . '/../inc/wizard/class-content-builder.php';
+
+	// Stubs for AI/provider classes that are needed but not included.
+	if ( ! class_exists( 'Inc\Wizard\AI_Provider_Registry' ) ) {
+		eval( 'namespace Inc\Wizard; class AI_Provider_Registry { public static function make_provider($p,$k=""){return new class{ function generate(){ if ( ! empty( $GLOBALS["_ai_fail"] ) ) { return ["success"=>false,"content"=>"","error"=>"HTTP 500 provider error"]; } return ["success"=>true,"content"=>json_encode(["headline"=>"Test","subheadline"=>"Test","body"=>"Test","hero_title"=>"Test","hero_description"=>"Test body copy for the landing hero."])]; } function list_models(){return [];} }; } public static function provider_exists($p){return true;} public static function default_provider(){return "test";} public static function get_provider_label($p){return "Test";} public static function list_providers(){return [["slug"=>"test","label"=>"Test"]];} }' );
+	}
+	if ( ! class_exists( 'Inc\Wizard\AI_Credential_Store' ) ) {
+		eval( 'namespace Inc\Wizard; class AI_Credential_Store { public static function has($p){return true;} public static function save($p,$k){return true;} public static function status($p){return ["has_key"=>true,"status"=>"saved"];} public static function mask_status($p){return "saved";} public static function normalize_api_key($k){return $k;} }' );
+	}
+	if ( ! class_exists( 'Inc\Wizard\AI_Provider' ) ) {
+		eval( 'namespace Inc\Wizard; class AI_Provider {}' );
+	}
+	if ( ! class_exists( 'Inc\Wizard\Step_Controller' ) ) {
+		eval( 'namespace Inc\Wizard; class Step_Controller { public static function get_required_steps(){return ["dependencies","acf-import","client-data","generate-pages","menu-setup","ia-generation","home-page-builder","landing-page-builder"];} }' );
+	}
+	if ( ! class_exists( 'Inc\Wizard\Wizard_Unlock_Controller' ) ) {
+		eval( 'namespace Inc\Wizard; class Wizard_Unlock_Controller { public static function is_force_unlocked(){return false;} public static function is_controlled_unlock_enabled(){return false;} public static function is_unlocked(){return false;} public static function has_unlock_marker(){return false;} const UNLOCKED_AT_OPTION=""; const UNLOCKED_BY_OPTION=""; const UNLOCK_ACTION=""; const RELOCK_ACTION=""; const NONCE_ACTION=""; public static function verify_admin_nonce($n){return true;} }' );
+	}
+
+	require_once __DIR__ . '/../inc/wizard/class-step-landing-page-builder.php';
+
+	use Inc\Wizard\Logger;
+	use Inc\Wizard\State_Manager;
+	use Inc\Wizard\Landing_Run_Orchestrator;
+	use Inc\Wizard\Step_Landing_Page_Builder;
+	use Inc\Wizard\Canonical_Section_Store;
+	use Inc\Wizard\Flexible_Content_Layouts;
+	use Inc\Wizard\AI_Content_Harness;
+	use Inc\Wizard\Content_Builder;
+
+	/**
+	 * Create a Step_Landing_Page_Builder with stubbed build_one_landing.
+	 * The stub deterministically creates a post and returns an entry,
+	 * simulating the real build flow without AI calls.
+	 */
+	function make_builder( ?State_Manager $sm = null, ?callable $build_override = null ): Step_Landing_Page_Builder {
+		$sm = $sm ?? new State_Manager();
+		$logger = new Logger();
+
+		// Set up AI config and client data in state.
+		$sm->save_state( [
+			'ai_config' => [ 'provider' => 'test', 'model' => 'test-model', 'has_credentials' => true ],
+			'client_data' => [ 'company_name' => 'Test Company' ],
+		] );
+
+		// Create a builder with a stub that overrides build_one_landing via reflection.
+		$builder = new Step_Landing_Page_Builder( $logger, $sm );
+
+		if ( null !== $build_override ) {
+			// Use reflection to replace build_one_landing behavior is complex.
+			// Instead, we set up the environment so the real build_one_landing works
+			// with stubbed AI providers (already done via AI_Provider_Registry stub).
+		}
+
+		return $builder;
+	}
+
+	$t = new TestRunner();
+
+	// === TEST 1: Plan persisted before processing (via public run start) ===
+	echo "\nTest 1: Plan persisted before processing (public run start)\n";
+	reset_state();
+	$sm = new State_Manager();
+	$sm->save_state( [
+		'ai_config' => [ 'provider' => 'test', 'model' => 'test-model', 'has_credentials' => true ],
+		'client_data' => [ 'company_name' => 'Test Company' ],
+	] );
+	$builder = new Step_Landing_Page_Builder( new Logger(), $sm );
+
+	$payload = [
+		'landing_action' => 'start',
+		'landings' => [
+			make_landing_payload_item( 'lk_1', 'Landing One' ),
+			make_landing_payload_item( 'lk_2', 'Landing Two' ),
+		],
+		'replace_canonical' => [],
+	];
+
+	$result = $builder->run( $payload );
+	$t->assert( ! is_wp_error( $result ), 'start does not return WP_Error' . ( is_wp_error( $result ) ? ': ' . $result->get_error_message() : '' ) );
+	if ( is_wp_error( $result ) ) {
+		$t->results();
+		return;
+	}
+	$t->assert( isset( $result['landing_run'] ), 'Result has landing_run' );
+	$t->assertEqual( 2, $result['total'], 'Total is 2' );
+
+	// Verify plan persisted in state before processing.
+	$state = $sm->get_state();
+	$t->assert( isset( $state['landing_run'] ), 'Plan persisted in state' );
+	$t->assertEqual( 2, count( $state['landing_run']['items'] ), 'Plan has 2 items' );
+
+	// === TEST 2: Nine-item run processes one per request ===
+	echo "\nTest 2: Nine-item run processes one per request\n";
+	reset_state();
+	$sm = new State_Manager();
+	$sm->save_state( [
+		'ai_config' => [ 'provider' => 'test', 'model' => 'test-model', 'has_credentials' => true ],
+		'client_data' => [ 'company_name' => 'Test Company' ],
+	] );
+	$builder = new Step_Landing_Page_Builder( new Logger(), $sm );
+
+	$landings = [];
+	for ( $i = 1; $i <= 9; $i++ ) {
+		$landings[] = make_landing_payload_item( "lk_{$i}", "Landing {$i}" );
+	}
+
+	$result = $builder->run( [ 'landing_action' => 'start', 'landings' => $landings, 'replace_canonical' => [] ] );
+	$t->assertEqual( 9, $result['total'], 'Nine-item total is 9' );
+
+	// After start, one item should have been processed (completed=1).
+	$t->assertEqual( 1, $result['completed'], 'One item completed after start+process' );
+
+	// Now call process repeatedly — each should complete one more.
+	$completed = 1;
+	for ( $req = 2; $req <= 9; $req++ ) {
+		$result = $builder->run( [ 'landing_action' => 'process' ] );
+		if ( is_wp_error( $result ) ) {
+			break;
+		}
+		$completed = $result['completed'];
+	}
+	$t->assertEqual( 9, $completed, 'All 9 completed after 9 process requests' );
+	$t->assertEqual( 'completed', $result['landing_run']['status'], 'Run status is completed' );
+
+	// Verify 9 unique landing pages.
+	$state = $sm->get_state();
+	$t->assertEqual( 9, count( $state['landing_pages'] ), '9 unique landing pages in state' );
+
+	// === TEST 3: Four pre-existing unchanged + five new ===
+	echo "\nTest 3: Four pre-existing unchanged skipped; five pending\n";
+	reset_state();
+	$sm = new State_Manager();
+	$existing = [];
+	for ( $i = 1; $i <= 4; $i++ ) {
+		$existing[ "lk_{$i}" ] = make_existing_entry_no_sections( "lk_{$i}", "Landing {$i}", 100 + $i );
+	}
+	$sm->save_state( [
+		'ai_config' => [ 'provider' => 'test', 'model' => 'test-model', 'has_credentials' => true ],
+		'client_data' => [ 'company_name' => 'Test Company' ],
+		'landing_pages' => array_values( $existing ),
+	] );
+	$builder = new Step_Landing_Page_Builder( new Logger(), $sm );
+
+	$landings = [];
+	for ( $i = 1; $i <= 9; $i++ ) {
+		$landings[] = make_landing_payload_item( "lk_{$i}", "Landing {$i}", $i <= 4 ? 100 + $i : 0 );
+	}
+
+	$result = $builder->run( [ 'landing_action' => 'start', 'landings' => $landings, 'replace_canonical' => [] ] );
+	$t->assertEqual( 9, $result['total'], 'Total is 9' );
+
+	// After start, 4 unchanged are completed + 1 new item processed = 5 total.
+	// But the plan BEFORE the first process had 4 completed. Verify via run items.
+	$state = $sm->get_state();
+	$completed_at_start = 0;
+	foreach ( $state['landing_run']['items'] as $item ) {
+		if ( 'completed' === $item['status'] && (int) $item['post_id'] > 0 && (int) $item['id'] > 0 ) {
+			$completed_at_start++;
+		}
+	}
+	// The 4 pre-existing items had id > 0 and were classified completed at plan time.
+	// The start then processed lk_5 (id=0, new), which is now also completed.
+	// So we check that lk_1 through lk_4 are all completed.
+	$lk1_to_4_completed = true;
+	foreach ( $state['landing_run']['items'] as $item ) {
+		if ( in_array( $item['key'], [ 'lk_1', 'lk_2', 'lk_3', 'lk_4' ], true ) && 'completed' !== $item['status'] ) {
+			$lk1_to_4_completed = false;
+			break;
+		}
+	}
+	$t->assert( $lk1_to_4_completed, 'Four pre-existing unchanged items (lk_1..lk_4) are completed' );
+
+	// Next pending item should be lk_6 (lk_5 was already processed by start).
+	$orch = new Landing_Run_Orchestrator( $sm, new Logger() );
+	$next = $orch->get_next_item();
+	$t->assertEqual( 'lk_6', $next['key'], 'Next pending is lk_6 (lk_5 processed by start)' );
+
+	// === TEST 4: Forced interruption after four preserves plan ===
+	echo "\nTest 4: Forced interruption after four preserves plan\n";
+	reset_state();
+	$sm = new State_Manager();
+	$sm->save_state( [
+		'ai_config' => [ 'provider' => 'test', 'model' => 'test-model', 'has_credentials' => true ],
+		'client_data' => [ 'company_name' => 'Test Company' ],
+	] );
+	$builder = new Step_Landing_Page_Builder( new Logger(), $sm );
+
+	$landings = [];
+	for ( $i = 1; $i <= 9; $i++ ) {
+		$landings[] = make_landing_payload_item( "lk_{$i}", "Landing {$i}" );
+	}
+	$builder->run( [ 'landing_action' => 'start', 'landings' => $landings, 'replace_canonical' => [] ] );
+
+	// Process 3 more items (total 4 completed).
+	for ( $i = 2; $i <= 4; $i++ ) {
+		$builder->run( [ 'landing_action' => 'process' ] );
+	}
+
+	$orch = new Landing_Run_Orchestrator( $sm, new Logger() );
+	$run = $orch->get_run();
+	$t->assertEqual( 4, $run['completed'], 'Four completed before interruption' );
+
+	// Simulate fatal: mark item 5 as running, then expire the mutex.
+	$orch->mark_item_running( 'lk_5' );
+	$state = $sm->get_state();
+	// Expire the mutex option.
+	$option_name = 'rms_landing_lease_' . sanitize_key( $state['landing_run']['run_id'] );
+	$lease = get_option( $option_name, false );
+	if ( is_array( $lease ) ) {
+		$lease['expires_at'] = time() - 100;
+		update_option( $option_name, $lease );
+	}
+
+	// === TEST 5: Reload hydrates plan ===
+	echo "\nTest 5: Reload hydrates plan\n";
+	$sm2 = new State_Manager();
+	$orch2 = new Landing_Run_Orchestrator( $sm2, new Logger() );
+	$run = $orch2->get_run();
+	$t->assert( null !== $run, 'Plan hydrated after reload' );
+	$t->assertEqual( 9, $run['total'], 'Plan total is 9 after reload' );
+
+	// === TEST 8: Stale lease recovers ===
+	echo "\nTest 8: Stale lease recovers\n";
+	$orch2->recover_stale_lease();
+	$run = $orch2->get_run();
+	$item5 = null;
+	foreach ( $run['items'] as $item ) {
+		if ( 'lk_5' === $item['key'] ) { $item5 = $item; break; }
+	}
+	$t->assertEqual( 'interrupted', $item5['status'], 'Item 5 is interrupted after stale recovery' );
+	$t->assertEqual( 'interrupted', $run['status'], 'Expired lease makes the run resumable interrupted' );
+	$t->assertEqual( 4, $run['completed'], 'Four items still completed after recovery' );
+
+	// === TEST 6: Resume starts fifth (via public run process) ===
+	echo "\nTest 6: Resume starts fifth via public process\n";
+	$builder2 = new Step_Landing_Page_Builder( new Logger(), $sm2 );
+	$result = $builder2->run( [ 'landing_action' => 'process' ] );
+	$t->assert( ! is_wp_error( $result ), 'Process after interruption succeeds' );
+	$t->assertEqual( 5, $result['completed'], 'Fifth item completed after resume' );
+
+	// === TEST 9: Concurrent call rejected (atomic mutex) ===
+	echo "\nTest 9: Concurrent call rejected\n";
+	reset_state();
+	$sm = new State_Manager();
+	$sm->save_state( [
+		'ai_config' => [ 'provider' => 'test', 'model' => 'test-model', 'has_credentials' => true ],
+		'client_data' => [ 'company_name' => 'Test Company' ],
+	] );
+	$builder = new Step_Landing_Page_Builder( new Logger(), $sm );
+	$start_result = $builder->run( [ 'landing_action' => 'start', 'landings' => [ make_landing_payload_item( 'lk_a', 'A' ), make_landing_payload_item( 'lk_b', 'B' ) ], 'replace_canonical' => [] ] );
+
+	// Check run state after start.
+	$state_after = $sm->get_state();
+	$run_after = $state_after['landing_run'] ?? null;
+
+	// If start processed both items (run completed), start a 3-item run.
+	if ( null === $run_after || 'completed' === ( $run_after['status'] ?? '' ) ) {
+		reset_state();
+		$sm = new State_Manager();
+		$sm->save_state( [
+			'ai_config' => [ 'provider' => 'test', 'model' => 'test-model', 'has_credentials' => true ],
+			'client_data' => [ 'company_name' => 'Test Company' ],
+		] );
+		$builder = new Step_Landing_Page_Builder( new Logger(), $sm );
+		$builder->run( [ 'landing_action' => 'start', 'landings' => [
+			make_landing_payload_item( 'lk_a', 'Alpha' ),
+			make_landing_payload_item( 'lk_b', 'Beta' ),
+			make_landing_payload_item( 'lk_c', 'Gamma' ),
+			make_landing_payload_item( 'lk_d', 'Delta' ),
+		], 'replace_canonical' => [] ] );
+		$state_after = $sm->get_state();
+		$run_after = $state_after['landing_run'] ?? null;
+	}
+
+	$t->assert( null !== $run_after && 'completed' !== ( $run_after['status'] ?? '' ), 'Run exists and is not completed after start' );
+
+	// Manually acquire lease to simulate active worker.
+	$orch = new Landing_Run_Orchestrator( $sm, new Logger() );
+	$owner = $orch->acquire_lease();
+	$t->assert( ! is_wp_error( $owner ), 'First worker acquires lease' . ( is_wp_error( $owner ) ? ': ' . $owner->get_error_message() : '' ) );
+
+	if ( is_wp_error( $owner ) ) {
+		echo "  Skipping remaining concurrent tests (no run available)\n";
+	} else {
+		$active_item = $orch->get_next_item();
+		if ( is_array( $active_item ) ) {
+			$orch->mark_item_running( (string) $active_item['key'] );
+			$orch->recover_stale_lease();
+			$polled_run  = $orch->get_run();
+			$polled_item = null;
+			foreach ( $polled_run['items'] as $candidate ) {
+				if ( $candidate['key'] === $active_item['key'] ) { $polled_item = $candidate; break; }
+			}
+			$t->assertEqual( 'running', $polled_item['status'], 'State polling does not interrupt an item with an active lease' );
+		}
+
+		// Second worker — should be rejected.
+		$owner2 = $orch->acquire_lease();
+		$t->assert( is_wp_error( $owner2 ), 'Second worker is rejected' );
+		$orch->release_lease( 'not-the-owner' );
+		$owner_after_wrong_release = $orch->acquire_lease();
+		$t->assert( is_wp_error( $owner_after_wrong_release ), 'Non-owner cannot release the active lease' );
+
+		// Release and verify third can acquire.
+		$orch->release_lease( (string) $owner );
+		$owner3 = $orch->acquire_lease();
+		$t->assert( ! is_wp_error( $owner3 ), 'Third worker acquires after release' );
+		$orch->release_lease( (string) $owner );
+		$owner_after_stale_release = $orch->acquire_lease();
+		$t->assert( is_wp_error( $owner_after_stale_release ), 'Stale owner cannot delete a replacement lease' );
+		$orch->release_lease( (string) $owner3 );
+	}
+
+	// === TEST 7: Post-created-before-checkpoint reconciles via public process ===
+	echo "\nTest 7: Post-created-before-checkpoint reconciles\n";
+	reset_state();
+	$sm = new State_Manager();
+	$sm->save_state( [
+		'ai_config' => [ 'provider' => 'test', 'model' => 'test-model', 'has_credentials' => true ],
+		'client_data' => [ 'company_name' => 'Test Company' ],
+	] );
+	$builder = new Step_Landing_Page_Builder( new Logger(), $sm );
+
+	// Create a 2-item run so start processes one and leaves one pending.
+	$builder->run( [ 'landing_action' => 'start', 'landings' => [
+		make_landing_payload_item( 'lk_rec', 'Reconcile Landing' ),
+		make_landing_payload_item( 'lk_pend', 'Pending Landing' ),
+	], 'replace_canonical' => [] ] );
+
+	// Model the post-fatal state: lk_rec was processed by start (completed),
+	// but we simulate a fatal before checkpoint by:
+	// 1. Reset lk_rec to interrupted with post_id=0.
+	// 2. Keep the post in the DB (it was created by the stub wp_insert_post).
+	// 3. Remove it from landing_pages (no checkpoint happened).
+	// 4. Expire any mutex.
+	$state = $sm->get_state();
+	$run = $state['landing_run'];
+
+	// Find lk_rec and mark it interrupted.
+	$orch = new Landing_Run_Orchestrator( $sm, new Logger() );
+	$orch->mark_item_error( 'lk_rec', 'interrupted', 'fatal_before_checkpoint', 'Process died before checkpoint' );
+
+	// Clear post_id and remove from landing_pages.
+	$state = $sm->get_state();
+	foreach ( $state['landing_run']['items'] as &$item ) {
+		if ( 'lk_rec' === $item['key'] ) {
+			$item['post_id'] = 0;
+			$item['id'] = 0;
+			break;
+		}
+	}
+	unset( $item );
+	$state['landing_pages'] = []; // No checkpoint happened.
+	$state['landing_run']['status'] = 'interrupted';
+	$sm->save_state( $state );
+
+	// Expire any mutex.
+	$option_name = 'rms_landing_lease_' . sanitize_key( $state['landing_run']['run_id'] );
+	delete_option( $option_name );
+
+	// Now invoke public process — it should find the existing WP_Post by slug and reconcile.
+	$posts_before = count( $GLOBALS['_posts'] );
+	$rec_slug     = '';
+	foreach ( $state['landing_run']['items'] as $item ) {
+		if ( 'lk_rec' === ( $item['key'] ?? '' ) ) {
+			$rec_slug = (string) ( $item['slug'] ?? '' );
+			break;
+		}
+	}
+	$existing_post = '' !== $rec_slug ? get_page_by_path( $rec_slug ) : null;
+	$t->assert( $existing_post instanceof \WP_Post, 'Reconciliation target WP_Post exists before process' );
+	$result = $builder->run( [ 'landing_action' => 'process' ] );
+	$t->assert( ! is_wp_error( $result ), 'Process reconciles without error' . ( is_wp_error( $result ) ? ': ' . $result->get_error_message() : '' ) );
+	$t->assertEqual( $posts_before, count( $GLOBALS['_posts'] ), 'Reconciliation does not create a duplicate post' );
+
+	$state = $sm->get_state();
+	$run = $state['landing_run'];
+	// Find lk_rec.
+	$rec_item = null;
+	foreach ( $run['items'] as $item ) {
+		if ( 'lk_rec' === $item['key'] ) { $rec_item = $item; break; }
+	}
+	$t->assertEqual( 'completed', $rec_item['status'], 'Reconciled item is completed' );
+	$expected_post_id = $existing_post instanceof \WP_Post ? (int) $existing_post->ID : 0;
+	$t->assertEqual( $expected_post_id, (int) ( $rec_item['post_id'] ?? 0 ), 'Reconciled item keeps the existing WP_Post ID' );
+
+	// Verify no duplicate post creation.
+	$pages = $state['landing_pages'];
+	// lk_rec should be in landing_pages now (checkpointed by reconciliation).
+	$rec_in_pages = false;
+	foreach ( $pages as $page ) {
+		if ( 'lk_rec' === ( $page['landing_key'] ?? '' ) ) { $rec_in_pages = true; break; }
+	}
+	$t->assert( $rec_in_pages, 'Reconciled landing is in landing_pages' );
+
+	// === TEST 10: Final nine unique pages complete ===
+	echo "\nTest 10: Final nine unique pages complete\n";
+	reset_state();
+	$sm = new State_Manager();
+	$sm->save_state( [
+		'ai_config' => [ 'provider' => 'test', 'model' => 'test-model', 'has_credentials' => true ],
+		'client_data' => [ 'company_name' => 'Test Company' ],
+	] );
+	$builder = new Step_Landing_Page_Builder( new Logger(), $sm );
+	$landings = [];
+	for ( $i = 1; $i <= 9; $i++ ) {
+		$landings[] = make_landing_payload_item( "lk_{$i}", "Landing {$i}" );
+	}
+	$result = $builder->run( [ 'landing_action' => 'start', 'landings' => $landings, 'replace_canonical' => [] ] );
+	for ( $req = 2; $req <= 9; $req++ ) {
+		$result = $builder->run( [ 'landing_action' => 'process' ] );
+	}
+	$state = $sm->get_state();
+	$page_ids = [];
+	foreach ( $state['landing_pages'] as $page ) {
+		$page_ids[] = (int) ( $page['id'] ?? 0 );
+	}
+	$t->assertEqual( 9, count( $page_ids ), 'Nine landing pages were checkpointed' );
+	$t->assertEqual( 9, count( array_unique( $page_ids ) ), 'Nine landing pages have unique post IDs' );
+	$t->assertEqual( 'completed', $state['landing_run']['status'] ?? '', 'Nine-item run completed' );
+
+	// === TEST 11: Provider error attribution through public process ===
+	echo "\nTest 11: Provider error attribution through public process\n";
+	reset_state();
+	$sm = new State_Manager();
+	$sm->save_state( [
+		'ai_config' => [ 'provider' => 'test', 'model' => 'test-model', 'has_credentials' => true ],
+		'client_data' => [ 'company_name' => 'Test Company' ],
+	] );
+	$GLOBALS['_ai_fail'] = true;
+	$builder = new Step_Landing_Page_Builder( new Logger(), $sm );
+	$failed_item = make_landing_payload_item( 'lk_err', 'Error Landing' );
+	$failed_item['sections'] = [ [ 'layout' => 'hero' ] ];
+	$result = $builder->run( [ 'landing_action' => 'start', 'landings' => [ $failed_item ], 'replace_canonical' => [] ] );
+	$t->assert( is_wp_error( $result ), 'Public start/process returns WP_Error on provider failure' );
+	$t->assertEqual( 'rms_wizard_landing_keyword_ai_failed', $result->get_error_code(), 'Public process uses keyword AI error code' );
+	$error_data = $result->get_error_data();
+	$t->assert( is_array( $error_data ) && isset( $error_data['attribution'] ), 'Public process attaches attribution' );
+	$t->assert( false !== strpos( (string) ( $error_data['attribution'] ?? '' ), 'provider_error' ), 'Attribution names provider_error' );
+	$t->assert( false !== strpos( (string) ( $error_data['attribution'] ?? '' ), 'test' ), 'Attribution names the provider' );
+	$orch = new Landing_Run_Orchestrator( $sm, new Logger() );
+	$run = $orch->get_run();
+	$t->assertEqual( 'failed', $run['items'][0]['status'] ?? '', 'Failed item status is persisted' );
+	$t->assertEqual( 'rms_wizard_landing_keyword_ai_failed', $run['items'][0]['error_code'] ?? '', 'Provider error code remains on the persisted item' );
+	$t->assertEqual( 'failed', $run['status'] ?? '', 'Run status is failed (not interrupted)' );
+	$original_run_id = (string) ( $run['run_id'] ?? '' );
+
+	$partial = $builder->run( [ 'landing_action' => 'start', 'landings' => [ make_landing_payload_item( 'lk_partial', 'Partial Form' ) ], 'replace_canonical' => [] ] );
+	$t->assert( is_wp_error( $partial ), 'start refuses to replace a failed run from a partial form' );
+	$t->assertEqual( 'rms_wizard_landing_run_active', $partial->get_error_code(), 'Partial start uses run_active code' );
+	$after_partial = $orch->get_run();
+	$t->assertEqual( $original_run_id, (string) ( $after_partial['run_id'] ?? '' ), 'Failed run identity is preserved' );
+	$t->assertEqual( 'lk_err', $after_partial['items'][0]['key'] ?? '', 'Persisted plan still has the original failed item' );
+	$t->assertEqual( 'rms_wizard_landing_keyword_ai_failed', $after_partial['items'][0]['error_code'] ?? '', 'Provider error stays visible until Resume' );
+
+	$resume_fail = $builder->run( [ 'landing_action' => 'process' ] );
+	$t->assert( is_wp_error( $resume_fail ), 'Explicit Resume retries the same failed item while the provider is still down' );
+	$t->assertEqual( 'lk_err', $orch->get_run()['items'][0]['key'] ?? '', 'Resume retries the same item key' );
+	$t->assertEqual( 1, (int) ( $orch->get_run()['total'] ?? 0 ), 'Resume does not rebuild a new plan' );
+
+	$GLOBALS['_ai_fail'] = false;
+	$state = $sm->get_state();
+	foreach ( $state['landing_run']['items'] as &$item ) {
+		if ( 'lk_err' === ( $item['key'] ?? '' ) ) {
+			$item['sections'] = [
+				[ 'layout' => 'badges' ],
+				[ 'layout' => 'portfolio-v1' ],
+			];
+		}
+	}
+	unset( $item );
+	$sm->save_state( $state );
+	$resume_ok = $builder->run( [ 'landing_action' => 'process' ] );
+	$t->assert( ! is_wp_error( $resume_ok ), 'Resume succeeds for the same item after it is processable again' . ( is_wp_error( $resume_ok ) ? ': ' . $resume_ok->get_error_message() : '' ) );
+	$t->assertEqual( 'lk_err', $orch->get_run()['items'][0]['key'] ?? '', 'Successful Resume still targets the original item key' );
+	$t->assertEqual( 'completed', $orch->get_run()['items'][0]['status'] ?? '', 'Same item completes after explicit Resume' );
+	$t->assertEqual( '', $orch->get_run()['items'][0]['error_code'] ?? 'missing', 'Successful checkpoint clears provider error attribution' );
+
+	// === TEST 12: Failed item prevents finalize ===
+	echo "\nTest 12: Failed item prevents finalize\n";
+	reset_state();
+	$sm = new State_Manager();
+	$sm->save_state( [ 'ai_config' => [ 'provider' => 'test', 'model' => 'test', 'has_credentials' => true ], 'client_data' => [ 'company_name' => 'Test' ] ] );
+	$orch = new Landing_Run_Orchestrator( $sm, new Logger() );
+	$orch->start_run( [ [ 'landing_key' => 'lk_e', 'id' => 0, 'title' => 'E', 'slug' => 'e', 'landing_type' => 'seo', 'menu_eligible' => true, 'primary_keyword' => 'kw', 'subkeywords' => [], 'sections' => [ [ 'layout' => 'badges' ] ] ] ], [], [] );
+	$orch->mark_item_running( 'lk_e' );
+	$orch->mark_item_error( 'lk_e', 'failed', 'rms_wizard_landing_keyword_ai_failed', 'AI generation failed' );
+	$t->assert( ! $orch->is_run_complete(), 'Run with failed item is not complete' );
+
+	// === TEST 13: Skip-all ===
+	echo "\nTest 13: Skip-all via public run\n";
+	reset_state();
+	$sm = new State_Manager();
+	$builder = new Step_Landing_Page_Builder( new Logger(), $sm );
+	$result = $builder->run( [ 'skip_all' => true ] );
+	$t->assert( ! is_wp_error( $result ), 'Skip-all does not error' );
+	$t->assert( ! empty( $result['skipped'] ), 'Skip-all returns skipped=true' );
+
+	// === TEST 14: No landing_action without skip_all → 400 ===
+	echo "\nTest 14: No landing_action without skip_all → 400 contract error\n";
+	reset_state();
+	$sm = new State_Manager();
+	$builder = new Step_Landing_Page_Builder( new Logger(), $sm );
+	$result = $builder->run( [ 'landings' => [ make_landing_payload_item( 'lk_x', 'X' ) ] ] );
+	$t->assert( is_wp_error( $result ), 'No action returns WP_Error' );
+	$t->assertEqual( 'rms_wizard_landing_action_required', $result->get_error_code(), 'Error code is landing_action_required' );
+
+	// === TEST 15: Sections change invalidation ===
+	echo "\nTest 15: Sections change invalidation\n";
+	reset_state();
+	$sm = new State_Manager();
+	$existing = [ 'lk_1' => make_existing_entry_no_sections( 'lk_1', 'Landing 1', 101 ) ];
+	// Add sections to the existing entry to test section comparison.
+	$existing['lk_1']['sections'] = [ [ 'layout' => 'badges', 'item_count' => 1, 'override_canonical' => false ] ];
+	$existing['lk_1']['generated_at'] = '2000-01-01 00:00:00';
+	$sm->save_state( [
+		'ai_config' => [ 'provider' => 'test', 'model' => 'test', 'has_credentials' => true ],
+		'client_data' => [ 'company_name' => 'Test' ],
+		'landing_pages' => array_values( $existing ),
+	] );
+
+	// Register the existing post so build_one_landing can update it.
+	$GLOBALS['_posts'][101] = [
+		'ID'           => 101,
+		'post_type'    => 'page',
+		'post_title'   => 'Landing 1',
+		'post_name'    => 'landing-1',
+		'post_status'  => 'publish',
+		'post_content' => 'existing landing content',
+	];
+	$GLOBALS['_pages_by_slug']['landing-1'] = new \WP_Post( [
+		'ID'           => 101,
+		'post_type'    => 'page',
+		'post_title'   => 'Landing 1',
+		'post_name'    => 'landing-1',
+		'post_status'  => 'publish',
+		'post_content' => 'existing landing content',
+	] );
+	$GLOBALS['_post_meta'][101]['rms_landing_type'] = 'seo';
+	$GLOBALS['_post_meta'][101]['_wp_page_template'] = 'pages/landing-page.php';
+
+	$builder = new Step_Landing_Page_Builder( new Logger(), $sm );
+
+	// Submit with different sections (non-keyword layouts to avoid AI).
+	$landings = [ make_landing_payload_item( 'lk_1', 'Landing 1', 101 ) ];
+	$landings[0]['sections'] = [ [ 'layout' => 'badges' ], [ 'layout' => 'testimonials-v1' ] ];
+
+	$result = $builder->run( [ 'landing_action' => 'start', 'landings' => $landings, 'replace_canonical' => [] ] );
+	if ( is_wp_error( $result ) ) {
+		$t->assert( false, 'Sections change test failed: ' . $result->get_error_message() );
+	} else {
+		// The item had changed sections, so it should NOT be classified as completed at plan time.
+		// After start, the first pending item is processed (completed=1).
+		// But we can verify the item was NOT pre-classified as completed by checking
+		// that it went through the build path (post_id > 0 in landing_pages).
+		$state = $sm->get_state();
+		$lk1_item = null;
+		foreach ( $state['landing_run']['items'] as $item ) {
+			if ( 'lk_1' === $item['key'] ) { $lk1_item = $item; break; }
+		}
+		// If the item was classified as completed at plan time (unchanged),
+		// it would have post_id=101 and completed_at set but NO entry in landing_pages
+		// beyond what was already there. If it was pending and processed,
+		// it would have been built and checkpointed.
+		// The key indicator: was the item pending at plan time?
+		// Since start processes it, we can't directly check. But we can verify
+		// the item went through build by checking if landing_pages has a fresh entry.
+		$t->assert( null !== $lk1_item, 'Item lk_1 found in run plan' );
+
+		// Verify the plan had the item as pending (not pre-completed) by checking
+		// that the run needed processing. If it was unchanged, start would not
+		// have called process and completed would be 1 with status=completed.
+		// If it was changed, start would process it and completed would be 1
+		// but with a new post_id (not 101).
+		$t->assert( (int) $lk1_item['post_id'] > 0, 'Item was processed (has post_id)' );
+		$t->assert( 'completed' === $lk1_item['status'], 'Item is completed after processing' );
+		$t->assertEqual( 2, count( $lk1_item['sections'] ?? [] ), 'Plan stored the changed two-section list' );
+		$fresh_generated_at = '';
+		foreach ( $state['landing_pages'] as $page ) {
+			if ( 'lk_1' === ( $page['landing_key'] ?? '' ) ) {
+				$fresh_generated_at = (string) ( $page['generated_at'] ?? '' );
+				break;
+			}
+		}
+		$t->assert( '2000-01-01 00:00:00' !== $fresh_generated_at && '' !== $fresh_generated_at, 'Changed sections rebuilt the landing entry instead of pre-completing it' );
+		$t->assert( in_array( 101, $GLOBALS['_updated_posts'], true ) || (int) $lk1_item['post_id'] !== 101, 'Section invalidation produced an observable rebuild write' );
+	}
+
+	// === TEST 16: Reload-safe public view ===
+	echo "\nTest 16: Reload-safe public view\n";
+	reset_state();
+	$sm = new State_Manager();
+	$sm->save_state( [ 'ai_config' => [ 'provider' => 'test', 'model' => 'test', 'has_credentials' => true ], 'client_data' => [ 'company_name' => 'Test' ] ] );
+	$builder = new Step_Landing_Page_Builder( new Logger(), $sm );
+	$builder->run( [ 'landing_action' => 'start', 'landings' => [
+		make_landing_payload_item( 'lk_a', 'Alpha' ),
+		make_landing_payload_item( 'lk_b', 'Beta' ),
+	], 'replace_canonical' => [] ] );
+
+	// Simulate reload.
+	$sm2 = new State_Manager();
+	$builder2 = new Step_Landing_Page_Builder( new Logger(), $sm2 );
+	// The state already has the run plan. Call process to see it hydrates.
+	$result = $builder2->run( [ 'landing_action' => 'process' ] );
+	$t->assert( ! is_wp_error( $result ), 'Process after reload succeeds' );
+	$t->assert( isset( $result['landing_run']['items'] ), 'Public view has items' );
+	$t->assertEqual( 2, count( $result['landing_run']['items'] ), 'All 2 items in public view' );
+	$t->assert( ! array_key_exists( 'lease_owner', $result['landing_run'] ), 'Public process view omits lease_owner' );
+
+	// === TEST 17: Active run cannot be replaced by start ===
+	echo "\nTest 17: Active run cannot be replaced by start\n";
+	reset_state();
+	$sm = new State_Manager();
+	$sm->save_state( [
+		'ai_config' => [ 'provider' => 'test', 'model' => 'test-model', 'has_credentials' => true ],
+		'client_data' => [ 'company_name' => 'Test Company' ],
+	] );
+	$builder = new Step_Landing_Page_Builder( new Logger(), $sm );
+	$builder->run( [ 'landing_action' => 'start', 'landings' => [
+		make_landing_payload_item( 'lk_keep_1', 'Keep One' ),
+		make_landing_payload_item( 'lk_keep_2', 'Keep Two' ),
+		make_landing_payload_item( 'lk_keep_3', 'Keep Three' ),
+	], 'replace_canonical' => [] ] );
+	$orch = new Landing_Run_Orchestrator( $sm, new Logger() );
+	$original_run_id = (string) ( $orch->get_run()['run_id'] ?? '' );
+	$owner = $orch->acquire_lease();
+	$t->assert( ! is_wp_error( $owner ), 'Worker holds a valid lease before start overwrite attempt' );
+	$start_again = $builder->run( [ 'landing_action' => 'start', 'landings' => [
+		make_landing_payload_item( 'lk_other', 'Other' ),
+	], 'replace_canonical' => [] ] );
+	$t->assert( is_wp_error( $start_again ), 'start refuses to overwrite an active run' );
+	$t->assertEqual( 'rms_wizard_landing_run_active', $start_again->get_error_code(), 'start overwrite uses run_active code' );
+	$after = $orch->get_run();
+	$t->assertEqual( $original_run_id, (string) ( $after['run_id'] ?? '' ), 'Active run_id is unchanged after start' );
+	$t->assertEqual( 3, (int) ( $after['total'] ?? 0 ), 'Original 3-item plan is preserved' );
+	$step_status = $sm->get_state()['step_status']['landing-page-builder'] ?? '';
+	$t->assertEqual( 'running', $step_status, 'Blocked start does not mark the step failed' );
+	$orch->release_lease( (string) $owner );
+
+	// === TEST 18: Process lease conflict preserves running ===
+	echo "\nTest 18: Process lease conflict preserves running status\n";
+	$owner = $orch->acquire_lease();
+	$t->assert( ! is_wp_error( $owner ), 'First worker re-acquires lease' );
+	$conflict = $builder->run( [ 'landing_action' => 'process' ] );
+	$t->assert( is_wp_error( $conflict ), 'Second process is rejected' );
+	$t->assertEqual( 'rms_wizard_landing_lease_active', $conflict->get_error_code(), 'Conflict code is lease_active' );
+	$state = $sm->get_state();
+	$t->assertEqual( 'running', $state['step_status']['landing-page-builder'] ?? '', 'Lease conflict keeps step status running' );
+	$t->assertEqual( $original_run_id, (string) ( $state['landing_run']['run_id'] ?? '' ), 'Lease conflict does not replace the run' );
+	$public = $orch->get_public_run();
+	$t->assertEqual( true, $public['processing_active'] ?? false, 'Active polling reports processing_active' );
+	$t->assert( ! array_key_exists( 'lease_owner', $public ), 'Public state strips lease_owner' );
+	$raw = $orch->get_run();
+	$t->assert( isset( $raw['lease_owner'] ), 'Internal run still stores lease_owner' );
+	$t->assertEqual( 'running', $raw['status'] ?? '', 'Active polling keeps run status running' );
+	$orch->release_lease( (string) $owner );
+
+	// === TEST 19: Persist complete plan before canonical bootstrap ===
+	echo "\nTest 19: Persist complete plan before canonical bootstrap\n";
+	$source = (string) file_get_contents( __DIR__ . '/../inc/wizard/class-step-landing-page-builder.php' );
+	$start_fn = strpos( $source, 'function orchestrate_start' );
+	$t->assert( false !== $start_fn, 'orchestrate_start is present' );
+	if ( false !== $start_fn ) {
+		$chunk = substr( $source, $start_fn, 3500 );
+		$persist_at = strpos( $chunk, 'start_run(' );
+		$bootstrap_at = strpos( $chunk, 'ensure_canonical_reusables(' );
+		$t->assert( false !== $persist_at && false !== $bootstrap_at && $persist_at < $bootstrap_at, 'start_run persists the plan before ensure_canonical_reusables' );
+	}
+
+	// === TEST 20: Public view after 4/9 keeps pending plan rows ===
+	echo "\nTest 20: Public view after 4/9 keeps pending plan rows\n";
+	reset_state();
+	$sm = new State_Manager();
+	$sm->save_state( [
+		'ai_config' => [ 'provider' => 'test', 'model' => 'test-model', 'has_credentials' => true ],
+		'client_data' => [ 'company_name' => 'Test Company' ],
+	] );
+	$builder = new Step_Landing_Page_Builder( new Logger(), $sm );
+	$landings = [];
+	for ( $i = 1; $i <= 9; $i++ ) {
+		$landings[] = make_landing_payload_item( "lk_{$i}", "Landing {$i}" );
+	}
+	$builder->run( [ 'landing_action' => 'start', 'landings' => $landings, 'replace_canonical' => [] ] );
+	for ( $i = 2; $i <= 4; $i++ ) {
+		$builder->run( [ 'landing_action' => 'process' ] );
+	}
+	$public = ( new Landing_Run_Orchestrator( $sm, new Logger() ) )->get_public_run();
+	$t->assertEqual( 9, count( $public['items'] ?? [] ), 'Public view still has all 9 plan rows after 4 completions' );
+	$t->assertEqual( 4, (int) ( $public['completed'] ?? 0 ), 'Four items are completed' );
+	$pending = 0;
+	foreach ( $public['items'] as $item ) {
+		if ( 'pending' === ( $item['status'] ?? '' ) ) {
+			$pending++;
+		}
+	}
+	$t->assertEqual( 5, $pending, 'Five pending plan rows remain visible for hydration' );
+
+	// === TEST 21: Found post + failed finalization never inserts a duplicate ===
+	echo "\nTest 21: Reconciliation finalization failure does not call wp_insert_post\n";
+	reset_state();
+	$sm = new State_Manager();
+	$sm->save_state( [
+		'ai_config' => [ 'provider' => 'test', 'model' => 'test-model', 'has_credentials' => true ],
+		'client_data' => [ 'company_name' => 'Test Company' ],
+	] );
+	$builder = new Step_Landing_Page_Builder( new Logger(), $sm );
+	$builder->run( [ 'landing_action' => 'start', 'landings' => [
+		make_landing_payload_item( 'lk_dup', 'Duplicate Guard' ),
+		make_landing_payload_item( 'lk_hold', 'Hold Second' ),
+	], 'replace_canonical' => [] ] );
+	$state = $sm->get_state();
+	$orch = new Landing_Run_Orchestrator( $sm, new Logger() );
+	$orch->mark_item_error( 'lk_dup', 'interrupted', 'fatal_before_checkpoint', 'Process died before checkpoint' );
+	$state = $sm->get_state();
+	foreach ( $state['landing_run']['items'] as &$item ) {
+		if ( 'lk_dup' === ( $item['key'] ?? '' ) ) {
+			$item['post_id'] = 0;
+			$item['id'] = 0;
+			break;
+		}
+	}
+	unset( $item );
+	$state['landing_pages'] = [];
+	$state['landing_run']['status'] = 'interrupted';
+	$sm->save_state( $state );
+	delete_option( 'rms_landing_lease_' . sanitize_key( $state['landing_run']['run_id'] ) );
+	$posts_before = count( $GLOBALS['_posts'] );
+	$inserts_before = (int) $GLOBALS['_insert_post_calls'];
+	$GLOBALS['_fail_landing_meta'] = true;
+	$result = $builder->run( [ 'landing_action' => 'process' ] );
+	$GLOBALS['_fail_landing_meta'] = false;
+	$t->assert( is_wp_error( $result ), 'Process records an error when found-post finalization fails' );
+	$t->assertEqual( $posts_before, count( $GLOBALS['_posts'] ), 'Failed finalization does not create another post' );
+	$t->assertEqual( $inserts_before, (int) $GLOBALS['_insert_post_calls'], 'wp_insert_post is not called after a found post fails finalization' );
+	$failed_item = null;
+	foreach ( $orch->get_run()['items'] as $item ) {
+		if ( 'lk_dup' === ( $item['key'] ?? '' ) ) {
+			$failed_item = $item;
+			break;
+		}
+	}
+	$t->assertEqual( 'failed', $failed_item['status'] ?? '', 'Found-post finalization failure marks the same item failed' );
+
+	// === TEST 22: Concurrent starts share one plan identity; stale release cannot steal the fence ===
+	echo "\nTest 22: Concurrent start fence serializes plan identity\n";
+	reset_state();
+	$sm = new State_Manager();
+	$sm->save_state( [
+		'ai_config' => [ 'provider' => 'test', 'model' => 'test-model', 'has_credentials' => true ],
+		'client_data' => [ 'company_name' => 'Test Company' ],
+	] );
+	$orch = new Landing_Run_Orchestrator( $sm, new Logger() );
+	$owner_a = $orch->acquire_start_fence();
+	$t->assert( ! is_wp_error( $owner_a ), 'First starter acquires the initialization fence' );
+	$owner_b = $orch->acquire_start_fence();
+	$t->assert( is_wp_error( $owner_b ), 'Second starter loses the initialization fence' );
+	$t->assertEqual( 'rms_wizard_landing_start_fence_active', is_wp_error( $owner_b ) ? $owner_b->get_error_code() : '', 'Fence contention uses start_fence_active' );
+	$builder = new Step_Landing_Page_Builder( new Logger(), $sm );
+	$blocked = $builder->run( [ 'landing_action' => 'start', 'landings' => [
+		make_landing_payload_item( 'lk_race_1', 'Race One' ),
+		make_landing_payload_item( 'lk_race_2', 'Race Two' ),
+	], 'replace_canonical' => [] ] );
+	$t->assert( is_wp_error( $blocked ), 'Public start cannot persist a plan while another starter holds the fence' );
+	$t->assert( null === $orch->get_run(), 'Losing starter does not persist a run' );
+	$orch->release_start_fence( 'not-the-owner' );
+	$owner_after_wrong = $orch->acquire_start_fence();
+	$t->assert( is_wp_error( $owner_after_wrong ), 'Non-owner cannot release the start fence' );
+	$orch->release_start_fence( (string) $owner_a );
+	$winner = $builder->run( [ 'landing_action' => 'start', 'landings' => [
+		make_landing_payload_item( 'lk_win_1', 'Winner One' ),
+		make_landing_payload_item( 'lk_win_2', 'Winner Two' ),
+		make_landing_payload_item( 'lk_win_3', 'Winner Three' ),
+	], 'replace_canonical' => [] ] );
+	$t->assert( ! is_wp_error( $winner ), 'Winning starter persists after the fence is released' . ( is_wp_error( $winner ) ? ': ' . $winner->get_error_message() : '' ) );
+	$winning_run = $orch->get_run();
+	$winning_id = (string) ( $winning_run['run_id'] ?? '' );
+	$t->assertEqual( 3, (int) ( $winning_run['total'] ?? 0 ), 'Winning start persisted the full three-item plan' );
+	$loser = $builder->run( [ 'landing_action' => 'start', 'landings' => [ make_landing_payload_item( 'lk_other', 'Other' ) ], 'replace_canonical' => [] ] );
+	$t->assert( is_wp_error( $loser ), 'Second start cannot replace the winning run identity' );
+	$t->assertEqual( $winning_id, (string) ( $orch->get_run()['run_id'] ?? '' ), 'Only one run identity remains' );
+	$t->assertEqual( 3, (int) ( $orch->get_run()['total'] ?? 0 ), 'Original plan is not replaced by a later start' );
+	$replacement = $orch->acquire_start_fence();
+	$t->assert( ! is_wp_error( $replacement ), 'A later starter can acquire a free start fence' );
+	$orch->release_start_fence( (string) $owner_a );
+	$after_stale = $orch->acquire_start_fence();
+	$t->assert( is_wp_error( $after_stale ), 'Stale/non-owner release cannot clear replacement start-fence ownership' );
+	$orch->release_start_fence( (string) $replacement );
+
+	echo "\n";
+	$t->results();
+}


### PR DESCRIPTION
Fixes #27

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Persists a normalized landing run plan and checkpoints each landing before the next bounded request so batches can resume after timeout.
- Merges start/process lock semantics with existing #22 truthful REST success mapping; skip-all stays on the legacy lock.
- Frontend is unchanged in this slice: the REST contract is ready (`landing_action=start|process`, public `landing_run` on GET) while admin hydration lands next.

## Changes

| File | Change |
|------|--------|
| `inc/wizard/class-landing-run-orchestrator.php` | New run plan, lease, start fence, checkpoint, and public view. |
| `inc/wizard/class-step-landing-page-builder.php` | Resumable start/process/skip orchestration; legacy whole-batch path removed. |
| `inc/wizard/class-state-manager.php` | Default `landing_run` merged beside preserved `home_seo_targeting`. |
| `inc/wizard/class-step-controller.php` | GET stale-lease recovery + start/process lease handoff; #22 success mapping kept. |
| `scripts/test-landing-run-orchestrator.php` | Backend orchestration harness baseline (109 cases). |

## Test Plan
- [x] `php scripts/test-landing-run-orchestrator.php` — 109/0 PASS.
- [x] `php tests/wizard-home-seo-targeting-harness.php` — 9/9 PASS (canonical/landing isolation kept).
- [x] `php tests/wizard-dependency-truth-harness.php` — 10/10 PASS.
- [x] `php tests/wizard-credential-dom-safety-harness.php` — 3/3 PASS.
- [x] `php tests/acf-inactive-frontend-harness.php` — 11/11 PASS.
- [x] `php scripts/test-footer-variants.php` — PASS.
- [x] `php scripts/test-palette-runtime.php` — PASS.
- [x] PHP lint on touched files — no syntax errors.
- [x] Diff against `feat/home-seo-ui` contains only the #27 backend slice.
- [x] Scripts run without errors: N/A — no shell scripts in this PR.

## size:exception

Review budget is **3323 / 400**. The orchestrator, resumable builder, controller merge, and 1151-line backend harness must travel together or the slice cannot prove checkpoint/resume behavior.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts: N/A — no shell scripts
- [x] Skills tested in at least one agent: N/A — wizard backend fix, not a skill change
- [x] Docs updated if behavior changed: REST-ready intermediate state; client hydration is the follow-up slice
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Chain Context

| Field | Value |
|-------|-------|
| Chain | wizard-setup beta issues #22–#29 |
| Tracker PR | Not needed — retained `feature/wizard-setup` @ `3205ee5` |
| Position | 9 of 11 |
| Base | `feat/home-seo-ui` |
| Depends on | PR #37 / #26 UI |
| Follow-up | Planned: #27 client UI/hydration |
| Review budget | 3323 / 400 (`size:exception` — orchestrator + builder + harness) |
| Starts at | `feat/home-seo-ui` |
| Ends with | Resumable landing backend checkpoints and REST-ready `landing_run` |

### Chain Overview

```text
feature/wizard-setup
 └── #30 docs/vite-manifest-checklist  (#24)
      └── #31 fix/acf-inactive-frontend-guard  (#23)
           └── #32 fix/footer-variant-runtime  (#28)
                └── #33 fix/palette-runtime-css  (#29)
                     └── #34 fix/wizard-dependency-truth  (#22)
                          └── #35 fix/wizard-credential-dom  (#25)
                               └── #36 feat/home-seo-backend  (#26 backend)
                                    └── #37 feat/home-seo-ui  (#26 UI)
                                         └── 📍 fix/landing-run-backend  (#27 backend)
                                              └── planned #27 client
```

### Scope
- Includes: Landing_Run_Orchestrator, resumable landing builder, `landing_run` default, controller start/process/skip merge with #22 truth, backend harness.
- Excludes: landing client helper/UI/progress markup, global Wizard_Mutation_Fence.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit
