### PR TITLE
feat(wizard): track internal page placeholder provenance

### DIFF
--- a/inc/wizard/class-placeholder-provenance-store.php
+++ b/inc/wizard/class-placeholder-provenance-store.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Placeholder provenance store for wizard-built internal pages.
+ *
+ * @package Simple_RMS_Theme
+ */
+
+namespace Inc\Wizard;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Records unmarked placeholder fields so owners can find and replace them.
+ *
+ * Backed by a non-autoloaded option. sync() is intentionally not implemented here.
+ */
+final class Placeholder_Provenance_Store {
+	public const OPTION_KEY = 'rms_wizard_placeholder_provenance';
+
+	/**
+	 * @var array<int,array<string,array<string,mixed>>>|null
+	 */
+	private $entries = null;
+
+	/**
+	 * Persist one placeholder field on a page.
+	 *
+	 * @param array<string,mixed> $value Field value used to compute value_hash.
+	 */
+	public function record( int $post_id, string $layout, int $row, string $field, string $reason, $value ): bool {
+		$post_id = \absint( $post_id );
+		$layout  = \sanitize_key( $layout );
+		$field   = \sanitize_key( $field );
+		$reason  = \sanitize_key( $reason );
+		$row     = max( 0, $row );
+
+		if ( $post_id <= 0 || '' === $layout || '' === $field ) {
+			return false;
+		}
+
+		$key = $row . ':' . $field;
+		$this->ensure_loaded();
+
+		$entries = is_array( $this->entries ) ? $this->entries : [];
+		$page    = is_array( $entries[ $post_id ] ?? null ) ? $entries[ $post_id ] : [];
+
+		$page[ $key ] = [
+			'layout'     => $layout,
+			'row'        => $row,
+			'field'      => $field,
+			'reason'     => '' !== $reason ? $reason : 'missing_client_fact',
+			'value_hash' => sha1( (string) \wp_json_encode( $value ) ),
+			'written_at' => \current_time( 'mysql', true ),
+		];
+
+		$entries[ $post_id ] = $page;
+
+		return $this->persist( $entries );
+	}
+
+	/**
+	 * Return provenance entries for a page, optionally one field key.
+	 *
+	 * @return array<string,array<string,mixed>>
+	 */
+	public function query( int $post_id, string $field = '' ): array {
+		$post_id = \absint( $post_id );
+		$this->ensure_loaded();
+		$page = is_array( ( $this->entries[ $post_id ] ?? null ) ) ? $this->entries[ $post_id ] : [];
+
+		if ( '' === $field ) {
+			return $page;
+		}
+
+		$field   = \sanitize_key( $field );
+		$matches = [];
+
+		foreach ( $page as $key => $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			if ( $field === (string) ( $entry['field'] ?? '' ) ) {
+				$matches[ $key ] = $entry;
+			}
+		}
+
+		return $matches;
+	}
+
+	/**
+	 * Outstanding placeholders across all pages.
+	 *
+	 * @return array<int,array{post_id:int,key:string,layout:string,row:int,field:string,reason:string}>
+	 */
+	public function queue(): array {
+		$this->ensure_loaded();
+		$queue = [];
+
+		foreach ( is_array( $this->entries ) ? $this->entries : [] as $post_id => $page ) {
+			if ( ! is_array( $page ) ) {
+				continue;
+			}
+
+			foreach ( $page as $key => $entry ) {
+				if ( ! is_array( $entry ) ) {
+					continue;
+				}
+
+				$queue[] = [
+					'post_id' => (int) $post_id,
+					'key'     => (string) $key,
+					'layout'  => (string) ( $entry['layout'] ?? '' ),
+					'row'     => (int) ( $entry['row'] ?? 0 ),
+					'field'   => (string) ( $entry['field'] ?? '' ),
+					'reason'  => (string) ( $entry['reason'] ?? '' ),
+				];
+			}
+		}
+
+		return $queue;
+	}
+
+	private function ensure_loaded(): void {
+		if ( null !== $this->entries ) {
+			return;
+		}
+
+		$stored = \get_option( self::OPTION_KEY, [] );
+		$this->entries = is_array( $stored ) ? $stored : [];
+	}
+
+	/**
+	 * @param array<int,array<string,array<string,mixed>>> $entries
+	 */
+	private function persist( array $entries ): bool {
+		$saved = \update_option( self::OPTION_KEY, $entries, false );
+
+		if ( $saved ) {
+			$this->entries = $entries;
+
+			return true;
+		}
+
+		$stored = \get_option( self::OPTION_KEY, [] );
+
+		if ( is_array( $stored ) && $stored === $entries ) {
+			$this->entries = $entries;
+
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/tests/wizard-placeholder-provenance-harness.php
+++ b/tests/wizard-placeholder-provenance-harness.php
@@ -15,7 +15,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', $theme_root . '/' );
 }
 
-$GLOBALS['_options'] = array();
+$GLOBALS['_options']          = array();
+$GLOBALS['_option_autoloads'] = array();
 
 if ( ! function_exists( 'sanitize_key' ) ) {
 	function sanitize_key( $key ) {
@@ -45,8 +46,8 @@ if ( ! function_exists( 'get_option' ) ) {
 }
 if ( ! function_exists( 'update_option' ) ) {
 	function update_option( $name, $value, $autoload = null ) {
-		unset( $autoload );
-		$GLOBALS['_options'][ $name ] = $value;
+		$GLOBALS['_options'][ $name ]          = $value;
+		$GLOBALS['_option_autoloads'][ $name ] = $autoload;
 		return true;
 	}
 }
@@ -89,6 +90,11 @@ $ids = array_values( array_unique( array_map( static function ( $row ) { return 
 sort( $ids );
 rms_prov_assert( array( 21, 22 ) === $ids, 'queue names both pages' );
 echo "PASS provenance-queue\n";
+++$passed;
+
+$autoload = $GLOBALS['_option_autoloads'][ Placeholder_Provenance_Store::OPTION_KEY ] ?? null;
+rms_prov_assert( false === $autoload, 'provenance option must be written with autoload=false' );
+echo "PASS provenance-option-autoload-false\n";
 ++$passed;
 
 echo 'Harness passed: ' . $passed . " scenarios.\n";

--- a/tests/wizard-placeholder-provenance-harness.php
+++ b/tests/wizard-placeholder-provenance-harness.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Provenance store record/query/queue proofs.
+ *
+ * Usage: php tests/wizard-placeholder-provenance-harness.php
+ */
+
+if ( PHP_SAPI !== 'cli' ) {
+	fwrite( STDERR, "CLI only.\n" );
+	exit( 1 );
+}
+
+$theme_root = dirname( __DIR__ );
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', $theme_root . '/' );
+}
+
+$GLOBALS['_options'] = array();
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) {
+		return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) ) );
+	}
+}
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $value ) {
+		return abs( (int) $value );
+	}
+}
+if ( ! function_exists( 'current_time' ) ) {
+	function current_time( $type, $gmt = false ) {
+		unset( $type, $gmt );
+		return '2026-08-26 00:00:00';
+	}
+}
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $options = 0 ) {
+		return json_encode( $data, $options );
+	}
+}
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $name, $default = false ) {
+		return $GLOBALS['_options'][ $name ] ?? $default;
+	}
+}
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( $name, $value, $autoload = null ) {
+		unset( $autoload );
+		$GLOBALS['_options'][ $name ] = $value;
+		return true;
+	}
+}
+
+require_once $theme_root . '/inc/wizard/class-placeholder-provenance-store.php';
+
+use Inc\Wizard\Placeholder_Provenance_Store;
+
+function rms_prov_assert( $condition, string $message ): void {
+	if ( ! $condition ) {
+		fwrite( STDERR, $message . "\n" );
+		exit( 1 );
+	}
+}
+
+$passed = 0;
+$store  = new Placeholder_Provenance_Store();
+
+rms_prov_assert( false === $store->record( 0, 'about-us', 0, 'about_headline', 'missing_client_fact', 'x' ), 'invalid post_id rejected' );
+rms_prov_assert( $store->record( 21, 'about-us', 0, 'about_headline', 'missing_client_fact', 'Hello' ), 'record page 21' );
+rms_prov_assert( $store->record( 21, 'about-us', 0, 'about_text', 'missing_client_fact', 'Body' ), 'second field same page' );
+rms_prov_assert( $store->record( 22, 'contact-info', 1, 'contact_headline', 'missing_client_fact', 'Hi' ), 'record page 22' );
+echo "PASS provenance-record\n";
+++$passed;
+
+$page21 = $store->query( 21 );
+rms_prov_assert( 2 === count( $page21 ) && isset( $page21['0:about_headline'] ), 'query returns page 21 fields' );
+rms_prov_assert( 'about-us' === ( $page21['0:about_headline']['layout'] ?? '' ), 'layout stored' );
+rms_prov_assert( 'missing_client_fact' === ( $page21['0:about_headline']['reason'] ?? '' ), 'reason stored' );
+$headline = $store->query( 21, 'about_headline' );
+rms_prov_assert( 1 === count( $headline ) && isset( $headline['0:about_headline'] ), 'query by field' );
+$page22 = $store->query( 22 );
+rms_prov_assert( 1 === count( $page22 ) && ! isset( $page22['0:about_headline'] ), 'query is page-scoped' );
+echo "PASS provenance-query-by-page\n";
+++$passed;
+
+$queue = $store->queue();
+rms_prov_assert( 3 === count( $queue ), 'queue lists all outstanding fields' );
+$ids = array_values( array_unique( array_map( static function ( $row ) { return (int) $row['post_id']; }, $queue ) ) );
+sort( $ids );
+rms_prov_assert( array( 21, 22 ) === $ids, 'queue names both pages' );
+echo "PASS provenance-queue\n";
+++$passed;
+
+echo 'Harness passed: ' . $passed . " scenarios.\n";


