### PR TITLE
feat(wizard): add internal page blueprint registry

### DIFF
--- a/inc/wizard/class-internal-page-blueprints.php
+++ b/inc/wizard/class-internal-page-blueprints.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Fixed internal page blueprint registry.
+ *
+ * @package Simple_RMS_Theme
+ */
+
+namespace Inc\Wizard;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Maps each internal page type to template, layouts, harness page type, and canonical policy.
+ */
+final class Internal_Page_Blueprints {
+	/**
+	 * Return the fixed blueprint map keyed by page type.
+	 *
+	 * PAGE_PROJECTS and PAGE_TESTIMONIALS are string identifiers until the harness
+	 * defines those constants. Existing types use AI_Content_Harness page-type constants.
+	 *
+	 * @return array<string,array{template:string,layouts:array<int,string>,page_type:string,canonical:string}>
+	 */
+	public static function all(): array {
+		return [
+			'about'         => [
+				'template'  => 'pages/about-us.php',
+				'layouts'   => [ 'about-us', 'vision-mission-v2' ],
+				'page_type' => AI_Content_Harness::PAGE_ABOUT,
+				'canonical' => 'copy',
+			],
+			'services'      => [
+				'template'  => 'pages/services.php',
+				'layouts'   => [ 'services-v1', 'cta-v2' ],
+				'page_type' => AI_Content_Harness::PAGE_SERVICE,
+				'canonical' => 'copy',
+			],
+			'contact'       => [
+				'template'  => 'pages/contact-us.php',
+				'layouts'   => [ 'contact-info' ],
+				'page_type' => AI_Content_Harness::PAGE_CONTACT,
+				'canonical' => 'copy',
+			],
+			'projects'      => [
+				'template'  => 'pages/projects.php',
+				'layouts'   => [ 'gallery-grid' ],
+				'page_type' => 'PAGE_PROJECTS',
+				'canonical' => 'copy',
+			],
+			'testimonials'  => [
+				'template'  => 'pages/testimonials.php',
+				'layouts'   => [ 'testimonials-v1' ],
+				'page_type' => 'PAGE_TESTIMONIALS',
+				'canonical' => 'copy',
+			],
+			'blog'          => [
+				'template'  => 'home.php',
+				'layouts'   => [ 'blog-v1' ],
+				'page_type' => AI_Content_Harness::PAGE_BLOG,
+				'canonical' => 'copy',
+			],
+		];
+	}
+}

--- a/inc/wizard/class-state-manager.php
+++ b/inc/wizard/class-state-manager.php
@@ -18,6 +18,21 @@ class State_Manager {
     public const COMPLETED_OPTION = 'rms_wizard_completed';
 
     /**
+     * Default per-page entry stored under state.internal_pages.
+     *
+     * Status is one of pending, complete, failed, or skipped.
+     *
+     * @var array{post_id:int,layouts:array<int,string>,status:string,reason:string,updated_at:string}
+     */
+    public const INTERNAL_PAGE_ENTRY = [
+        'post_id'    => 0,
+        'layouts'    => [],
+        'status'     => 'pending',
+        'reason'     => '',
+        'updated_at' => '',
+    ];
+
+    /**
      * Return the default state shape.
      *
      * @return array<string,mixed>
@@ -39,6 +54,7 @@ class State_Manager {
             'home_seo_targeting'     => [ 'enabled' => false ],
             'landing_pages'          => [],
             'landing_run'             => null,
+            'internal_pages'         => [],
             'canonical_sections'     => [],
             'logs'                   => self::LOG_OPTION,
             'locks'                  => [],


### PR DESCRIPTION
Closes #42

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds the fixed Internal Page blueprint registry for About, Services, Contact, Projects, Testimonials, and Blog.
- Adds a backward-compatible `internal_pages` state default and `INTERNAL_PAGE_ENTRY` shape.
- No step dispatch, REST wiring, or UI in this slice.

## Changes

| File | Change |
|------|--------|
| `inc/wizard/class-internal-page-blueprints.php` | New static `all()` map: template, layouts, `PAGE_*`, canonical policy. |
| `inc/wizard/class-state-manager.php` | `INTERNAL_PAGE_ENTRY` plus empty `internal_pages` default. |

## Test Plan
- [x] `php -l inc/wizard/class-internal-page-blueprints.php` — No syntax errors detected, exit 0, PHP 8.2.29.
- [x] `php -l inc/wizard/class-state-manager.php` — No syntax errors detected, exit 0, PHP 8.2.29.
- [x] Focused lint: **2/2 pass**.
- [x] `php tests/wizard-integration-truth-harness.php` — **8 scenarios pass**. Existing regression only; this slice has no new runtime boundary.
- [x] Diff against `feat/internal-page-builder` is exactly these two production files (**80 / 400**).
- [x] Scripts run without errors: N/A — no shell scripts in this PR.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts: N/A — no shell scripts
- [x] Skills tested in at least one agent: N/A — wizard domain feature, not a skill change
- [x] Docs updated if behavior changed: OpenSpec already versioned on the tracker
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Chain Context

| Field | Value |
|-------|-------|
| Chain | wizard-internal-page-builder |
| Tracker PR | `feat/internal-page-builder` → `main` |
| Position | 1 of 8 |
| Base | `feat/internal-page-builder` |
| Depends on | Tracker OpenSpec commit `6df7272` / issue #42 |
| Follow-up | PR2 `Section_Assembler` extraction |
| Review budget | 80 / 400 |
| Starts at | Tracker `feat/internal-page-builder` @ `6df7272` |
| Ends with | Six-type blueprint registry + `internal_pages` state shape |

### Chain Overview

```text
main
 └── feat/internal-page-builder  (draft tracker)
      └── 📍 PR1 feat/internal-page-blueprints
           └── PR2 Section_Assembler
                └── PR3 About backend
                     └── PR4 templates + shell
                          └── PR5 remaining backends + Testimonials
                               └── PR6 Blog chrome
                                    └── PR7 harness L2 + sync
                                         └── PR8 UI + activation
```

### Scope
- Includes: blueprint registry and `internal_pages` default only.
- Excludes: step class, assembler, templates, harness Layer 2, provenance store, admin UI, `REQUIRED_STEPS`, REST dispatch.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit

### Rollback
Delete `inc/wizard/class-internal-page-blueprints.php`. Revert `INTERNAL_PAGE_ENTRY` and the empty `'internal_pages' => []` default in `inc/wizard/class-state-manager.php`. Home/Landing keys stay untouched.
