### PR TITLE
refactor(wizard): delegate landing section assembly

### DIFF
--- a/inc/wizard/class-step-landing-page-builder.php
+++ b/inc/wizard/class-step-landing-page-builder.php
@@ -9,6 +9,8 @@ namespace Inc\Wizard;
 
 defined( 'ABSPATH' ) || exit;
 
+require_once __DIR__ . '/class-section-assembler.php';
+
 /**
  * Builds N SEO/Ads landing pages from canonical reusable sections + keyword copy.
  *
@@ -43,32 +45,34 @@ class Step_Landing_Page_Builder {
 	private $reviewer;
 	private $canonical_store;
 	private $menu_builder;
-	private $yoast_meta_writer;
-	private $run_orchestrator;
+		private $yoast_meta_writer;
+		private $run_orchestrator;
+		private $section_assembler;
 
-	public function __construct(
-		?Logger $logger = null,
-		?State_Manager $state_manager = null,
-		?Content_Builder $content_builder = null,
-		?Flexible_Content_Layouts $layout_repository = null,
-		?AI_Content_Harness $harness = null,
-		?AI_Content_Reviewer $reviewer = null,
-		?Canonical_Section_Store $canonical_store = null,
-		?Menu_Builder $menu_builder = null,
-		?Yoast_Meta_Writer $yoast_meta_writer = null,
-		?Landing_Run_Orchestrator $run_orchestrator = null
-	) {
-		$this->logger            = $logger ?? new Logger();
-		$this->state_manager     = $state_manager ?? new State_Manager();
-		$this->content_builder   = $content_builder ?? new Content_Builder( $this->logger, $this->state_manager );
-		$this->layout_repository = $layout_repository ?? new Flexible_Content_Layouts();
-		$this->harness           = $harness ?? new AI_Content_Harness();
-		$this->reviewer          = $reviewer;
-		$this->canonical_store   = $canonical_store ?? new Canonical_Section_Store();
-		$this->menu_builder      = $menu_builder ?? new Menu_Builder( $this->logger );
-		$this->yoast_meta_writer = $yoast_meta_writer ?? new Yoast_Meta_Writer( $this->logger );
-		$this->run_orchestrator  = $run_orchestrator ?? new Landing_Run_Orchestrator( $this->state_manager, $this->logger );
-	}
+		public function __construct(
+			?Logger $logger = null,
+			?State_Manager $state_manager = null,
+			?Content_Builder $content_builder = null,
+			?Flexible_Content_Layouts $layout_repository = null,
+			?AI_Content_Harness $harness = null,
+			?AI_Content_Reviewer $reviewer = null,
+			?Canonical_Section_Store $canonical_store = null,
+			?Menu_Builder $menu_builder = null,
+			?Yoast_Meta_Writer $yoast_meta_writer = null,
+			?Landing_Run_Orchestrator $run_orchestrator = null
+		) {
+			$this->logger            = $logger ?? new Logger();
+			$this->state_manager     = $state_manager ?? new State_Manager();
+			$this->content_builder   = $content_builder ?? new Content_Builder( $this->logger, $this->state_manager );
+			$this->layout_repository = $layout_repository ?? new Flexible_Content_Layouts();
+			$this->harness           = $harness ?? new AI_Content_Harness();
+			$this->reviewer          = $reviewer;
+			$this->canonical_store   = $canonical_store ?? new Canonical_Section_Store();
+			$this->menu_builder      = $menu_builder ?? new Menu_Builder( $this->logger );
+			$this->yoast_meta_writer = $yoast_meta_writer ?? new Yoast_Meta_Writer( $this->logger );
+			$this->run_orchestrator  = $run_orchestrator ?? new Landing_Run_Orchestrator( $this->state_manager, $this->logger );
+			$this->section_assembler = new Section_Assembler( $this->harness );
+		}
 
 	/**
 	 * Run the Landing page builder — orchestrated resumable execution.
@@ -2156,122 +2160,7 @@ class Step_Landing_Page_Builder {
 	}
 
 	private function section_data( string $section_key, array $client_data, array $copy, int $item_count ): array {
-		$section = array_merge( [ 'acf_fc_layout' => $section_key ], $this->placeholder_copy( $section_key, $client_data, $item_count ) );
-		$allowed = array_flip( $this->harness->get_fillable_fields( $section_key ) );
-
-		foreach ( $copy as $field => $value ) {
-			$field = (string) $field;
-
-			if ( false !== strpos( $field, '_services' ) ) {
-				continue;
-			}
-
-			if ( isset( $allowed[ $field ] ) ) {
-				$section[ $field ] = $this->section_value( $value );
-			}
-		}
-
-		$service_rows = $this->service_rows( $section_key, $client_data, $copy, $item_count );
-
-		if ( [] !== $service_rows ) {
-			$section[ $service_rows['field'] ] = $service_rows['rows'];
-		}
-
-		return $section;
-	}
-
-	private function placeholder_copy( string $section_key, array $client_data, int $item_count ): array {
-		if ( ! $this->harness->has_fillable_fields( $section_key ) ) {
-			return [];
-		}
-
-		$company        = $this->text( $client_data['company_name'] ?? \__( 'Your Company', 'simple-rms-theme' ) );
-		$text_repeaters = $this->harness->get_text_repeater_fields( $section_key );
-		$copy           = [];
-
-		foreach ( $this->harness->get_fillable_fields( $section_key ) as $field ) {
-			if ( false !== strpos( $field, '_services' ) || isset( $text_repeaters[ $field ] ) ) {
-				continue;
-			}
-
-			$copy[ $field ] = $this->placeholder_field_value( $field, $company );
-		}
-
-		foreach ( $text_repeaters as $field => $sub_fields ) {
-			$copy[ $field ] = $this->placeholder_repeater_rows( $sub_fields, $company, $item_count );
-		}
-
-		return $copy;
-	}
-
-	private function placeholder_repeater_rows( array $sub_fields, string $company, int $item_count ): array {
-		$rows  = [];
-		$count = max( 1, min( 12, $item_count ) );
-
-		for ( $index = 0; $index < $count; $index++ ) {
-			$row = [];
-
-			foreach ( $sub_fields as $sub_field ) {
-				$row[ (string) $sub_field ] = $this->placeholder_field_value( (string) $sub_field, $company );
-			}
-
-			if ( [] !== $row ) {
-				$rows[] = $row;
-			}
-		}
-
-		return $rows;
-	}
-
-	private function placeholder_field_value( string $field, string $company ): string {
-		if ( false !== strpos( $field, 'headline' ) || false !== strpos( $field, 'title' ) || false !== strpos( $field, 'question' ) ) {
-			return sprintf( /* translators: %s: company name. */ \__( '%s Services You Can Trust', 'simple-rms-theme' ), $company );
-		}
-
-		if ( false !== strpos( $field, 'subheadline' ) || false !== strpos( $field, 'eyebrow' ) || false !== strpos( $field, 'label' ) ) {
-			return \__( 'Dependable service and clear communication', 'simple-rms-theme' );
-		}
-
-		if ( false !== strpos( $field, 'cta' ) || false !== strpos( $field, 'button' ) ) {
-			return \__( 'Get an Estimate', 'simple-rms-theme' );
-		}
-
-		return sprintf( /* translators: %s: company name. */ \__( '%s provides reliable service with careful attention to each project.', 'simple-rms-theme' ), $company );
-	}
-
-	/**
-	 * @return array{field:string,rows:array<int,array<string,string>>}|array{}
-	 */
-	private function service_rows( string $section_key, array $client_data, array $copy, int $item_count ): array {
-		$contracts = [
-			'services-v1' => [ 'field' => 'services_v1_services', 'name' => 'service_title', 'description' => 'service_text' ],
-			'services-v2' => [ 'field' => 'services_v2_services', 'name' => 'service_title', 'description' => 'service_text' ],
-			'services-v3' => [ 'field' => 'services_v3_services', 'name' => 'service_name', 'description' => 'service_overlay_text' ],
-		];
-
-		if ( ! isset( $contracts[ $section_key ] ) ) {
-			return [];
-		}
-
-		$contract = $contracts[ $section_key ];
-		$ai_rows  = is_array( $copy[ $contract['field'] ] ?? null ) ? array_values( $copy[ $contract['field'] ] ) : [];
-		$rows     = [];
-
-		foreach ( array_slice( is_array( $client_data['company_services'] ?? null ) ? $client_data['company_services'] : [], 0, $item_count ) as $index => $service ) {
-			if ( ! is_array( $service ) || empty( $service['service_name'] ) ) {
-				continue;
-			}
-
-			$ai_row      = is_array( $ai_rows[ $index ] ?? null ) ? $ai_rows[ $index ] : [];
-			$description = $ai_row[ $contract['description'] ] ?? $service['service_short_description'] ?? '';
-
-			$rows[] = [
-				$contract['name']        => $this->text( $service['service_name'] ),
-				$contract['description'] => $this->html( $description ),
-			];
-		}
-
-		return [ 'field' => $contract['field'], 'rows' => $rows ];
+		return $this->section_assembler->section_data( $section_key, $client_data, $copy, $item_count );
 	}
 
 	private function item_count( string $section_key, int $requested ): int {
@@ -2430,22 +2319,6 @@ class Step_Landing_Page_Builder {
 		}
 
 		return (bool) $value;
-	}
-
-	private function section_value( $value ) {
-		if ( is_array( $value ) ) {
-			return array_map( [ $this, 'section_value' ], $value );
-		}
-
-		return $this->html( $value );
-	}
-
-	private function text( $value ): string {
-		return \sanitize_text_field( (string) $value );
-	}
-
-	private function html( $value ): string {
-		return \wp_kses_post( (string) $value );
 	}
 
 	private function truthy( $value ): bool {

--- a/scripts/test-landing-run-orchestrator.php
+++ b/scripts/test-landing-run-orchestrator.php
@@ -555,6 +555,7 @@ namespace {
 	require_once __DIR__ . '/../inc/wizard/class-yoast-meta-writer.php';
 	require_once __DIR__ . '/../inc/wizard/class-menu-builder.php';
 	require_once __DIR__ . '/../inc/wizard/class-content-builder.php';
+	require_once __DIR__ . '/../inc/wizard/class-section-assembler.php';
 
 	// Stubs for AI/provider classes that are needed but not included.
 	if ( ! class_exists( 'Inc\Wizard\AI_Provider_Registry' ) ) {


### PR DESCRIPTION
Closes #42

## PR Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [x] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Delegates Landing builder `section_data` assembly to the shared `Section_Assembler`.
- Adds the one harness loader require so orchestrator tests still construct the assembler.
- No public behavior change. Does not start later Internal Page Builder phases.

## Changes

| File | Change |
|------|--------|
| `inc/wizard/class-step-landing-page-builder.php` | Landing assembly methods replaced by assembler delegation. |
| `scripts/test-landing-run-orchestrator.php` | One require line so the harness can load `Section_Assembler`. |

## Test Plan
- [x] `php -l inc/wizard/class-step-landing-page-builder.php` — No syntax errors detected, exit 0, PHP 8.2.29.
- [x] `php -l scripts/test-landing-run-orchestrator.php` — No syntax errors detected, exit 0, PHP 8.2.29.
- [x] Landing-vs-assembler `section_data` equivalence **10/10 PASS**.
- [x] `php scripts/test-landing-run-orchestrator.php` — **293 passed, 0 failed**, exit 0.
- [x] `php tests/wizard-integration-truth-harness.php` — **8 scenarios pass**, exit 0.
- [x] Diff against PR2B is Landing + one harness loader (**190 / 400**).
- [x] Scripts run without errors: N/A — no shell scripts in this PR.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts: N/A — no shell scripts
- [x] Skills tested in at least one agent: N/A — wizard domain refactor, not a skill change
- [x] Docs updated if behavior changed: OpenSpec progress is on the tracker; no public behavior change
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Chain Context

| Field | Value |
|-------|-------|
| Chain | wizard-internal-page-builder |
| Tracker PR | #43 `feat/internal-page-builder` (draft, no-merge) |
| Position | 2C of 8 (Landing section-assembler delegation) |
| Base | `refactor/home-section-assembler` |
| Depends on | PR2B #46 |
| Follow-up | PR3 About backend (not in this publication) |
| Review budget | 190 / 400 |
| Starts at | PR2B `refactor/home-section-assembler` @ `4c58330` |
| Ends with | Landing builder delegates section assembly; harness loads assembler |

### Chain Overview

```text
main
 └── #43 feat/internal-page-builder  (draft tracker, no-merge)
      └── #44 PR1 feat/internal-page-blueprints  (merged)
           └── #45 PR2A refactor/wizard-section-assembler-core
                └── #46 PR2B refactor/home-section-assembler
                     └── 📍 PR2C refactor/landing-section-assembler
                          └── PR3+ later Internal Builder phases (out of scope)
```

### Scope
- Includes: Landing builder delegation and one orchestrator harness loader line.
- Excludes: internal-page backends, templates, harness Layer 2, provenance, admin UI, later Internal Builder phases.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit

### Rollback
Revert Landing builder delegation in `inc/wizard/class-step-landing-page-builder.php` and the one require line in `scripts/test-landing-run-orchestrator.php`. Leave Home and the assembler file untouched.
