### PR TITLE
feat(wizard): build About page sections

### DIFF
--- a/inc/wizard/class-step-internal-page-builder.php
+++ b/inc/wizard/class-step-internal-page-builder.php
@@ -1,0 +1,307 @@
+<?php
+/**
+ * Wizard internal page builder — About core slice.
+ *
+ * @package Simple_RMS_Theme
+ */
+
+namespace Inc\Wizard;
+
+defined( 'ABSPATH' ) || exit;
+
+require_once __DIR__ . '/class-section-assembler.php';
+require_once __DIR__ . '/class-placeholder-provenance-store.php';
+
+/** About-only start/process under execute_step. Does not acquire the fence. */
+class Step_Internal_Page_Builder {
+	private const STEP        = 'internal-page-builder';
+	private const SCOPE_TYPE  = 'about';
+	private const SCOPE_SLUGS = [ 'about', 'about-us' ];
+	private $logger;
+	private $state_manager;
+	private $content_builder;
+	private $harness;
+	private $canonical_store;
+	private $section_assembler;
+	private $provenance;
+
+	public function __construct(
+		?Logger $logger = null,
+		?State_Manager $state_manager = null,
+		?Content_Builder $content_builder = null,
+		?AI_Content_Harness $harness = null,
+		?Canonical_Section_Store $canonical_store = null,
+		?Section_Assembler $section_assembler = null,
+		?Placeholder_Provenance_Store $provenance = null
+	) {
+		$this->logger            = $logger ?? new Logger();
+		$this->state_manager     = $state_manager ?? new State_Manager();
+		$this->content_builder   = $content_builder ?? new Content_Builder( $this->logger, $this->state_manager );
+		$this->harness           = $harness ?? new AI_Content_Harness();
+		$this->canonical_store   = $canonical_store ?? new Canonical_Section_Store();
+		$this->section_assembler = $section_assembler ?? new Section_Assembler( $this->harness );
+		$this->provenance        = $provenance ?? new Placeholder_Provenance_Store();
+	}
+
+	/** @param array<string,mixed> $payload @return array<string,mixed>|\WP_Error */
+	public function run( array $payload ) {
+		if ( $this->truthy( $payload['skip_all'] ?? false ) ) {
+			return $this->run_skip_all();
+		}
+
+		$action = \sanitize_key( (string) ( $payload['action'] ?? '' ) );
+
+		if ( 'start' === $action ) {
+			return $this->start();
+		}
+
+		if ( 'process' === $action ) {
+			return $this->process();
+		}
+
+		return new \WP_Error(
+			'rms_wizard_internal_action_required',
+			\__( 'An action (start or process) is required.', 'simple-rms-theme' ),
+			[ 'status' => 400 ]
+		);
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private function run_skip_all(): array {
+		$fresh = $this->state_manager->get_state();
+		$plan  = is_array( $fresh['internal_pages'] ?? null ) ? $fresh['internal_pages'] : [];
+
+		foreach ( $plan as $type => $entry ) {
+			if ( ! is_array( $entry ) || in_array( (string) ( $entry['status'] ?? '' ), [ 'complete', 'skipped' ], true ) ) {
+				continue;
+			}
+			$entry['status']     = 'skipped';
+			$entry['reason']     = 'skip_all';
+			$entry['updated_at'] = \current_time( 'mysql', true );
+			$plan[ $type ]       = $entry;
+		}
+
+		$fresh['internal_pages'] = $plan;
+		$this->state_manager->save_state( $fresh );
+		$this->state_manager->set_step_status( self::STEP, 'complete' );
+
+		return [ 'skipped' => true, 'internal_pages' => $plan, 'canonical_wrote' => false ];
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private function start(): array {
+		$fresh = $this->state_manager->get_state();
+		$plan  = $this->ensure_about_plan( $fresh );
+		$fresh['internal_pages'] = $plan;
+		$this->state_manager->save_state( $fresh );
+		$pending = $this->is_pending( $plan );
+		$this->state_manager->set_step_status( self::STEP, $pending ? 'running' : 'complete' );
+
+		return [ 'internal_pages' => $plan, 'status' => $pending ? 'running' : 'complete' ];
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private function process(): array {
+		$fresh = $this->state_manager->get_state();
+		$plan  = $this->ensure_about_plan( $fresh );
+		$entry = is_array( $plan[ self::SCOPE_TYPE ] ?? null ) ? $plan[ self::SCOPE_TYPE ] : null;
+
+		if ( null === $entry ) {
+			$fresh['internal_pages'] = $plan;
+			$this->state_manager->save_state( $fresh );
+			$this->state_manager->set_step_status( self::STEP, 'complete' );
+
+			return [ 'internal_pages' => $plan, 'status' => 'complete', 'unavailable' => true ];
+		}
+
+		$entry                    = $this->process_about( $entry );
+		$plan[ self::SCOPE_TYPE ] = $entry;
+		$fresh                    = $this->state_manager->get_state();
+		$fresh['internal_pages']  = $plan;
+		$this->state_manager->save_state( $fresh );
+		$pending = $this->is_pending( $plan );
+		$done    = in_array( (string) ( $entry['status'] ?? '' ), [ 'complete', 'skipped' ], true ) && ! $pending;
+		$this->state_manager->set_step_status( self::STEP, $done ? 'complete' : ( $pending ? 'running' : 'pending' ) );
+
+		return [
+			'internal_pages' => $plan,
+			'processed'      => self::SCOPE_TYPE,
+			'status'         => (string) ( $entry['status'] ?? '' ),
+			'reason'         => (string) ( $entry['reason'] ?? '' ),
+		];
+	}
+
+	/**
+	 * @param array<string,mixed> $state
+	 * @return array<string,array<string,mixed>>
+	 */
+	private function ensure_about_plan( array $state ): array {
+		$plan  = is_array( $state['internal_pages'] ?? null ) ? $state['internal_pages'] : [];
+		$shell = $this->find_about_shell( is_array( $state['generated_pages'] ?? null ) ? $state['generated_pages'] : [] );
+		$entry = is_array( $plan[ self::SCOPE_TYPE ] ?? null )
+			? array_merge( State_Manager::INTERNAL_PAGE_ENTRY, $plan[ self::SCOPE_TYPE ] )
+			: State_Manager::INTERNAL_PAGE_ENTRY;
+
+		if ( null === $shell ) {
+			$entry['post_id']         = 0;
+			$entry['status']          = 'skipped';
+			$entry['reason']          = 'unavailable';
+			$entry['updated_at']      = \current_time( 'mysql', true );
+			$plan[ self::SCOPE_TYPE ] = $entry;
+
+			return $plan;
+		}
+
+		$entry['post_id'] = (int) $shell['id'];
+		if ( '' === (string) ( $entry['status'] ?? '' ) ) {
+			$entry['status'] = 'pending';
+		}
+		$plan[ self::SCOPE_TYPE ] = $entry;
+
+		return $plan;
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $generated_pages
+	 * @return array{id:int,slug:string}|null
+	 */
+	private function find_about_shell( array $generated_pages ) {
+		foreach ( $generated_pages as $page ) {
+			if ( ! is_array( $page ) ) {
+				continue;
+			}
+			$slug = \sanitize_title( (string) ( $page['slug'] ?? '' ) );
+			$type = \sanitize_key( (string) ( $page['type'] ?? '' ) );
+			if ( self::SCOPE_TYPE !== $type && ! in_array( $slug, self::SCOPE_SLUGS, true ) ) {
+				continue;
+			}
+			$id = \absint( $page['id'] ?? 0 );
+			if ( $id <= 0 ) {
+				continue;
+			}
+			$post = \get_post( $id );
+			if ( $post && 'page' === $post->post_type ) {
+				return [ 'id' => $id, 'slug' => $slug ];
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param array<string,mixed> $entry
+	 * @return array<string,mixed>
+	 */
+	private function process_about( array $entry ): array {
+		$post_id = \absint( $entry['post_id'] ?? 0 );
+		$now     = \current_time( 'mysql', true );
+
+		if ( $post_id <= 0 ) {
+			$entry['status']     = 'skipped';
+			$entry['reason']     = 'unavailable';
+			$entry['updated_at'] = $now;
+
+			return $entry;
+		}
+
+		if ( 'complete' === (string) ( $entry['status'] ?? '' ) ) {
+			$entry['reason']     = 'unchanged';
+			$entry['updated_at'] = $now;
+
+			return $entry;
+		}
+
+		if ( [] !== $this->current_sections( $post_id ) ) {
+			$entry['status']     = 'complete';
+			$entry['reason']     = 'preserved';
+			$entry['updated_at'] = $now;
+
+			return $entry;
+		}
+
+		$blueprint = Internal_Page_Blueprints::all()[ self::SCOPE_TYPE ];
+		$built     = $this->assemble_about_rows( $blueprint, $post_id );
+		$saved     = $this->content_builder->build_page(
+			[
+				'id'           => $post_id,
+				'section_only' => true,
+				'sections'     => $built['rows'],
+				'meta_input'   => [ '_wp_page_template' => (string) $blueprint['template'] ],
+			]
+		);
+
+		if ( $saved <= 0 ) {
+			return $entry;
+		}
+
+		$entry['status']     = 'complete';
+		$entry['reason']     = '';
+		$entry['layouts']    = $built['layouts'];
+		$entry['post_id']    = $post_id;
+		$entry['updated_at'] = $now;
+
+		return $entry;
+	}
+
+	/**
+	 * @param array{template:string,layouts:array<int,string>,page_type:string,canonical:string} $blueprint
+	 * @return array{rows:array<int,array<string,mixed>>,layouts:array<int,string>}
+	 */
+	private function assemble_about_rows( array $blueprint, int $post_id ): array {
+		$client  = is_array( $this->state_manager->get_state()['client_data'] ?? null ) ? $this->state_manager->get_state()['client_data'] : [];
+		$rows    = [];
+		$layouts = [];
+
+		foreach ( is_array( $blueprint['layouts'] ?? null ) ? $blueprint['layouts'] : [] as $index => $layout ) {
+			$layout = \sanitize_key( (string) $layout );
+			if ( '' === $layout ) {
+				continue;
+			}
+			$layouts[] = $layout;
+			if ( 'copy' === (string) ( $blueprint['canonical'] ?? '' ) && $this->canonical_store->has( $layout ) ) {
+				$payload = $this->canonical_store->get( $layout );
+				if ( [] !== $payload ) {
+					$payload['acf_fc_layout'] = $layout;
+					$rows[]                   = $this->content_builder->prepare_image_fallbacks( $payload );
+					continue;
+				}
+			}
+			$count  = $this->harness->has_fillable_fields( $layout ) ? ( 'vision-mission-v2' === $layout ? 3 : 1 ) : 0;
+			$row    = $this->content_builder->prepare_image_fallbacks( $this->section_assembler->section_data( $layout, $client, [], $count ) );
+			$rows[] = $row;
+			foreach ( $this->harness->get_fillable_fields( $layout ) as $field ) {
+				if ( isset( $row[ $field ] ) ) {
+					$this->provenance->record( $post_id, $layout, (int) $index, (string) $field, 'missing_client_fact', $row[ $field ] );
+				}
+			}
+		}
+
+		return [ 'rows' => $rows, 'layouts' => $layouts ];
+	}
+
+	/**
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function current_sections( int $post_id ): array {
+		$rows = function_exists( 'get_field' ) ? \get_field( 'page_sections', $post_id ) : \get_post_meta( $post_id, 'page_sections', true );
+
+		return is_array( $rows ) ? $rows : [];
+	}
+
+	/**
+	 * @param array<string,array<string,mixed>> $plan
+	 */
+	private function is_pending( array $plan ): bool {
+		return 'pending' === (string) ( ( is_array( $plan[ self::SCOPE_TYPE ] ?? null ) ? $plan[ self::SCOPE_TYPE ] : [] )['status'] ?? '' );
+	}
+
+	private function truthy( $value ): bool {
+		return true === $value || 1 === $value || '1' === $value || 'true' === $value || 'yes' === $value || 'on' === $value;
+	}
+}

--- a/tests/wizard-internal-page-builder-harness.php
+++ b/tests/wizard-internal-page-builder-harness.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * About core builder proofs.
+ * Usage: php tests/wizard-internal-page-builder-harness.php
+ */
+if ( PHP_SAPI !== 'cli' ) { fwrite( STDERR, "CLI only.\n" ); exit( 1 ); }
+$theme_root = dirname( __DIR__ );
+if ( ! defined( 'ABSPATH' ) ) { define( 'ABSPATH', $theme_root . '/' ); }
+if ( ! class_exists( 'WP_Error', false ) ) {
+	class WP_Error { public $code; public $message; public $data; public function __construct( $c = '', $m = '', $d = '' ) { $this->code = $c; $this->message = $m; $this->data = $d; } }
+}
+if ( ! class_exists( 'WP_Post', false ) ) {
+	class WP_Post { public $ID; public $post_type = 'page'; public $post_content = ''; public function __construct( $id = 0 ) { $this->ID = (int) $id; } }
+}
+$GLOBALS['_options'] = $GLOBALS['_posts'] = $GLOBALS['_post_meta'] = $GLOBALS['_build_log'] = array();
+if ( ! function_exists( 'sanitize_text_field' ) ) { function sanitize_text_field( $s ) { return trim( preg_replace( '/\s+/', ' ', (string) $s ) ); } }
+if ( ! function_exists( 'sanitize_key' ) ) { function sanitize_key( $k ) { return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $k ) ) ); } }
+if ( ! function_exists( 'sanitize_title' ) ) { function sanitize_title( $v ) { return strtolower( preg_replace( '/[^a-z0-9-]+/', '-', (string) $v ) ); } }
+if ( ! function_exists( '__' ) ) { function __( $t, $d = null ) { unset( $d ); return $t; } }
+if ( ! function_exists( 'wp_kses_post' ) ) { function wp_kses_post( $v ) { return (string) $v; } }
+if ( ! function_exists( 'wp_json_encode' ) ) { function wp_json_encode( $d, $o = 0 ) { return json_encode( $d, $o ); } }
+if ( ! function_exists( 'absint' ) ) { function absint( $v ) { return abs( (int) $v ); } }
+if ( ! function_exists( 'current_time' ) ) { function current_time( $t, $g = false ) { unset( $t, $g ); return '2026-08-26 00:00:00'; } }
+if ( ! function_exists( 'get_option' ) ) { function get_option( $n, $d = false ) { return $GLOBALS['_options'][ $n ] ?? $d; } }
+if ( ! function_exists( 'update_option' ) ) { function update_option( $n, $v, $a = null ) { unset( $a ); $GLOBALS['_options'][ $n ] = $v; return true; } }
+if ( ! function_exists( 'get_post' ) ) { function get_post( $id ) { return $GLOBALS['_posts'][ (int) $id ] ?? null; } }
+if ( ! function_exists( 'get_post_meta' ) ) { function get_post_meta( $id, $k, $s = false ) { unset( $s ); return $GLOBALS['_post_meta'][ (int) $id ][ $k ] ?? ''; } }
+if ( ! function_exists( 'is_wp_error' ) ) { function is_wp_error( $t ) { return $t instanceof WP_Error; } }
+if ( ! function_exists( 'get_template_directory_uri' ) ) { function get_template_directory_uri() { return 'https://example.test/theme'; } }
+if ( ! function_exists( 'trailingslashit' ) ) { function trailingslashit( $v ) { return rtrim( (string) $v, '/\\' ) . '/'; } }
+foreach ( array( 'class-logger.php', 'class-state-manager.php', 'class-ai-content-harness.php', 'class-canonical-section-store.php', 'class-yoast-meta-writer.php', 'class-content-builder.php', 'class-section-assembler.php', 'class-placeholder-provenance-store.php', 'class-internal-page-blueprints.php', 'class-step-internal-page-builder.php' ) as $f ) {
+	require_once $theme_root . '/inc/wizard/' . $f;
+}
+use Inc\Wizard\AI_Content_Harness;
+use Inc\Wizard\Canonical_Section_Store;
+use Inc\Wizard\Content_Builder;
+use Inc\Wizard\Internal_Page_Blueprints;
+use Inc\Wizard\Logger;
+use Inc\Wizard\Placeholder_Provenance_Store;
+use Inc\Wizard\State_Manager;
+use Inc\Wizard\Step_Internal_Page_Builder;
+class RMS_Internal_Fake_Builder extends Content_Builder {
+	public function build_page( array $page ): int {
+		$id = absint( $page['id'] ?? 0 ); $GLOBALS['_build_log'][] = $page;
+		if ( $id > 0 && isset( $page['sections'] ) ) { $GLOBALS['_post_meta'][ $id ]['page_sections'] = $page['sections']; }
+		if ( $id > 0 && isset( $page['meta_input']['_wp_page_template'] ) ) { $GLOBALS['_post_meta'][ $id ]['_wp_page_template'] = $page['meta_input']['_wp_page_template']; }
+		return $id;
+	}
+}
+function rms_ipb_assert( $c, string $m ): void { if ( ! $c ) { fwrite( STDERR, $m . "\n" ); exit( 1 ); } }
+function rms_ipb_reset(): void { $GLOBALS['_options'] = $GLOBALS['_posts'] = $GLOBALS['_post_meta'] = $GLOBALS['_build_log'] = array(); }
+function rms_ipb_builder(): Step_Internal_Page_Builder {
+	$l = new Logger(); $s = new State_Manager();
+	return new Step_Internal_Page_Builder( $l, $s, new RMS_Internal_Fake_Builder( $l, $s ), new AI_Content_Harness(), new Canonical_Section_Store() );
+}
+function rms_ipb_seed_about(): void {
+	$GLOBALS['_posts'][12] = new WP_Post( 12 ); $sm = new State_Manager(); $st = $sm->get_state();
+	$st['generated_pages'] = array( array( 'id' => 12, 'slug' => 'about', 'role' => '' ), array( 'id' => 99, 'slug' => 'home', 'role' => 'home' ) );
+	$sm->save_state( $st );
+}
+$passed = 0;
+$src = file_get_contents( $theme_root . '/inc/wizard/class-step-internal-page-builder.php' );
+rms_ipb_assert( is_string( $src ) && false === strpos( $src, '->replace(' ) && false === strpos( $src, 'acquire_lock' ), 'no replace/lock' );
+echo "PASS source-about-only-no-replace-no-fence-acquire\n"; ++$passed;
+rms_ipb_reset(); $skip = rms_ipb_builder()->run( array( 'skip_all' => true ) );
+rms_ipb_assert( ! is_wp_error( $skip ) && ! empty( $skip['skipped'] ) && array() === $GLOBALS['_build_log'], 'skip-all' );
+echo "PASS skip-all-no-mutation\n"; ++$passed;
+rms_ipb_reset(); rms_ipb_seed_about(); $b = rms_ipb_builder(); $b->run( array( 'action' => 'start' ) ); $built = $b->run( array( 'action' => 'process' ) );
+$page = $GLOBALS['_build_log'][0];
+rms_ipb_assert( 'complete' === ( $built['status'] ?? '' ) && 'pages/about-us.php' === ( $page['meta_input']['_wp_page_template'] ?? '' ), 'happy path' );
+rms_ipb_assert( array( 'about-us', 'vision-mission-v2' ) === array_column( $page['sections'], 'acf_fc_layout' ), 'layouts' );
+rms_ipb_assert( AI_Content_Harness::PAGE_ABOUT === Internal_Page_Blueprints::all()['about']['page_type'], 'PAGE_ABOUT' );
+echo "PASS about-happy-path-blueprint\n"; ++$passed;
+rms_ipb_reset(); ( new State_Manager() )->save_state( array( 'generated_pages' => array( array( 'id' => 99, 'slug' => 'home', 'role' => 'home' ) ) ) );
+$GLOBALS['_posts'][99] = new WP_Post( 99 ); $missing = rms_ipb_builder()->run( array( 'action' => 'process' ) );
+rms_ipb_assert( array() === $GLOBALS['_build_log'] && ( 'unavailable' === ( $missing['reason'] ?? '' ) || 'skipped' === ( $missing['status'] ?? '' ) ), 'missing shell' );
+echo "PASS missing-shell-not-created\n"; ++$passed;
+rms_ipb_reset(); rms_ipb_seed_about(); $c = new Canonical_Section_Store();
+$c->set_if_empty( 'about-us', array( 'acf_fc_layout' => 'about-us', 'about_headline' => 'Canonical About' ) ); $before = $c->get( 'about-us' );
+$b = rms_ipb_builder(); $b->run( array( 'action' => 'start' ) ); $b->run( array( 'action' => 'process' ) );
+rms_ipb_assert( $before === ( new Canonical_Section_Store() )->get( 'about-us' ) && 'Canonical About' === ( $GLOBALS['_build_log'][0]['sections'][0]['about_headline'] ?? '' ), 'canonical copy' );
+echo "PASS canonical-copy-unchanged\n"; ++$passed;
+rms_ipb_reset(); rms_ipb_seed_about(); $b = rms_ipb_builder(); $b->run( array( 'action' => 'start' ) ); $b->run( array( 'action' => 'process' ) );
+rms_ipb_assert( false === ( new Canonical_Section_Store() )->has( 'about-us' ) && count( ( new Placeholder_Provenance_Store() )->query( 12 ) ) >= 1, 'placeholders' );
+echo "PASS placeholders-provenance-not-canonical\n"; ++$passed;
+rms_ipb_reset(); rms_ipb_seed_about();
+$GLOBALS['_post_meta'][12]['page_sections'] = array( array( 'acf_fc_layout' => 'about-us', 'about_headline' => 'Editor edit' ) );
+$sm = new State_Manager(); $st = $sm->get_state();
+$st['internal_pages']['about'] = array_merge( State_Manager::INTERNAL_PAGE_ENTRY, array( 'post_id' => 12, 'status' => 'complete' ) ); $sm->save_state( $st );
+$noop = rms_ipb_builder()->run( array( 'action' => 'process' ) );
+rms_ipb_assert( array() === $GLOBALS['_build_log'] && 'complete' === ( $noop['status'] ?? '' ) && 'Editor edit' === ( $GLOBALS['_post_meta'][12]['page_sections'][0]['about_headline'] ?? '' ), 'preserve' );
+echo "PASS preserve-edit-and-complete-noop\n"; ++$passed;
+echo 'Harness passed: ' . $passed . " scenarios.\n";


### PR DESCRIPTION
Closes #42

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds the About-only Internal Page Builder: start/process one existing About shell, assemble blueprint sections, and record unmarked placeholders.
- Skip-all marks pending plan entries skipped without mutating pages.
- Does not acquire the mutation fence; Phase 8 controller/dispatch owns that.

## Changes

| File | Change |
|------|--------|
| `inc/wizard/class-step-internal-page-builder.php` | About-only builder: plan, start/process, skip-all, assemble `about-us` + `vision-mission-v2`, record provenance. No fence acquire. |
| `tests/wizard-internal-page-builder-harness.php` | 7 core scenarios for About-only happy path, skip-all, missing shell, canonical copy, placeholders, and preserve-edit. |

## Test Plan
- [x] `php -l inc/wizard/class-step-internal-page-builder.php` — No syntax errors detected, exit 0, PHP 8.2.29.
- [x] `php -l tests/wizard-internal-page-builder-harness.php` — No syntax errors detected, exit 0, PHP 8.2.29.
- [x] Focused lint: **2/2 pass** (plus parent provenance files still clean).
- [x] `php tests/wizard-internal-page-builder-harness.php` — **7/7 pass**: `source-about-only-no-replace-no-fence-acquire`, `skip-all-no-mutation`, `about-happy-path-blueprint`, `missing-shell-not-created`, `canonical-copy-unchanged`, `placeholders-provenance-not-canonical`, `preserve-edit-and-complete-noop`.
- [x] `php tests/wizard-home-seo-targeting-harness.php` — **9/9 pass**.
- [x] Three-dot diff against `feat/internal-page-placeholder-provenance` is exactly these two files (**400 / 400**).
- [x] Scripts run without errors: N/A — no shell scripts in this PR.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts: N/A — no shell scripts
- [x] Skills tested in at least one agent: N/A — wizard domain feature, not a skill change
- [x] Docs updated if behavior changed: OpenSpec progress is on tracker #43; no public UI change
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Chain Context

| Field | Value |
|-------|-------|
| Chain | wizard-internal-page-builder |
| Tracker PR | #43 `feat/internal-page-builder` (draft, no-merge) |
| Position | 3B of 8 (About core builder) |
| Base | `feat/internal-page-placeholder-provenance` |
| Depends on | PR3A #48 `feat/internal-page-placeholder-provenance` / tracker #43 / approved issue #42 |
| Follow-up | PR3C #50 `feat/internal-page-about-recovery` (conversion and retry) |
| Review budget | 400 / 400 |
| Starts at | PR3A `feat/internal-page-placeholder-provenance` @ `ffe3d95` |
| Ends with | About core start/process/skip-all and 7-scenario harness |

### Chain Overview

```text
main
 └── #43 feat/internal-page-builder  (draft tracker, no-merge)
      └── #44 PR1 feat/internal-page-blueprints  (merged)
           └── #45–#47 PR2A–PR2C section assembler  (merged)
                └── #48 PR3A feat/internal-page-placeholder-provenance
                     └── 📍 #49 PR3B feat/internal-page-about-core
                          └── #50 PR3C feat/internal-page-about-recovery
                               └── PR4+ later Internal Builder phases (out of scope)
```

### Scope
- Includes: About-only builder core and the 7-scenario harness.
- Excludes: controller/dispatch/UI, templates, Blog, later internal pages, visible placeholder labels, hiding, completion blocking, overwrite/convert/retry, later phases.
- Placeholders stay unmarked. Nothing is hidden and completion is not blocked.
- Builder does not acquire the mutation fence.
- Tracker #43 remains draft/no-merge.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit

### Rollback
Delete `inc/wizard/class-step-internal-page-builder.php` and `tests/wizard-internal-page-builder-harness.php`. Parent provenance files stay.
