### PR TITLE
fix(wizard): hydrate resumable landing progress in admin

### DIFF
--- a/inc/wizard/wizard-init.php
+++ b/inc/wizard/wizard-init.php
@@ -905,6 +905,12 @@ function rms_wizard_render_landing_page_builder_form(): void {
 				<?php esc_html_e( 'Create one or more SEO or Ads landing pages. Only Hero and SEO Content receive keywords; reusable sections stay neutral and pull from the canonical store. Ads landings are noindex and never auto-added to menus.', 'simple-rms-theme' ); ?>
 			</p>
 
+			<div class="rms-wizard-landing-run-progress" data-wizard-landing-run-progress hidden>
+				<p class="rms-wizard-landing-run-progress__text" data-wizard-landing-run-progress-text aria-live="polite"></p>
+				<p class="rms-wizard-landing-run-progress__current" data-wizard-landing-run-current-title aria-live="polite"></p>
+				<button type="button" class="button button-primary" data-wizard-landing-resume><?php esc_html_e( 'Resume run', 'simple-rms-theme' ); ?></button>
+			</div>
+
 			<label class="rms-wizard-landing-skip-all">
 				<input type="checkbox" name="skip_all" value="1" data-wizard-landing-skip-all>
 				<span><?php esc_html_e( 'Skip landing pages for now (complete this step with zero landings)', 'simple-rms-theme' ); ?></span>
@@ -986,6 +992,7 @@ function rms_wizard_render_landing_page_builder_form(): void {
 
 			<template data-wizard-landing-section-row-template>
 				<div class="rms-wizard-landing-section-row" data-wizard-landing-section-row>
+					<input type="hidden" name="landings[__LINDEX__][sections][__SINDEX__][item_count]" value="" data-wizard-landing-section-item-count>
 					<select name="landings[__LINDEX__][sections][__SINDEX__][layout]" data-wizard-landing-section-layout></select>
 					<label class="rms-wizard-landing-section-override">
 						<input type="checkbox" name="landings[__LINDEX__][sections][__SINDEX__][override_canonical]" value="1" data-wizard-landing-section-override>

--- a/scripts/test-landing-run-client.mjs
+++ b/scripts/test-landing-run-client.mjs
@@ -1,0 +1,122 @@
+/**
+ * Deterministic proof for landing hydration merge and active-run UI.
+ *
+ * Imports the production helper used by src/ts/admin/wizard.ts.
+ * Run with: node scripts/test-landing-run-client.mjs
+ */
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const ts = require('typescript');
+const helperPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '../src/ts/admin/landing-run-helpers.ts');
+const compiled = ts.transpileModule(fs.readFileSync(helperPath, 'utf8'), {
+  compilerOptions: {
+    module: ts.ModuleKind.ESNext,
+    target: ts.ScriptTarget.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+  },
+  fileName: helperPath,
+});
+const compiledUrl = `data:text/javascript;charset=utf-8,${encodeURIComponent(compiled.outputText)}`;
+const {
+  mergeLandingRowsByKey,
+  sectionsFromPlanItem,
+  shouldOfferLandingResume,
+  isIncompleteLandingRunStatus,
+  resolveLandingClientRequest,
+} = await import(compiledUrl);
+
+const completed = [
+  { landing_key: 'lk_1', id: 11, title: 'One', sections: [{ layout: 'cta-v1' }] },
+  { landing_key: 'lk_2', id: 12, title: 'Two', sections: [{ layout: 'cta-v1' }] },
+  { landing_key: 'lk_3', id: 13, title: 'Three', sections: [{ layout: 'cta-v1' }] },
+  { landing_key: 'lk_4', id: 14, title: 'Four', sections: [{ layout: 'cta-v1' }] },
+];
+const planItems = [
+  ...completed.map((row) => ({ ...row, key: row.landing_key, status: 'completed', sections: [{ layout: 'hero' }] })),
+  { key: 'lk_5', landing_key: 'lk_5', id: 0, title: 'Five', status: 'pending', sections: [{ layout: 'badges', item_count: 7, override_canonical: true }] },
+  { key: 'lk_6', landing_key: 'lk_6', id: 0, title: 'Six', status: 'pending', sections: [{ layout: 'badges' }] },
+  { key: 'lk_7', landing_key: 'lk_7', id: 0, title: 'Seven', status: 'pending', sections: [{ layout: 'badges' }] },
+  { key: 'lk_8', landing_key: 'lk_8', id: 0, title: 'Eight', status: 'pending', sections: [{ layout: 'badges' }] },
+  { key: 'lk_9', landing_key: 'lk_9', id: 0, title: 'Nine', status: 'pending', sections: [{ layout: 'badges' }] },
+];
+
+const merged = mergeLandingRowsByKey(completed, planItems);
+assert.equal(merged.length, 9, 'merge restores all 9 plan rows');
+assert.equal(merged.filter((row) => Number(row.id) > 0).length, 4, 'completed rows keep post IDs');
+assert.equal(new Set(merged.map((row) => row.landing_key)).size, 9, 'merge does not duplicate keys');
+assert.equal(merged.find((row) => row.landing_key === 'lk_1')?.sections?.[0]?.layout, 'hero', 'completed-row default sections are replaced by persisted plan sections');
+assert.ok(merged.some((row) => row.landing_key === 'lk_9' && row.sections?.[0]?.layout === 'badges'), 'pending plan rows restore their actual sections');
+
+const newlyAdded = merged.find((row) => row.landing_key === 'lk_5');
+const newlyAddedSections = sectionsFromPlanItem(newlyAdded);
+assert.equal(newlyAddedSections[0]?.item_count, 7, 'newly added plan rows restore item_count');
+assert.equal(newlyAddedSections[0]?.override_canonical, true, 'newly added plan rows restore override_canonical');
+
+assert.equal(shouldOfferLandingResume({ processingActive: true, runningStep: null, runStatus: 'running' }), false);
+assert.equal(shouldOfferLandingResume({ processingActive: false, runningStep: 'landing-page-builder', runStatus: 'running' }), false);
+assert.equal(shouldOfferLandingResume({ processingActive: false, runningStep: null, runStatus: 'interrupted' }), true);
+assert.equal(shouldOfferLandingResume({ processingActive: false, runningStep: null, runStatus: 'failed' }), true);
+assert.equal(shouldOfferLandingResume({ processingActive: true, runningStep: null, runStatus: 'failed' }), false);
+assert.equal(isIncompleteLandingRunStatus('pending'), true);
+assert.equal(isIncompleteLandingRunStatus('running'), true);
+assert.equal(isIncompleteLandingRunStatus('interrupted'), true);
+assert.equal(isIncompleteLandingRunStatus('failed'), true);
+assert.equal(isIncompleteLandingRunStatus('completed'), false);
+
+const wizardSource = fs.readFileSync(
+  path.join(path.dirname(fileURLToPath(import.meta.url)), '../src/ts/admin/wizard.ts'),
+  'utf8'
+);
+
+assert.ok(wizardSource.includes("from './landing-run-helpers'"), 'wizard imports the production hydration helper');
+assert.ok(wizardSource.includes('processing_active'), 'wizard reads processing_active');
+assert.ok(wizardSource.includes('upsertLandingRowFromPlanItem'), 'wizard upserts existing rows by landing key');
+assert.ok(wizardSource.includes('replaceLandingRowSections'), 'wizard replaces completed-row sections from the persisted plan');
+assert.ok(!/if \(rows\.querySelector\('\[data-wizard-landing-row\]'\)\) \{\s*return;\s*\}/.test(wizardSource), 'plan hydration no longer no-ops when completed rows already exist');
+assert.ok(wizardSource.includes('resumeButton.hidden = !canResume'), 'active processing hides Resume');
+assert.ok(wizardSource.includes('Processing is active. Refresh state to update.'), 'active processing tells the operator to refresh later');
+assert.ok(wizardSource.includes('sectionsFromPlanItem'), 'wizard hydrates newly added rows from persisted plan sections');
+assert.ok(wizardSource.includes('isIncompleteLandingRunStatus'), 'wizard gates generic start/retry on incomplete persisted runs');
+assert.ok(wizardSource.includes('button.hidden = incompleteLandingRun'), 'wizard hides generic start/retry while an incomplete run exists');
+assert.ok(wizardSource.includes('resolveLandingClientRequest'), 'wizard uses the production request decision helper');
+assert.ok(wizardSource.includes("void runStep(step, 'run')"), 'Run click passes run intent into the shared handler');
+assert.ok(wizardSource.includes("void runStep(step, 'retry')"), 'Retry click passes retry intent into the shared handler');
+assert.ok(!wizardSource.includes("!('skip_all' in payload)"), 'wizard no longer treats skip_all:false as skip-all');
+
+const runDecision = resolveLandingClientRequest({ intent: 'run', skipAll: false, incompleteRun: false });
+const retryDecision = resolveLandingClientRequest({ intent: 'retry', skipAll: false, incompleteRun: false });
+const resumeDecision = resolveLandingClientRequest({ intent: 'resume', skipAll: false, incompleteRun: true });
+const skipDecision = resolveLandingClientRequest({ intent: 'run', skipAll: true, incompleteRun: false });
+const skipWithIncomplete = resolveLandingClientRequest({ intent: 'retry', skipAll: true, incompleteRun: true });
+const retryIncomplete = resolveLandingClientRequest({ intent: 'retry', skipAll: false, incompleteRun: true });
+const runIncomplete = resolveLandingClientRequest({ intent: 'run', skipAll: false, incompleteRun: true });
+const resumeWithoutRun = resolveLandingClientRequest({ intent: 'resume', skipAll: false, incompleteRun: false });
+
+assert.equal(runDecision.kind, 'start', 'Run without an incomplete run starts');
+assert.equal(runDecision.body?.landing_action, 'start', 'Run payload uses landing_action start');
+assert.equal(retryDecision.kind, 'start', 'Retry without an incomplete run starts');
+assert.equal(retryDecision.body?.landing_action, 'start', 'Retry payload uses landing_action start');
+assert.equal(resumeDecision.kind, 'process', 'Resume with an incomplete run processes');
+assert.equal(resumeDecision.body?.landing_action, 'process', 'Resume payload uses landing_action process');
+assert.equal(skipDecision.kind, 'skip', 'skip-all stays skip-only');
+assert.equal(skipDecision.body?.skip_all, true, 'skip-all payload is skip_all true');
+assert.equal(skipDecision.body?.landing_action, undefined, 'skip-all does not send landing_action');
+assert.equal(skipWithIncomplete.kind, 'skip', 'skip-all stays skip-only even with an incomplete run');
+assert.equal(retryIncomplete.kind, 'blocked', 'Retry never starts over an incomplete run');
+assert.equal(runIncomplete.kind, 'blocked', 'Run never starts over an incomplete run');
+assert.equal(resumeWithoutRun.kind, 'blocked', 'Resume without an incomplete run does not start');
+assert.ok(![runIncomplete, retryIncomplete, resumeWithoutRun].some((decision) => decision.body?.landing_action === 'start'), 'incomplete run never selects start');
+
+console.log('  PASS: production helper restores 4 completed + 5 pending and replaces default sections');
+console.log('  PASS: newly added plan rows restore item_count and override_canonical');
+console.log('  PASS: active processing hides Resume; expired/interrupted can resume');
+console.log('  PASS: incomplete persisted runs hide generic start/retry');
+console.log('  PASS: wizard.ts imports and applies the production helper');
+console.log('  PASS: Run/Retry produce start; Resume produces process; skip-all stays skip-only');
+console.log('  PASS: incomplete run never selects start from Run, Retry, or Resume');
+console.log('\n  Results: 7 passed, 0 failed');

--- a/src/ts/admin/landing-run-helpers.ts
+++ b/src/ts/admin/landing-run-helpers.ts
@@ -1,0 +1,168 @@
+export interface LandingHydrationSection {
+  layout?: string;
+  override_canonical?: boolean;
+  item_count?: number;
+}
+
+export interface LandingHydrationRow {
+  landing_key?: string;
+  key?: string;
+  id?: number | string | null;
+  post_id?: number | string | null;
+  title?: string;
+  slug?: string;
+  landing_type?: string;
+  primary_keyword?: string;
+  subkeywords?: string[];
+  sections?: LandingHydrationSection[];
+}
+
+export interface LandingResumeOfferInput {
+  processingActive?: boolean;
+  runningStep?: string | null;
+  runStatus?: string | null;
+}
+
+export type LandingClientIntent = 'run' | 'retry' | 'resume';
+
+export interface LandingClientRequestContext {
+  intent: LandingClientIntent;
+  skipAll?: boolean;
+  incompleteRun?: boolean;
+}
+
+export type LandingClientRequestDecision =
+  | { kind: 'start'; body: { landing_action: 'start' } }
+  | { kind: 'process'; body: { landing_action: 'process' } }
+  | { kind: 'skip'; body: { skip_all: true } }
+  | { kind: 'blocked'; reason: 'incomplete_run' };
+
+/**
+ * Decide the Landing Page Builder request from the actual button intent.
+ * Run/Retry start a new plan only when no incomplete persisted run exists.
+ * Resume continues that plan with process. Skip-all never sends start/process.
+ */
+export const resolveLandingClientRequest = ({
+  intent,
+  skipAll = false,
+  incompleteRun = false,
+}: LandingClientRequestContext): LandingClientRequestDecision => {
+  if (skipAll) {
+    return { kind: 'skip', body: { skip_all: true } };
+  }
+
+  if (incompleteRun) {
+    if (intent === 'resume') {
+      return { kind: 'process', body: { landing_action: 'process' } };
+    }
+
+    return { kind: 'blocked', reason: 'incomplete_run' };
+  }
+
+  if (intent === 'resume') {
+    return { kind: 'blocked', reason: 'incomplete_run' };
+  }
+
+  return { kind: 'start', body: { landing_action: 'start' } };
+};
+
+const normalizeKey = (row: LandingHydrationRow): string =>
+  String(row.landing_key || row.key || '').trim();
+
+const numericId = (value: unknown): number => {
+  const parsed = typeof value === 'number' ? value : Number.parseInt(String(value ?? ''), 10);
+
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+};
+
+/**
+ * Merge completed landing rows with the persisted run plan by landing key.
+ *
+ * Plan sections replace empty/default completed-row sections. Completed post
+ * IDs and other durable values are retained.
+ */
+export const mergeLandingRowsByKey = (
+  existingRows: LandingHydrationRow[],
+  planItems: LandingHydrationRow[]
+): LandingHydrationRow[] => {
+  const byKey = new Map<string, LandingHydrationRow>();
+
+  for (const row of existingRows) {
+    const key = normalizeKey(row);
+
+    if (key) {
+      byKey.set(key, { ...row, landing_key: key });
+    }
+  }
+
+  for (const item of planItems) {
+    const key = normalizeKey(item);
+
+    if (!key) {
+      continue;
+    }
+
+    const current = byKey.get(key);
+    const planId = numericId(item.id ?? item.post_id);
+    const existingId = numericId(current?.id ?? current?.post_id);
+    const planSections = Array.isArray(item.sections) ? item.sections : [];
+    const currentSections = Array.isArray(current?.sections) ? current.sections : [];
+
+    byKey.set(key, {
+      ...(current || {}),
+      ...item,
+      landing_key: key,
+      id: existingId > 0 ? existingId : (planId > 0 ? planId : null),
+      sections: planSections.length > 0 ? planSections : currentSections,
+    });
+  }
+
+  return [...byKey.values()];
+};
+
+export const shouldOfferLandingResume = ({
+  processingActive,
+  runningStep,
+  runStatus,
+}: LandingResumeOfferInput): boolean => {
+  if (processingActive || runningStep) {
+    return false;
+  }
+
+  return runStatus === 'interrupted' || runStatus === 'failed' || runStatus === 'running' || runStatus === 'pending';
+};
+
+export const isIncompleteLandingRunStatus = (runStatus?: string | null): boolean => (
+  runStatus === 'pending'
+  || runStatus === 'running'
+  || runStatus === 'interrupted'
+  || runStatus === 'failed'
+);
+
+/**
+ * Map a persisted plan item's sections onto form-ready values.
+ * Newly added DOM rows must keep item_count and override_canonical.
+ */
+export const sectionsFromPlanItem = (item: LandingHydrationRow): LandingHydrationSection[] => {
+  if (!Array.isArray(item.sections)) {
+    return [];
+  }
+
+  return item.sections.flatMap((section) => {
+    const layout = typeof section === 'object' && section !== null ? String(section.layout ?? '').trim() : '';
+
+    if (!layout) {
+      return [];
+    }
+
+    const itemCount = typeof section.item_count === 'number' && Number.isFinite(section.item_count)
+      ? section.item_count
+      : undefined;
+
+    return [{
+      layout,
+      override_canonical: Boolean(section.override_canonical),
+      ...(itemCount !== undefined ? { item_count: itemCount } : {}),
+    }];
+  });
+};

--- a/src/ts/admin/wizard.ts
+++ b/src/ts/admin/wizard.ts
@@ -1,4 +1,13 @@
 import {
+  isIncompleteLandingRunStatus,
+  mergeLandingRowsByKey,
+  resolveLandingClientRequest,
+  sectionsFromPlanItem,
+  shouldOfferLandingResume,
+  type LandingClientIntent,
+  type LandingHydrationRow,
+} from './landing-run-helpers';
+import {
   applyApiKeyInputSafety,
   presentStepOutcome,
   summarizeDependencyResult,
@@ -17,6 +26,8 @@ import {
 } from './wizard-home-seo';
 
 type StepStatus = 'pending' | 'running' | 'complete' | 'failed';
+
+export {};
 
 interface WizardSettings {
   root: string;
@@ -49,6 +60,34 @@ interface LandingPageState {
     primary_keyword?: string;
     subkeywords?: string[];
   };
+}
+
+interface LandingRunItem {
+  key?: string;
+  landing_key?: string;
+  id?: number;
+  title?: string;
+  slug?: string;
+  landing_type?: string;
+  menu_eligible?: boolean;
+  primary_keyword?: string;
+  subkeywords?: string[];
+  sections?: Array<{ layout?: string; override_canonical?: boolean; item_count?: number }>;
+  status?: 'pending' | 'running' | 'completed' | 'interrupted' | 'failed' | string;
+  post_id?: number;
+  error_code?: string;
+  error_message?: string;
+}
+
+interface LandingRunPlan {
+  run_id?: string;
+  status?: string;
+  total?: number;
+  completed?: number;
+  current_index?: number;
+  processing_active?: boolean;
+  lease_expires_at?: number | null;
+  items?: LandingRunItem[];
 }
 
 interface WizardPageTemplate {
@@ -85,6 +124,7 @@ interface HomeSectionPayload {
 interface LandingSectionPayload {
   layout: string;
   override_canonical: boolean;
+  item_count?: number;
 }
 
 interface LandingPayloadItem {
@@ -127,6 +167,7 @@ interface WizardState {
     secondary_keywords?: string[];
   };
   landing_pages?: LandingPageState[];
+  landing_run?: LandingRunPlan | null;
   locked?: boolean;
   unlocked?: boolean;
   completed_flag?: boolean;
@@ -367,7 +408,10 @@ declare global {
 
     [...runButtons, ...retryButtons].forEach((button) => {
       const step = button.dataset.wizardRunStep || button.dataset.wizardRetryStep || '';
-      button.disabled = isHydrating || isLocked || runningStep !== null || statusFor(step) === 'running';
+      const processingBlocks = step === 'landing-page-builder' && isProcessingActive();
+      const incompleteLandingRun = step === 'landing-page-builder' && isIncompleteLandingRunStatus(state.landing_run?.status ?? '');
+      button.hidden = incompleteLandingRun;
+      button.disabled = isHydrating || isLocked || runningStep !== null || statusFor(step) === 'running' || processingBlocks || incompleteLandingRun;
     });
 
     loadModelButtons.forEach((button) => {
@@ -388,7 +432,7 @@ declare global {
     });
 
     if (refreshButton) {
-      refreshButton.disabled = isHydrating || runningStep !== null;
+      refreshButton.disabled = isHydrating;
     }
 
     if (completeButton) {
@@ -397,6 +441,22 @@ declare global {
     }
 
     syncLandingSkipAllUi();
+
+    // Disable landing builder editing controls while a run is active/interrupted.
+    const landingRunActive = isLandingRunActive();
+
+    root.querySelectorAll<HTMLButtonElement>('[data-wizard-add-landing], [data-wizard-duplicate-landing], [data-wizard-remove-landing]').forEach((button) => {
+      button.disabled = isHydrating || isLocked || landingRunActive || runningStep !== null;
+    });
+
+    root.querySelectorAll<HTMLInputElement>('[data-wizard-landing-title], [data-wizard-landing-slug], [data-wizard-landing-type], [data-wizard-landing-primary-keyword], [data-wizard-landing-subkeywords]').forEach((field) => {
+      field.disabled = isHydrating || isLocked || landingRunActive || runningStep !== null;
+    });
+
+    root.querySelectorAll<HTMLButtonElement>('[data-wizard-landing-toggle]').forEach((button) => {
+      // Toggle (expand/collapse) stays enabled — it's read-only navigation.
+      button.disabled = isHydrating;
+    });
   };
 
   const render = (options?: { replaceHomeSeo?: boolean }): void => {
@@ -409,6 +469,7 @@ declare global {
     hydrateHomeSeoTargetingForm(options?.replaceHomeSeo);
     hydrateLandingRowsFromState();
     renderLandingReplaceOptions();
+    renderLandingRunProgressFromState();
     syncGuidedControlState();
     setActiveStep(nextStep);
     updateNav();
@@ -493,7 +554,52 @@ declare global {
     }
   };
 
-  const runStep = async (step: string): Promise<void> => {
+  const applyStepOutcomePresentation = (step: string, response: StepResponse, successNotice?: string): void => {
+    const stepStatus = statusFor(step);
+    const responseSuccess = response.success !== false;
+    const outcome = presentStepOutcome(stepStatus, responseSuccess);
+
+    if (outcome === 'success') {
+      /*
+       * Clear the API key input immediately after a successful IA Generation
+       * save so the plaintext does not linger in the DOM between the
+       * response and the state re-hydration. The saved-key status element
+       * already shows masked metadata.
+       */
+      if (step === 'ia-generation') {
+        clearApiKeyInput();
+      }
+
+      const nextStep = nextStepFor(step);
+      setStepActionStatus(step, 'Step completed.', 'success');
+      setNotice(
+        successNotice
+          ?? (nextStep
+            ? `${labelFor(step)} completed successfully. Continue to ${labelFor(nextStep)} when ready.`
+            : `${labelFor(step)} completed successfully.`),
+        'success'
+      );
+      return;
+    }
+
+    if (outcome === 'progress') {
+      /*
+       * Issue #27 merge invariant: a healthy landing-page-builder request
+       * may finish still `running`. Do not paint that as "Step completed"
+       * and do not paint it as a failure.
+       */
+      const progressMessage = `${labelFor(step)} is still in progress.`;
+      setStepActionStatus(step, progressMessage, 'info');
+      setNotice(progressMessage, 'info');
+      return;
+    }
+
+    const summary = stepResultSummary(step, response.result);
+    setStepActionStatus(step, summary, 'error');
+    setNotice(summary, 'error');
+  };
+
+  const runStep = async (step: string, intent: LandingClientIntent = 'run'): Promise<void> => {
     runningStep = step;
     setActiveStep(step);
     setStepActionStatus(step, 'Running step...', 'info');
@@ -513,6 +619,42 @@ declare global {
 
       render();
 
+      if (step === 'landing-page-builder') {
+        const decision = resolveLandingClientRequest({
+          intent,
+          skipAll: Boolean(payload.skip_all),
+          incompleteRun: isIncompleteLandingRunStatus(state.landing_run?.status ?? ''),
+        });
+
+        if (decision.kind === 'blocked') {
+          setStepActionStatus(step, 'An incomplete landing run already exists. Use Resume.', 'error');
+          setNotice('An incomplete landing run already exists. Use Resume to continue from the last checkpoint.', 'info');
+          return;
+        }
+
+        if (decision.kind === 'skip') {
+          const response = await request<StepResponse>(`steps/${step}/run`, {
+            method: 'POST',
+            body: JSON.stringify({ ...payload, ...decision.body }),
+          }, 1);
+
+          if (response.state) {
+            state = response.state;
+          }
+
+          setStepResult(step, response.result ?? response);
+          applyStepOutcomePresentation(step, response, 'Landing step completed with skip-all.');
+          return;
+        }
+
+        if (decision.kind === 'start') {
+          await runLandingStepOrchestrated(payload, decision.body);
+          return;
+        }
+
+        return;
+      }
+
       const response = await request<StepResponse>(`steps/${step}/run`, {
         method: 'POST',
         body: JSON.stringify(payload),
@@ -523,44 +665,8 @@ declare global {
       }
 
       persisted = true;
-      const stepStatus = statusFor(step);
-      const responseSuccess = response.success !== false;
-      const outcome = presentStepOutcome(stepStatus, responseSuccess);
       setStepResult(step, response.result ?? response);
-
-      if (outcome === 'success') {
-        /*
-         * Clear the API key input immediately after a successful IA Generation
-         * save so the plaintext does not linger in the DOM between the
-         * response and the state re-hydration. The saved-key status element
-         * already shows masked metadata.
-         */
-        if (step === 'ia-generation') {
-          clearApiKeyInput();
-        }
-
-        const nextStep = nextStepFor(step);
-        setStepActionStatus(step, 'Step completed.', 'success');
-        setNotice(
-          nextStep
-            ? `${labelFor(step)} completed successfully. Continue to ${labelFor(nextStep)} when ready.`
-            : `${labelFor(step)} completed successfully.`,
-          'success'
-        );
-      } else if (outcome === 'progress') {
-        /*
-         * Issue #27 merge invariant: a healthy landing-page-builder request
-         * may finish still `running`. Do not paint that as "Step completed"
-         * and do not paint it as a failure.
-         */
-        const progressMessage = `${labelFor(step)} is still in progress.`;
-        setStepActionStatus(step, progressMessage, 'info');
-        setNotice(progressMessage, 'info');
-      } else {
-        const summary = stepResultSummary(step, response.result);
-        setStepActionStatus(step, summary, 'error');
-        setNotice(summary, 'error');
-      }
+      applyStepOutcomePresentation(step, response);
     } catch (error) {
       const message = errorMessage(error);
       validationBlocked = isHomeSeoValidationError(error);
@@ -586,6 +692,401 @@ declare global {
         updateButtons();
       }
     }
+  };
+
+  const runLandingStepOrchestrated = async (
+    payload: StepPayload,
+    actionBody: { landing_action: 'start' }
+  ): Promise<void> => {
+    const step = 'landing-page-builder';
+
+    setStepActionStatus(step, 'Starting landing run...', 'info');
+    setNotice('Starting landing run. Each landing is processed one at a time.', 'info');
+
+    try {
+      // Start the run plan (persist before AI work). attempts=1 — no retry on non-idempotent start.
+      const startPayload = { ...payload, ...actionBody };
+      const startResponse = await request<StepResponse>(`steps/${step}/run`, {
+        method: 'POST',
+        body: JSON.stringify(startPayload),
+      }, 1);
+
+      if (startResponse.state) {
+        state = startResponse.state;
+      }
+
+      const result = startResponse.result as { landing_run?: LandingRunPlan; completed?: number; total?: number; current_title?: string } | undefined;
+
+      if (result?.landing_run) {
+        renderLandingRunProgress(result.landing_run, result.current_title ?? '');
+      }
+
+      // If the run is already complete after start (all unchanged), finish.
+      if (result?.landing_run && result.landing_run.status === 'completed') {
+        setStepActionStatus(step, `All ${result.total ?? 0} landings are already complete.`, 'success');
+        setNotice(`Landing run complete: ${result.completed ?? 0} of ${result.total ?? 0} landings.`, 'success');
+        return;
+      }
+
+      // Process items one at a time.
+      await processLandingItems(step);
+    } catch (error) {
+      const message = errorMessage(error);
+      setStepActionStatus(step, message, 'error');
+      setNotice(message, 'error');
+      // On network/HTTP error, load persisted state and offer Resume.
+      await loadState();
+    }
+  };
+
+  const processLandingItems = async (
+    step: string,
+    actionBody: { landing_action: 'process' } = { landing_action: 'process' }
+  ): Promise<void> => {
+    const maxIterations = 100; // Safety bound.
+    let iteration = 0;
+
+    while (iteration < maxIterations) {
+      iteration += 1;
+
+      // attempts=1 — no retry on non-idempotent process. Each request advances at most one item.
+      let processResponse: StepResponse;
+
+      try {
+        processResponse = await request<StepResponse>(`steps/${step}/run`, {
+          method: 'POST',
+          body: JSON.stringify(actionBody),
+        }, 1);
+      } catch (error) {
+        // Network/HTTP error: load persisted state once, offer Resume/Retry explicitly.
+        const message = errorMessage(error);
+        setStepActionStatus(step, message, 'error');
+        if (isAlreadyProcessingMessage(message)) {
+          setNotice('Landing processing is already active. Refresh state to update.', 'info');
+        } else {
+          setNotice(`${message} Click Resume to continue from the last checkpoint.`, 'error');
+        }
+        await loadState();
+        return;
+      }
+
+      if (processResponse.state) {
+        state = processResponse.state;
+      }
+
+      const result = processResponse.result as { landing_run?: LandingRunPlan; completed?: number; total?: number; current_title?: string } | undefined;
+
+      if (!result?.landing_run) {
+        break;
+      }
+
+      renderLandingRunProgress(result.landing_run, result.current_title ?? '');
+
+      if (result.landing_run.status === 'completed') {
+        setStepActionStatus(step, `Landing run complete: ${result.completed ?? 0} of ${result.total ?? 0} landings.`, 'success');
+        setNotice(`Landing run complete: ${result.completed ?? 0} of ${result.total ?? 0} landings.`, 'success');
+        return;
+      }
+
+      if (result.landing_run.status === 'interrupted' || result.landing_run.status === 'failed') {
+        const failedItem = result.landing_run.items?.find((item) => item.status === 'failed' || item.status === 'interrupted');
+        const message = failedItem?.error_message ?? 'The landing run was interrupted.';
+        setStepActionStatus(step, message, 'error');
+        setNotice(`${message} Click Resume to retry from the last checkpoint.`, 'error');
+        return;
+      }
+
+      const completed = result.completed ?? 0;
+      const total = result.total ?? 0;
+
+      setStepActionStatus(step, `Processing: ${completed} of ${total} completed.`, 'info');
+      setNotice(`Landing run in progress: ${completed} of ${total} completed. Current: ${result.current_title ?? ''}.`, 'info');
+    }
+
+    setStepActionStatus(step, 'Landing run reached maximum iterations.', 'error');
+    setNotice('Landing run reached maximum iterations without completing.', 'error');
+  };
+
+  const resumeLandingRun = async (): Promise<void> => {
+    const step = 'landing-page-builder';
+    const decision = resolveLandingClientRequest({
+      intent: 'resume',
+      skipAll: false,
+      incompleteRun: isIncompleteLandingRunStatus(state.landing_run?.status ?? ''),
+    });
+
+    if (decision.kind !== 'process') {
+      setStepActionStatus(step, 'No incomplete landing run is available to resume.', 'info');
+      setNotice('No incomplete landing run is available to resume.', 'info');
+      return;
+    }
+
+    runningStep = step;
+    setActiveStep(step);
+    setStepActionStatus(step, 'Resuming landing run...', 'info');
+    setNotice('Resuming landing run from the last checkpoint.', 'info');
+
+    try {
+      await processLandingItems(step, decision.body);
+    } catch (error) {
+      const message = errorMessage(error);
+      setStepActionStatus(step, message, 'error');
+      setNotice(message, 'error');
+      await loadState();
+    } finally {
+      runningStep = null;
+      await loadState();
+    }
+  };
+
+  const isLandingRunActive = (): boolean => {
+    const run = state.landing_run;
+    if (!run) {
+      return false;
+    }
+    return run.status === 'running' || run.status === 'pending' || run.status === 'interrupted' || isProcessingActive();
+  };
+
+  const isProcessingActive = (): boolean => {
+    const run = state.landing_run;
+    if (!run) {
+      return false;
+    }
+    if (run.processing_active === true) {
+      return true;
+    }
+    return typeof run.lease_expires_at === 'number' && run.lease_expires_at > Math.floor(Date.now() / 1000);
+  };
+
+  const isAlreadyProcessingMessage = (message: string): boolean => (
+    message.includes('already running') || message.includes('already active')
+  );
+
+  const renderLandingRunProgress = (run: LandingRunPlan, currentTitle: string): void => {
+    const progressContainer = root.querySelector<HTMLElement>('[data-wizard-landing-run-progress]');
+    const progressText = root.querySelector<HTMLElement>('[data-wizard-landing-run-progress-text]');
+    const currentTitleEl = root.querySelector<HTMLElement>('[data-wizard-landing-run-current-title]');
+    const resumeButton = root.querySelector<HTMLButtonElement>('[data-wizard-landing-resume]');
+
+    if (!progressContainer) {
+      return;
+    }
+
+    const completed = run.completed ?? 0;
+    const total = run.total ?? 0;
+    const processingActive = run.processing_active === true || isProcessingActive();
+    const isInterrupted = !processingActive && (run.status === 'interrupted' || run.status === 'failed');
+    const canResume = shouldOfferLandingResume({
+      processingActive,
+      runningStep,
+      runStatus: run.status ?? '',
+    });
+
+    progressContainer.hidden = false;
+
+    if (progressText) {
+      progressText.textContent = processingActive
+        ? `${completed} of ${total} completed. Processing is active. Refresh state to update.`
+        : `${completed} of ${total} completed`;
+    }
+
+    if (currentTitleEl) {
+      currentTitleEl.textContent = currentTitle ? `Current: ${currentTitle}` : '';
+    }
+
+    if (resumeButton) {
+      resumeButton.hidden = !canResume;
+      resumeButton.disabled = !canResume;
+      resumeButton.setAttribute(
+        'aria-label',
+        processingActive
+          ? `Landing processing is active (${completed} of ${total} completed)`
+          : isInterrupted
+            ? `Resume interrupted landing run (${completed} of ${total} completed)`
+            : `Continue landing run (${completed} of ${total} completed)`
+      );
+    }
+  };
+
+  const renderLandingRunProgressFromState = (): void => {
+    const run = state.landing_run;
+
+    if (!run) {
+      const progressContainer = root.querySelector<HTMLElement>('[data-wizard-landing-run-progress]');
+
+      if (progressContainer) {
+        progressContainer.hidden = true;
+      }
+
+      return;
+    }
+
+    // Find current item title from items (first pending/interrupted/running).
+    const currentTitle = run.items?.find((item) => item.status === 'running' || item.status === 'pending' || item.status === 'interrupted')?.title ?? '';
+
+    renderLandingRunProgress(run, currentTitle);
+
+    // Hydrate all persisted plan rows (including pending/interrupted/failed).
+    hydrateLandingRowsFromRunPlan(run);
+  };
+
+  /**
+   * Hydrate all persisted run plan rows into the landing builder.
+   *
+   * Full reload/Refresh must restore all plan rows — including
+   * pending/interrupted/failed definitions — not only completed landing_pages.
+   * Merge/upsert by stable landing key so completed rows keep post IDs
+   * while pending plan rows and sections are restored without duplicates.
+   */
+  const hydrateLandingRowsFromRunPlan = (run: LandingRunPlan): void => {
+    const rows = getLandingRowsContainer();
+
+    if (!rows) {
+      return;
+    }
+
+    const items = Array.isArray(run.items) ? run.items : [];
+
+    if (items.length === 0) {
+      return;
+    }
+
+    const existingByKey = new Map<string, HTMLElement>();
+    const existingRows: LandingHydrationRow[] = [];
+
+    rows.querySelectorAll<HTMLElement>('[data-wizard-landing-row]').forEach((row) => {
+      const snapshot = readLandingRowHydration(row);
+      const key = (snapshot.landing_key || '').trim();
+
+      if (!key) {
+        return;
+      }
+
+      existingByKey.set(key, row);
+      existingRows.push(snapshot);
+    });
+
+    const merged = mergeLandingRowsByKey(existingRows, items);
+
+    merged.forEach((item) => {
+      const key = (item.landing_key || item.key || '').trim();
+      if (!key) {
+        return;
+      }
+
+      const existing = existingByKey.get(key);
+      if (existing) {
+        upsertLandingRowFromPlanItem(existing, item);
+        return;
+      }
+
+      const rawId = item.id ?? item.post_id;
+      const parsedId = typeof rawId === 'number'
+        ? rawId
+        : (typeof rawId === 'string' ? Number.parseInt(rawId, 10) : NaN);
+
+      addLandingRow({
+        id: Number.isFinite(parsedId) && parsedId > 0 ? parsedId : null,
+        landing_key: key,
+        title: item.title || '',
+        slug: item.slug || '',
+        landing_type: item.landing_type === 'ads' ? 'ads' : 'seo',
+        primary_keyword: item.primary_keyword || '',
+        subkeywords: Array.isArray(item.subkeywords) ? item.subkeywords : [],
+        sections: sectionsFromPlanItem(item).map((section) => ({
+          layout: section.layout || '',
+          override_canonical: Boolean(section.override_canonical),
+          ...(typeof section.item_count === 'number' ? { item_count: section.item_count } : {}),
+        })),
+      }, { focus: false });
+    });
+  };
+
+  const readLandingRowHydration = (row: HTMLElement): LandingHydrationRow => {
+    const sections = [...row.querySelectorAll<HTMLElement>('[data-wizard-landing-section-row]')].map((sectionRow) => {
+      const rawCount = sectionRow.querySelector<HTMLInputElement>('[data-wizard-landing-section-item-count]')?.value ?? '';
+      const parsedCount = Number.parseInt(rawCount, 10);
+
+      return {
+        layout: sectionRow.querySelector<HTMLSelectElement>('[data-wizard-landing-section-layout]')?.value ?? '',
+        override_canonical: Boolean(sectionRow.querySelector<HTMLInputElement>('[data-wizard-landing-section-override]')?.checked),
+        ...(Number.isFinite(parsedCount) ? { item_count: parsedCount } : {}),
+      };
+    });
+
+    return {
+      landing_key: row.querySelector<HTMLInputElement>('[data-wizard-landing-key]')?.value.trim() ?? '',
+      id: row.querySelector<HTMLInputElement>('[data-wizard-landing-id]')?.value ?? '',
+      title: row.querySelector<HTMLInputElement>('[data-wizard-landing-title]')?.value ?? '',
+      slug: row.querySelector<HTMLInputElement>('[data-wizard-landing-slug]')?.value ?? '',
+      landing_type: row.querySelector<HTMLSelectElement>('[data-wizard-landing-type]')?.value ?? 'seo',
+      primary_keyword: row.querySelector<HTMLInputElement>('[data-wizard-landing-primary-keyword]')?.value ?? '',
+      subkeywords: (row.querySelector<HTMLInputElement>('[data-wizard-landing-subkeywords]')?.value ?? '')
+        .split(',')
+        .map((value) => value.trim())
+        .filter(Boolean),
+      sections,
+    };
+  };
+
+  const replaceLandingRowSections = (row: HTMLElement, sections: LandingHydrationRow['sections']): void => {
+    const container = row.querySelector<HTMLElement>('[data-wizard-landing-section-rows]');
+
+    if (!container || !Array.isArray(sections) || sections.length === 0) {
+      return;
+    }
+
+    container.replaceChildren();
+    sections.forEach((section) => {
+      const layout = typeof section === 'object' && section !== null ? section.layout ?? '' : '';
+
+      if (layout) {
+        addLandingSectionRow(row, layout, Boolean(section.override_canonical), section.item_count);
+      }
+    });
+  };
+
+  const upsertLandingRowFromPlanItem = (row: HTMLElement, item: LandingHydrationRow): void => {
+    const idInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-id]');
+    const titleInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-title]');
+    const slugInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-slug]');
+    const keywordInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-primary-keyword]');
+    const subkeywordsInput = row.querySelector<HTMLInputElement>('[data-wizard-landing-subkeywords]');
+    const typeSelect = row.querySelector<HTMLSelectElement>('[data-wizard-landing-type]');
+    const rawId = item.id ?? item.post_id;
+    const parsedId = typeof rawId === 'number'
+      ? rawId
+      : (typeof rawId === 'string' ? Number.parseInt(rawId, 10) : NaN);
+
+    if (idInput && (!idInput.value || Number.parseInt(idInput.value, 10) <= 0) && Number.isFinite(parsedId) && parsedId > 0) {
+      idInput.value = String(parsedId);
+    }
+
+    if (titleInput && !titleInput.value.trim() && item.title) {
+      titleInput.value = item.title;
+    }
+
+    if (slugInput && !slugInput.value.trim() && item.slug) {
+      slugInput.value = item.slug;
+    }
+
+    if (keywordInput && !keywordInput.value.trim() && item.primary_keyword) {
+      keywordInput.value = item.primary_keyword;
+    }
+
+    if (subkeywordsInput && !subkeywordsInput.value.trim() && Array.isArray(item.subkeywords) && item.subkeywords.length > 0) {
+      subkeywordsInput.value = item.subkeywords.join(', ');
+    }
+
+    if (typeSelect && item.landing_type) {
+      typeSelect.value = item.landing_type === 'ads' ? 'ads' : 'seo';
+    }
+
+    if (Array.isArray(item.sections) && item.sections.length > 0) {
+      replaceLandingRowSections(row, item.sections);
+    }
+
+    syncLandingRowSummary(row);
   };
 
   const completeWizard = async (): Promise<void> => {
@@ -911,12 +1412,18 @@ declare global {
       row.querySelectorAll<HTMLElement>('[data-wizard-landing-section-row]').forEach((sectionRow) => {
         const layout = sectionRow.querySelector<HTMLSelectElement>('[data-wizard-landing-section-layout]')?.value.trim() ?? '';
         const override = Boolean(sectionRow.querySelector<HTMLInputElement>('[data-wizard-landing-section-override]')?.checked);
+        const rawCount = sectionRow.querySelector<HTMLInputElement>('[data-wizard-landing-section-item-count]')?.value ?? '';
+        const parsedCount = Number.parseInt(rawCount, 10);
 
         if (!layout) {
           return;
         }
 
-        sections.push({ layout, override_canonical: override });
+        sections.push({
+          layout,
+          override_canonical: override,
+          ...(Number.isFinite(parsedCount) ? { item_count: parsedCount } : {}),
+        });
       });
 
       if (sections.length === 0) {
@@ -1337,7 +1844,7 @@ declare global {
 
     sectionLayouts.forEach((layout, sectionIndex) => {
       const override = Boolean(data.sections?.[sectionIndex]?.override_canonical);
-      addLandingSectionRow(row, layout, override);
+      addLandingSectionRow(row, layout, override, data.sections?.[sectionIndex]?.item_count);
     });
 
     reindexLandingRows();
@@ -1351,7 +1858,7 @@ declare global {
     return row;
   };
 
-  const addLandingSectionRow = (landingRow: HTMLElement, layout = '', override = false): void => {
+  const addLandingSectionRow = (landingRow: HTMLElement, layout = '', override = false, itemCount?: number): void => {
     const container = landingRow.querySelector<HTMLElement>('[data-wizard-landing-section-rows]');
     const template = getLandingSectionRowTemplate();
 
@@ -1372,6 +1879,7 @@ declare global {
 
     const select = sectionRow.querySelector<HTMLSelectElement>('[data-wizard-landing-section-layout]');
     const overrideInput = sectionRow.querySelector<HTMLInputElement>('[data-wizard-landing-section-override]');
+    const countInput = sectionRow.querySelector<HTMLInputElement>('[data-wizard-landing-section-item-count]');
     const options = readLandingSectionOptions();
 
     if (select) {
@@ -1399,6 +1907,10 @@ declare global {
 
     if (overrideInput) {
       overrideInput.checked = override;
+    }
+
+    if (countInput && typeof itemCount === 'number' && Number.isFinite(itemCount)) {
+      countInput.value = String(itemCount);
     }
 
     container.append(sectionRow);
@@ -1438,10 +1950,16 @@ declare global {
       .split(',')
       .map((value) => value.trim())
       .filter(Boolean);
-    const sections: LandingSectionPayload[] = Array.from(source.querySelectorAll<HTMLElement>('[data-wizard-landing-section-row]')).map((sectionRow) => ({
-      layout: sectionRow.querySelector<HTMLSelectElement>('[data-wizard-landing-section-layout]')?.value.trim() ?? '',
-      override_canonical: Boolean(sectionRow.querySelector<HTMLInputElement>('[data-wizard-landing-section-override]')?.checked),
-    })).filter((section) => section.layout);
+    const sections: LandingSectionPayload[] = Array.from(source.querySelectorAll<HTMLElement>('[data-wizard-landing-section-row]')).map((sectionRow) => {
+      const rawCount = sectionRow.querySelector<HTMLInputElement>('[data-wizard-landing-section-item-count]')?.value ?? '';
+      const parsedCount = Number.parseInt(rawCount, 10);
+
+      return {
+        layout: sectionRow.querySelector<HTMLSelectElement>('[data-wizard-landing-section-layout]')?.value.trim() ?? '',
+        override_canonical: Boolean(sectionRow.querySelector<HTMLInputElement>('[data-wizard-landing-section-override]')?.checked),
+        ...(Number.isFinite(parsedCount) ? { item_count: parsedCount } : {}),
+      };
+    }).filter((section) => section.layout);
 
     // Duplicate must clear id and mint a new landing_key.
     addLandingRow({
@@ -2060,6 +2578,23 @@ declare global {
     }
   };
 
+  /**
+   * Build a truthful per-step summary from the response result.
+   *
+   * For the dependencies step, renders a per-plugin status line from the
+   * authoritative installed/active flags and diagnostic `action` labels so
+   * the user sees which plugins failed and why. For other steps, returns a
+   * generic incomplete message. Only the final step status (checked by the
+   * caller) decides whether success copy is shown.
+   */
+  const stepResultSummary = (step: string, result: unknown): string => {
+    if (step === 'dependencies') {
+      return summarizeDependencyResult(result);
+    }
+
+    return `${labelFor(step)} did not complete. Check the result details and retry.`;
+  };
+
   const hydrateIaGenerationForm = (): void => {
     const form = root.querySelector<HTMLFormElement>('[data-wizard-ia-generation-form]');
     const aiConfig = state.ai_config;
@@ -2380,23 +2915,6 @@ declare global {
 
     target.hidden = false;
     target.textContent = JSON.stringify(result, null, 2);
-  };
-
-  /**
-   * Build a truthful per-step summary from the response result.
-   *
-   * For the dependencies step, renders a per-plugin status line from the
-   * authoritative installed/active flags and diagnostic `action` labels so
-   * the user sees which plugins failed and why. For other steps, returns a
-   * generic incomplete message. Only the final step status (checked by the
-   * caller) decides whether success copy is shown.
-   */
-  const stepResultSummary = (step: string, result: unknown): string => {
-    if (step === 'dependencies') {
-      return summarizeDependencyResult(result);
-    }
-
-    return `${labelFor(step)} did not complete. Check the result details and retry.`;
   };
 
   const labelFor = (step: string): string => steps.find((item) => item.slug === step)?.label ?? step;
@@ -2839,14 +3357,14 @@ declare global {
   runButtons.forEach((button) => {
     button.addEventListener('click', () => {
       const step = button.dataset.wizardRunStep;
-      if (step) void runStep(step);
+      if (step) void runStep(step, 'run');
     });
   });
 
   retryButtons.forEach((button) => {
     button.addEventListener('click', () => {
       const step = button.dataset.wizardRetryStep;
-      if (step) void runStep(step);
+      if (step) void runStep(step, 'retry');
     });
   });
 
@@ -2884,6 +3402,10 @@ declare global {
 
   refreshButton?.addEventListener('click', () => {
     void loadState({ replaceHomeSeo: true });
+  });
+
+  root.querySelector<HTMLButtonElement>('[data-wizard-landing-resume]')?.addEventListener('click', () => {
+    void resumeLandingRun();
   });
 
   completeButton?.addEventListener('click', () => {


### PR DESCRIPTION
Fixes #27

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Hydrates the persisted landing run plan into admin rows, progress text, and Resume.
- Routes Run/Retry to `landing_action=start` and Resume to `process` with `attempts=1`; skip-all stays skip-only.
- Keeps existing #22/#25/#26 wizard.ts wiring; no global mutation fence.

## Changes

| File | Change |
|------|--------|
| `src/ts/admin/landing-run-helpers.ts` | Production merge/resume/request-routing helpers. |
| `src/ts/admin/wizard.ts` | Hydration, progress UI, attempts=1 start/process routing. |
| `inc/wizard/wizard-init.php` | Progress markup, Resume button, section `item_count` field. |
| `scripts/test-landing-run-client.mjs` | Focused landing client harness. |

## Test Plan
- [x] `node scripts/test-landing-run-client.mjs` — 7/7 PASS.
- [x] `node tests/wizard-home-seo-targeting-client-harness.mjs` — 14/14 PASS.
- [x] `node tests/wizard-client-truth-harness.mjs` — 8/8 PASS (#22/#25 truth).
- [x] `php scripts/test-landing-run-orchestrator.php` — 109/0 PASS.
- [x] `npm run build` (`tsc && vite build`) passed.
- [x] Diff against `fix/landing-run-backend` contains only the #27 client slice.
- [x] Scripts run without errors: N/A — no shell scripts in this PR.

## size:exception

Review budget is **951 / 400**. Helper, wizard.ts hydration/routing, progress markup, and client harness must travel together to prove reload-safe resume.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts: N/A — no shell scripts
- [x] Skills tested in at least one agent: N/A — wizard client fix, not a skill change
- [x] Docs updated if behavior changed: N/A — UI hydration of the previous REST contract
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Chain Context

| Field | Value |
|-------|-------|
| Chain | wizard-setup beta issues #22–#29 |
| Tracker PR | Not needed — retained `feature/wizard-setup` @ `3205ee5` |
| Position | 10 of 11 |
| Base | `fix/landing-run-backend` |
| Depends on | PR #38 / #27 backend |
| Follow-up | Planned: global mutation fence / final integration |
| Review budget | 951 / 400 (`size:exception` — helper + hydration + harness) |
| Starts at | `fix/landing-run-backend` |
| Ends with | Admin hydration of resumable landing progress |

### Chain Overview

```text
feature/wizard-setup
 └── #30 docs/vite-manifest-checklist  (#24)
      └── #31 fix/acf-inactive-frontend-guard  (#23)
           └── #32 fix/footer-variant-runtime  (#28)
                └── #33 fix/palette-runtime-css  (#29)
                     └── #34 fix/wizard-dependency-truth  (#22)
                          └── #35 fix/wizard-credential-dom  (#25)
                               └── #36 feat/home-seo-backend  (#26 backend)
                                    └── #37 feat/home-seo-ui  (#26 UI)
                                         └── #38 fix/landing-run-backend  (#27 backend)
                                              └── 📍 fix/landing-run-client  (#27 client)
                                                   └── planned mutation fence
```

### Scope
- Includes: landing-run-helpers, wizard.ts hydration/routing, progress markup, client harness.
- Excludes: global Wizard_Mutation_Fence PHP/tests.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit
