### PR TITLE
feat(wizard): add About conversion and retry controls

### DIFF
--- a/inc/wizard/class-step-internal-page-builder.php
+++ b/inc/wizard/class-step-internal-page-builder.php
@@ -52,11 +52,11 @@ class Step_Internal_Page_Builder {
 		$action = \sanitize_key( (string) ( $payload['action'] ?? '' ) );
 
 		if ( 'start' === $action ) {
-			return $this->start();
+			return $this->start( $payload );
 		}
 
 		if ( 'process' === $action ) {
-			return $this->process();
+			return $this->process( $payload );
 		}
 
 		return new \WP_Error(
@@ -91,11 +91,12 @@ class Step_Internal_Page_Builder {
 	}
 
 	/**
+	 * @param array<string,mixed> $payload
 	 * @return array<string,mixed>
 	 */
-	private function start(): array {
+	private function start( array $payload ): array {
 		$fresh = $this->state_manager->get_state();
-		$plan  = $this->ensure_about_plan( $fresh );
+		$plan  = $this->ensure_about_plan( $fresh, $this->truthy( $payload['retry_failed'] ?? false ) );
 		$fresh['internal_pages'] = $plan;
 		$this->state_manager->save_state( $fresh );
 		$pending = $this->is_pending( $plan );
@@ -105,11 +106,12 @@ class Step_Internal_Page_Builder {
 	}
 
 	/**
+	 * @param array<string,mixed> $payload
 	 * @return array<string,mixed>
 	 */
-	private function process(): array {
+	private function process( array $payload ): array {
 		$fresh = $this->state_manager->get_state();
-		$plan  = $this->ensure_about_plan( $fresh );
+		$plan  = $this->ensure_about_plan( $fresh, $this->truthy( $payload['retry_failed'] ?? false ) );
 		$entry = is_array( $plan[ self::SCOPE_TYPE ] ?? null ) ? $plan[ self::SCOPE_TYPE ] : null;
 
 		if ( null === $entry ) {
@@ -120,7 +122,11 @@ class Step_Internal_Page_Builder {
 			return [ 'internal_pages' => $plan, 'status' => 'complete', 'unavailable' => true ];
 		}
 
-		$entry                    = $this->process_about( $entry );
+		$entry                    = $this->process_about(
+			$entry,
+			$this->type_requested( $payload['overwrite'] ?? [], self::SCOPE_TYPE ),
+			$this->type_requested( $payload['convert_legacy'] ?? [], self::SCOPE_TYPE )
+		);
 		$plan[ self::SCOPE_TYPE ] = $entry;
 		$fresh                    = $this->state_manager->get_state();
 		$fresh['internal_pages']  = $plan;
@@ -141,7 +147,7 @@ class Step_Internal_Page_Builder {
 	 * @param array<string,mixed> $state
 	 * @return array<string,array<string,mixed>>
 	 */
-	private function ensure_about_plan( array $state ): array {
+	private function ensure_about_plan( array $state, bool $retry_failed = false ): array {
 		$plan  = is_array( $state['internal_pages'] ?? null ) ? $state['internal_pages'] : [];
 		$shell = $this->find_about_shell( is_array( $state['generated_pages'] ?? null ) ? $state['generated_pages'] : [] );
 		$entry = is_array( $plan[ self::SCOPE_TYPE ] ?? null )
@@ -159,6 +165,10 @@ class Step_Internal_Page_Builder {
 		}
 
 		$entry['post_id'] = (int) $shell['id'];
+		if ( $retry_failed && 'failed' === (string) ( $entry['status'] ?? '' ) ) {
+			$entry['status'] = 'pending';
+			$entry['reason'] = '';
+		}
 		if ( '' === (string) ( $entry['status'] ?? '' ) ) {
 			$entry['status'] = 'pending';
 		}
@@ -198,7 +208,7 @@ class Step_Internal_Page_Builder {
 	 * @param array<string,mixed> $entry
 	 * @return array<string,mixed>
 	 */
-	private function process_about( array $entry ): array {
+	private function process_about( array $entry, bool $overwrite = false, bool $convert = false ): array {
 		$post_id = \absint( $entry['post_id'] ?? 0 );
 		$now     = \current_time( 'mysql', true );
 
@@ -210,16 +220,28 @@ class Step_Internal_Page_Builder {
 			return $entry;
 		}
 
-		if ( 'complete' === (string) ( $entry['status'] ?? '' ) ) {
+		if ( 'complete' === (string) ( $entry['status'] ?? '' ) && ! $overwrite ) {
 			$entry['reason']     = 'unchanged';
 			$entry['updated_at'] = $now;
 
 			return $entry;
 		}
 
-		if ( [] !== $this->current_sections( $post_id ) ) {
+		$sections = $this->current_sections( $post_id );
+		$post     = \get_post( $post_id );
+		$content  = $post ? (string) $post->post_content : '';
+
+		if ( [] !== $sections && ! $overwrite ) {
 			$entry['status']     = 'complete';
 			$entry['reason']     = 'preserved';
+			$entry['updated_at'] = $now;
+
+			return $entry;
+		}
+
+		if ( [] === $sections && '' !== trim( $content ) && ! $convert ) {
+			$entry['status']     = 'skipped';
+			$entry['reason']     = 'legacy_unconfirmed';
 			$entry['updated_at'] = $now;
 
 			return $entry;
@@ -237,6 +259,10 @@ class Step_Internal_Page_Builder {
 		);
 
 		if ( $saved <= 0 ) {
+			$entry['status']     = 'failed';
+			$entry['reason']     = 'persist_failed';
+			$entry['updated_at'] = $now;
+
 			return $entry;
 		}
 
@@ -298,7 +324,25 @@ class Step_Internal_Page_Builder {
 	 * @param array<string,array<string,mixed>> $plan
 	 */
 	private function is_pending( array $plan ): bool {
-		return 'pending' === (string) ( ( is_array( $plan[ self::SCOPE_TYPE ] ?? null ) ? $plan[ self::SCOPE_TYPE ] : [] )['status'] ?? '' );
+		$status = (string) ( ( is_array( $plan[ self::SCOPE_TYPE ] ?? null ) ? $plan[ self::SCOPE_TYPE ] : [] )['status'] ?? '' );
+
+		return in_array( $status, [ 'pending', 'failed' ], true );
+	}
+
+	/**
+	 * @param mixed $list
+	 */
+	private function type_requested( $list, string $type ): bool {
+		if ( ! is_array( $list ) ) {
+			return false;
+		}
+		foreach ( $list as $item ) {
+			if ( $type === \sanitize_key( (string) $item ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private function truthy( $value ): bool {

--- a/tests/wizard-internal-page-builder-harness.php
+++ b/tests/wizard-internal-page-builder-harness.php
@@ -41,6 +41,7 @@ use Inc\Wizard\State_Manager;
 use Inc\Wizard\Step_Internal_Page_Builder;
 class RMS_Internal_Fake_Builder extends Content_Builder {
 	public function build_page( array $page ): int {
+		if ( ! empty( $GLOBALS['_fail_build'] ) ) { return 0; }
 		$id = absint( $page['id'] ?? 0 ); $GLOBALS['_build_log'][] = $page;
 		if ( $id > 0 && isset( $page['sections'] ) ) { $GLOBALS['_post_meta'][ $id ]['page_sections'] = $page['sections']; }
 		if ( $id > 0 && isset( $page['meta_input']['_wp_page_template'] ) ) { $GLOBALS['_post_meta'][ $id ]['_wp_page_template'] = $page['meta_input']['_wp_page_template']; }
@@ -48,7 +49,7 @@ class RMS_Internal_Fake_Builder extends Content_Builder {
 	}
 }
 function rms_ipb_assert( $c, string $m ): void { if ( ! $c ) { fwrite( STDERR, $m . "\n" ); exit( 1 ); } }
-function rms_ipb_reset(): void { $GLOBALS['_options'] = $GLOBALS['_posts'] = $GLOBALS['_post_meta'] = $GLOBALS['_build_log'] = array(); }
+function rms_ipb_reset(): void { $GLOBALS['_options'] = $GLOBALS['_posts'] = $GLOBALS['_post_meta'] = $GLOBALS['_build_log'] = array(); $GLOBALS['_fail_build'] = false; }
 function rms_ipb_builder(): Step_Internal_Page_Builder {
 	$l = new Logger(); $s = new State_Manager();
 	return new Step_Internal_Page_Builder( $l, $s, new RMS_Internal_Fake_Builder( $l, $s ), new AI_Content_Harness(), new Canonical_Section_Store() );
@@ -90,4 +91,24 @@ $st['internal_pages']['about'] = array_merge( State_Manager::INTERNAL_PAGE_ENTRY
 $noop = rms_ipb_builder()->run( array( 'action' => 'process' ) );
 rms_ipb_assert( array() === $GLOBALS['_build_log'] && 'complete' === ( $noop['status'] ?? '' ) && 'Editor edit' === ( $GLOBALS['_post_meta'][12]['page_sections'][0]['about_headline'] ?? '' ), 'preserve' );
 echo "PASS preserve-edit-and-complete-noop\n"; ++$passed;
+rms_ipb_reset(); rms_ipb_seed_about();
+$GLOBALS['_post_meta'][12]['page_sections'] = array( array( 'acf_fc_layout' => 'about-us', 'about_headline' => 'Editor edit' ) );
+$sm = new State_Manager(); $st = $sm->get_state();
+$st['internal_pages']['about'] = array_merge( State_Manager::INTERNAL_PAGE_ENTRY, array( 'post_id' => 12, 'status' => 'complete' ) ); $sm->save_state( $st );
+$over = rms_ipb_builder()->run( array( 'action' => 'process', 'overwrite' => array( 'about' ) ) );
+rms_ipb_assert( 1 === count( $GLOBALS['_build_log'] ) && 'complete' === ( $over['status'] ?? '' ), 'overwrite' );
+echo "PASS explicit-overwrite-regenerates\n"; ++$passed;
+rms_ipb_reset(); $GLOBALS['_posts'][12] = new WP_Post( 12 ); $GLOBALS['_posts'][12]->post_content = 'Legacy about body';
+$sm = new State_Manager(); $st = $sm->get_state(); $st['generated_pages'] = array( array( 'id' => 12, 'slug' => 'about', 'role' => '' ) ); $sm->save_state( $st );
+$b = rms_ipb_builder(); $b->run( array( 'action' => 'start' ) ); $legacy = $b->run( array( 'action' => 'process' ) );
+rms_ipb_assert( 'skipped' === ( $legacy['status'] ?? '' ) && array() === $GLOBALS['_build_log'], 'legacy skip' );
+$conv = $b->run( array( 'action' => 'process', 'convert_legacy' => array( 'about' ) ) );
+rms_ipb_assert( 'complete' === ( $conv['status'] ?? '' ) && 1 === count( $GLOBALS['_build_log'] ), 'legacy convert' );
+echo "PASS legacy-unconfirmed-then-convert\n"; ++$passed;
+rms_ipb_reset(); rms_ipb_seed_about(); $GLOBALS['_fail_build'] = true;
+$b = rms_ipb_builder(); $b->run( array( 'action' => 'start' ) ); $fail = $b->run( array( 'action' => 'process' ) );
+rms_ipb_assert( 'failed' === ( $fail['status'] ?? '' ) && 'persist_failed' === ( $fail['reason'] ?? '' ) && ! is_wp_error( $fail ), 'isolated fail' );
+$GLOBALS['_fail_build'] = false; $retried = $b->run( array( 'action' => 'process', 'retry_failed' => true ) );
+rms_ipb_assert( 'complete' === ( $retried['status'] ?? '' ), 'retry' );
+echo "PASS failure-isolation-and-retry\n"; ++$passed;
 echo 'Harness passed: ' . $passed . " scenarios.\n";


### PR DESCRIPTION
Closes #42

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds About recovery controls: explicit overwrite, confirmed legacy-content conversion, and retry of a failed plan entry.
- A completed/edited About page is a no-op unless overwrite is requested. Unconfirmed legacy content is not converted.
- Failures stay isolated to the About plan entry so a later retry can resume.

## Changes

| File | Change |
|------|--------|
| `inc/wizard/class-step-internal-page-builder.php` | Payload-aware start/process: `overwrite`, `convert_legacy`, and `retry_failed` for About only. |
| `tests/wizard-internal-page-builder-harness.php` | Adds 3 recovery scenarios (10 total): overwrite, legacy-unconfirmed-then-convert, failure isolation + retry. |

## Test Plan
- [x] `php -l inc/wizard/class-step-internal-page-builder.php` — No syntax errors detected, exit 0, PHP 8.2.29.
- [x] `php -l tests/wizard-internal-page-builder-harness.php` — No syntax errors detected, exit 0, PHP 8.2.29.
- [x] Focused lint: **4/4 pass** (builder, builder harness, provenance store, provenance harness).
- [x] `php tests/wizard-internal-page-builder-harness.php` — **10/10 pass** (7 core + `explicit-overwrite-regenerates`, `legacy-unconfirmed-then-convert`, `failure-isolation-and-retry`).
- [x] `php tests/wizard-placeholder-provenance-harness.php` — **4/4 pass**, including `provenance-option-autoload-false`.
- [x] `php tests/wizard-home-seo-targeting-harness.php` — **9/9 pass**.
- [x] `php tests/wizard-integration-truth-harness.php` — **8/8 pass**.
- [x] Landing: **N/A** — shared Home/Landing/assembler files are untouched in this slice.
- [x] Three-dot diff against `feat/internal-page-about-core` is exactly these two files (**91 / 400**).
- [x] Scripts run without errors: N/A — no shell scripts in this PR.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts: N/A — no shell scripts
- [x] Skills tested in at least one agent: N/A — wizard domain feature, not a skill change
- [x] Docs updated if behavior changed: OpenSpec progress is on tracker #43; no public UI change
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Chain Context

| Field | Value |
|-------|-------|
| Chain | wizard-internal-page-builder |
| Tracker PR | #43 `feat/internal-page-builder` (draft, no-merge) |
| Position | 3C of 8 (About conversion and retry) |
| Base | `feat/internal-page-about-core` |
| Depends on | PR3B #49 `feat/internal-page-about-core` / PR3A #48 / tracker #43 / approved issue #42 |
| Follow-up | PR4 templates + shell (out of this publish) |
| Review budget | 91 / 400 |
| Starts at | PR3B `feat/internal-page-about-core` @ `842376a` |
| Ends with | About overwrite/convert/retry controls and 10-scenario cumulative harness |

### Chain Overview

```text
main
 └── #43 feat/internal-page-builder  (draft tracker, no-merge)
      └── #44 PR1 feat/internal-page-blueprints  (merged)
           └── #45–#47 PR2A–PR2C section assembler  (merged)
                └── #48 PR3A feat/internal-page-placeholder-provenance
                     └── #49 PR3B feat/internal-page-about-core
                          └── 📍 #50 PR3C feat/internal-page-about-recovery
                               └── PR4+ later Internal Builder phases (out of scope)
```

### Scope
- Includes: About overwrite, confirmed conversion, retry-failed, and the three recovery harness scenarios.
- Excludes: controller/dispatch/UI, templates, Blog, later internal pages, visible placeholder labels, hiding, completion blocking, later phases.
- Placeholders stay unmarked. Nothing is hidden and completion is not blocked.
- Builder still does not acquire the mutation fence.
- Tracker #43 remains draft/no-merge.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit

### Rollback
Revert the overwrite/convert/retry/fail-isolation changes in `inc/wizard/class-step-internal-page-builder.php` and the three recovery scenarios in `tests/wizard-internal-page-builder-harness.php`. Core About builder stays.