### PR DESCRIPTION
Closes #42

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds a dedicated non-autoloaded placeholder provenance store (`record` / `query` / `queue`) for wizard-built internal pages.
- Records unmarked placeholder fields so owners can find and replace them later. `sync()` is intentionally not implemented here.
- Proves `update_option(..., false)` so the option is not autoloaded.

## Changes

| File | Change |
|------|--------|
| `inc/wizard/class-placeholder-provenance-store.php` | New store: persist/query/queue unmarked placeholder fields on a non-autoloaded option. |
| `tests/wizard-placeholder-provenance-harness.php` | 4-scenario harness: record, query-by-page, queue, and autoload=false. |

## Test Plan
- [x] `php -l inc/wizard/class-placeholder-provenance-store.php` — No syntax errors detected, exit 0, PHP 8.2.29.
- [x] `php -l tests/wizard-placeholder-provenance-harness.php` — No syntax errors detected, exit 0, PHP 8.2.29.
- [x] Focused lint: **2/2 pass**.
- [x] `php tests/wizard-placeholder-provenance-harness.php` — **4/4 pass**: `provenance-record`, `provenance-query-by-page`, `provenance-queue`, `provenance-option-autoload-false`.
- [x] Three-dot diff against `feat/internal-page-builder` is exactly these two files (**255 / 400**). Tracker-only OpenSpec docs do not appear.
- [x] Scripts run without errors: N/A — no shell scripts in this PR.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts: N/A — no shell scripts
- [x] Skills tested in at least one agent: N/A — wizard domain feature, not a skill change
- [x] Docs updated if behavior changed: OpenSpec progress is on tracker #43; no public UI change
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Chain Context

| Field | Value |
|-------|-------|
| Chain | wizard-internal-page-builder |
| Tracker PR | #43 `feat/internal-page-builder` (draft, no-merge) |
| Position | 3A of 8 (placeholder provenance) |
| Base | `feat/internal-page-builder` |
| Depends on | Tracker #43 / merged PR1 #44 / merged PR2A–PR2C #45–#47 / approved issue #42 |
| Follow-up | PR3B #49 `feat/internal-page-about-core` (About core builder) |
| Review budget | 255 / 400 |
| Starts at | Tracker ancestor `feat/internal-page-builder` @ `4b8b717` |
| Ends with | Provenance store + 4-scenario harness, including autoload=false proof |

### Chain Overview

```text
main
 └── #43 feat/internal-page-builder  (draft tracker, no-merge)
      └── #44 PR1 feat/internal-page-blueprints  (merged)
           └── #45–#47 PR2A–PR2C section assembler  (merged)
                └── 📍 #48 PR3A feat/internal-page-placeholder-provenance
                     └── #49 PR3B feat/internal-page-about-core
                          └── #50 PR3C feat/internal-page-about-recovery
                               └── PR4+ later Internal Builder phases (out of scope)
```

### Scope
- Includes: provenance store `record`/`query`/`queue` and the 4-scenario harness.
- Excludes: controller/dispatch/UI, templates, Blog, later internal pages, visible placeholder labels, hiding, completion blocking, `sync()`, About builder, conversion/retry, later phases.
- Placeholders stay unmarked in this slice. Nothing is hidden and completion is not blocked.
- Tracker #43 remains draft/no-merge.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit

### Rollback
Revert or delete `inc/wizard/class-placeholder-provenance-store.php` and `tests/wizard-placeholder-provenance-harness.php`. No other production files change in this slice.
