### PR TITLE
feat(wizard): preserve page types across custom slugs

### DIFF
--- a/inc/wizard/class-step-generate-pages.php
+++ b/inc/wizard/class-step-generate-pages.php
@@ -173,13 +173,38 @@ class Step_Generate_Pages {
 				continue;
 			}
 
+			$type = $this->resolve_page_type( $config, is_string( $key ) ? $key : '', $slug, $available );
+
 			$selected[ $slug ] = [
-				'title' => \sanitize_text_field( (string) ( $config['title'] ?? $available[ $slug ] ?? ucwords( str_replace( '-', ' ', $slug ) ) ) ),
+				'title' => \sanitize_text_field( (string) ( $config['title'] ?? $available[ $type ] ?? $available[ $slug ] ?? ucwords( str_replace( '-', ' ', $slug ) ) ) ),
 				'role'  => \sanitize_key( (string) ( $config['role'] ?? '' ) ),
+				'type'  => $type,
 			];
 		}
 
 		return $selected;
+	}
+
+	/**
+	 * Prefer a valid explicit type; ignore unknown types; fall back to legacy keys/slugs.
+	 *
+	 * @param array<string,mixed>      $config    Page payload item.
+	 * @param array<string,string>     $available Catalog keyed by immutable type.
+	 */
+	private function resolve_page_type( array $config, string $key, string $slug, array $available ): string {
+		$explicit = \sanitize_title( (string) ( $config['type'] ?? '' ) );
+
+		if ( '' !== $explicit && isset( $available[ $explicit ] ) ) {
+			return $explicit;
+		}
+
+		$from_key = \sanitize_title( $key );
+
+		if ( '' !== $from_key && isset( $available[ $from_key ] ) ) {
+			return $from_key;
+		}
+
+		return isset( $available[ $slug ] ) ? $slug : '';
 	}
 
 	private function resolve_roles( array $pages, array $payload ) {

--- a/inc/wizard/class-step-generate-pages.php
+++ b/inc/wizard/class-step-generate-pages.php
@@ -117,6 +117,7 @@ class Step_Generate_Pages {
 				'title' => $page['title'],
 				'slug'  => $slug,
 				'role'  => $role,
+				'type'  => \sanitize_title( (string) ( $page['type'] ?? '' ) ),
 			];
 		}
 

--- a/inc/wizard/class-step-internal-page-builder.php
+++ b/inc/wizard/class-step-internal-page-builder.php
@@ -187,8 +187,11 @@ class Step_Internal_Page_Builder {
 				continue;
 			}
 			$slug = \sanitize_title( (string) ( $page['slug'] ?? '' ) );
-			$type = \sanitize_key( (string) ( $page['type'] ?? '' ) );
-			if ( self::SCOPE_TYPE !== $type && ! in_array( $slug, self::SCOPE_SLUGS, true ) ) {
+			$type = \sanitize_title( (string) ( $page['type'] ?? '' ) );
+			if ( '' !== $type && self::SCOPE_TYPE !== $type ) {
+				continue;
+			}
+			if ( '' === $type && ! in_array( $slug, self::SCOPE_SLUGS, true ) ) {
 				continue;
 			}
 			$id = \absint( $page['id'] ?? 0 );

--- a/inc/wizard/wizard-init.php
+++ b/inc/wizard/wizard-init.php
@@ -569,6 +569,7 @@ function rms_wizard_render_generate_pages_form(): void {
 			'title'       => $page['title'],
 			'description' => $page['description'],
 			'role'        => 'home' === $slug || 'blog' === $slug ? $slug : '',
+			'type'        => $slug,
 		];
 	}
 	?>
@@ -603,7 +604,7 @@ function rms_wizard_render_generate_pages_form(): void {
 			</label>
 
 			<template data-wizard-page-row-template>
-				<article class="rms-wizard-page-row" role="listitem" data-wizard-page-row>
+				<article class="rms-wizard-page-row" role="listitem" data-wizard-page-row data-wizard-page-type="">
 					<div class="rms-wizard-field rms-wizard-page-row__title">
 						<label for="rms-wizard-page-title-__INDEX__"><?php esc_html_e( 'Page title', 'simple-rms-theme' ); ?></label>
 						<input id="rms-wizard-page-title-__INDEX__" type="text" name="pages[__INDEX__][title]" data-wizard-page-title placeholder="<?php esc_attr_e( 'Services', 'simple-rms-theme' ); ?>">

--- a/src/ts/admin/wizard-helpers.ts
+++ b/src/ts/admin/wizard-helpers.ts
@@ -79,6 +79,39 @@ export const summarizeDependencyResult = (result: unknown): string => {
   return `${activeCount} of ${plugins.length} dependencies active. ${lines.join(' ')}`;
 };
 
+export type GeneratePagePayloadItem = {
+  slug: string;
+  title: string;
+  generate: true;
+  role: string;
+  type?: string;
+};
+
+export const sanitizeWizardPageType = (value: string): string => (
+  value.trim().toLowerCase().replace(/[^a-z0-9-]+/g, '').replace(/^-+|-+$/g, '')
+);
+
+export const buildGeneratePagePayloadItem = (input: {
+  slug: string;
+  title: string;
+  role: string;
+  type?: string;
+}): GeneratePagePayloadItem => {
+  const item: GeneratePagePayloadItem = {
+    slug: input.slug,
+    title: input.title,
+    generate: true,
+    role: input.role,
+  };
+  const type = sanitizeWizardPageType(input.type ?? '');
+
+  if (type !== '') {
+    item.type = type;
+  }
+
+  return item;
+};
+
 export const inputContainsSecret = (input: ApiKeyInputLike, sentinel: string): boolean => {
   if (input.value.includes(sentinel)) {
     return true;

--- a/src/ts/admin/wizard.ts
+++ b/src/ts/admin/wizard.ts
@@ -9,8 +9,11 @@ import {
 } from './landing-run-helpers';
 import {
   applyApiKeyInputSafety,
+  buildGeneratePagePayloadItem,
   presentStepOutcome,
+  sanitizeWizardPageType,
   summarizeDependencyResult,
+  type GeneratePagePayloadItem,
 } from './wizard-helpers';
 import {
   applyHomeSeoTargetingUi,
@@ -95,6 +98,7 @@ interface WizardPageTemplate {
   slug?: string;
   description?: string;
   role?: string;
+  type?: string;
 }
 
 interface HomeSectionTemplate {
@@ -138,12 +142,7 @@ interface LandingPayloadItem {
   sections: LandingSectionPayload[];
 }
 
-interface PagePayloadItem {
-  slug: string;
-  title: string;
-  generate: boolean;
-  role: string;
-}
+type PagePayloadItem = GeneratePagePayloadItem;
 
 interface WizardState {
   current_step?: string;
@@ -1183,7 +1182,12 @@ declare global {
       const isBlog = Boolean(row.querySelector<HTMLInputElement>('[data-wizard-page-blog]')?.checked);
       const role = isBlog ? 'blog' : (isHome ? 'home' : '');
 
-      pages[slug] = { slug, title: rawTitle, generate: true, role };
+      pages[slug] = buildGeneratePagePayloadItem({
+        slug,
+        title: rawTitle,
+        role,
+        type: row.dataset.wizardPageType ?? '',
+      });
       selectedSlugs.push(slug);
 
       if (isHome) {
@@ -2152,6 +2156,8 @@ declare global {
       slugInput.value = slug;
       slugInput.dataset.wizardSlugAuto = '1';
     }
+
+    row.dataset.wizardPageType = sanitizeWizardPageType(data.type ?? '');
 
     rows.append(row);
     updatePageRowRadioValues(row);

--- a/tests/wizard-internal-page-builder-harness.php
+++ b/tests/wizard-internal-page-builder-harness.php
@@ -13,6 +13,7 @@ if ( ! class_exists( 'WP_Post', false ) ) {
 	class WP_Post { public $ID; public $post_type = 'page'; public $post_content = ''; public function __construct( $id = 0 ) { $this->ID = (int) $id; } }
 }
 $GLOBALS['_options'] = $GLOBALS['_posts'] = $GLOBALS['_post_meta'] = $GLOBALS['_build_log'] = array();
+$GLOBALS['_next_id'] = 20;
 if ( ! function_exists( 'sanitize_text_field' ) ) { function sanitize_text_field( $s ) { return trim( preg_replace( '/\s+/', ' ', (string) $s ) ); } }
 if ( ! function_exists( 'sanitize_key' ) ) { function sanitize_key( $k ) { return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $k ) ) ); } }
 if ( ! function_exists( 'sanitize_title' ) ) { function sanitize_title( $v ) { return strtolower( preg_replace( '/[^a-z0-9-]+/', '-', (string) $v ) ); } }
@@ -24,11 +25,15 @@ if ( ! function_exists( 'current_time' ) ) { function current_time( $t, $g = fal
 if ( ! function_exists( 'get_option' ) ) { function get_option( $n, $d = false ) { return $GLOBALS['_options'][ $n ] ?? $d; } }
 if ( ! function_exists( 'update_option' ) ) { function update_option( $n, $v, $a = null ) { unset( $a ); $GLOBALS['_options'][ $n ] = $v; return true; } }
 if ( ! function_exists( 'get_post' ) ) { function get_post( $id ) { return $GLOBALS['_posts'][ (int) $id ] ?? null; } }
+if ( ! function_exists( 'get_page_by_path' ) ) { function get_page_by_path( $s, $o = null, $t = 'page' ) { unset( $s, $o, $t ); return null; } }
+if ( ! function_exists( 'get_posts' ) ) { function get_posts( $a = array() ) { unset( $a ); return array(); } }
+if ( ! function_exists( 'esc_html' ) ) { function esc_html( $t ) { return htmlspecialchars( (string) $t, ENT_QUOTES, 'UTF-8' ); } }
+if ( ! defined( 'OBJECT' ) ) { define( 'OBJECT', 'OBJECT' ); }
 if ( ! function_exists( 'get_post_meta' ) ) { function get_post_meta( $id, $k, $s = false ) { unset( $s ); return $GLOBALS['_post_meta'][ (int) $id ][ $k ] ?? ''; } }
 if ( ! function_exists( 'is_wp_error' ) ) { function is_wp_error( $t ) { return $t instanceof WP_Error; } }
 if ( ! function_exists( 'get_template_directory_uri' ) ) { function get_template_directory_uri() { return 'https://example.test/theme'; } }
 if ( ! function_exists( 'trailingslashit' ) ) { function trailingslashit( $v ) { return rtrim( (string) $v, '/\\' ) . '/'; } }
-foreach ( array( 'class-logger.php', 'class-state-manager.php', 'class-ai-content-harness.php', 'class-canonical-section-store.php', 'class-yoast-meta-writer.php', 'class-content-builder.php', 'class-section-assembler.php', 'class-placeholder-provenance-store.php', 'class-internal-page-blueprints.php', 'class-step-internal-page-builder.php' ) as $f ) {
+foreach ( array( 'class-logger.php', 'class-state-manager.php', 'class-ai-content-harness.php', 'class-canonical-section-store.php', 'class-yoast-meta-writer.php', 'class-content-builder.php', 'class-section-assembler.php', 'class-placeholder-provenance-store.php', 'class-internal-page-blueprints.php', 'class-step-internal-page-builder.php', 'class-step-generate-pages.php' ) as $f ) {
 	require_once $theme_root . '/inc/wizard/' . $f;
 }
 use Inc\Wizard\AI_Content_Harness;
@@ -38,18 +43,21 @@ use Inc\Wizard\Internal_Page_Blueprints;
 use Inc\Wizard\Logger;
 use Inc\Wizard\Placeholder_Provenance_Store;
 use Inc\Wizard\State_Manager;
+use Inc\Wizard\Step_Generate_Pages;
 use Inc\Wizard\Step_Internal_Page_Builder;
 class RMS_Internal_Fake_Builder extends Content_Builder {
 	public function build_page( array $page ): int {
 		if ( ! empty( $GLOBALS['_fail_build'] ) ) { return 0; }
-		$id = absint( $page['id'] ?? 0 ); $GLOBALS['_build_log'][] = $page;
+		$id = absint( $page['id'] ?? 0 );
+		if ( $id <= 0 ) { $GLOBALS['_next_id'] = ( $GLOBALS['_next_id'] ?? 20 ) + 1; $id = $GLOBALS['_next_id']; }
+		$GLOBALS['_build_log'][] = $page;
 		if ( $id > 0 && isset( $page['sections'] ) ) { $GLOBALS['_post_meta'][ $id ]['page_sections'] = $page['sections']; }
 		if ( $id > 0 && isset( $page['meta_input']['_wp_page_template'] ) ) { $GLOBALS['_post_meta'][ $id ]['_wp_page_template'] = $page['meta_input']['_wp_page_template']; }
 		return $id;
 	}
 }
 function rms_ipb_assert( $c, string $m ): void { if ( ! $c ) { fwrite( STDERR, $m . "\n" ); exit( 1 ); } }
-function rms_ipb_reset(): void { $GLOBALS['_options'] = $GLOBALS['_posts'] = $GLOBALS['_post_meta'] = $GLOBALS['_build_log'] = array(); $GLOBALS['_fail_build'] = false; }
+function rms_ipb_reset(): void { $GLOBALS['_options'] = $GLOBALS['_posts'] = $GLOBALS['_post_meta'] = $GLOBALS['_build_log'] = array(); $GLOBALS['_fail_build'] = false; $GLOBALS['_next_id'] = 20; }
 function rms_ipb_builder(): Step_Internal_Page_Builder {
 	$l = new Logger(); $s = new State_Manager();
 	return new Step_Internal_Page_Builder( $l, $s, new RMS_Internal_Fake_Builder( $l, $s ), new AI_Content_Harness(), new Canonical_Section_Store() );
@@ -111,4 +119,30 @@ rms_ipb_assert( 'failed' === ( $fail['status'] ?? '' ) && 'persist_failed' === (
 $GLOBALS['_fail_build'] = false; $retried = $b->run( array( 'action' => 'process', 'retry_failed' => true ) );
 rms_ipb_assert( 'complete' === ( $retried['status'] ?? '' ), 'retry' );
 echo "PASS failure-isolation-and-retry\n"; ++$passed;
+rms_ipb_reset();
+$l = new Logger(); $sm = new State_Manager();
+$gen = new Step_Generate_Pages( $l, $sm, new RMS_Internal_Fake_Builder( $l, $sm ) );
+$out = $gen->run( array( 'pages' => array( 'home' => array( 'type' => 'home', 'slug' => 'home', 'title' => 'Home', 'role' => 'home', 'generate' => true ), 'our-company' => array( 'type' => 'about', 'slug' => 'our-company', 'title' => 'Our Company', 'generate' => true ) ), 'confirm_cleanup' => true ) );
+rms_ipb_assert( ! is_wp_error( $out ), 'generate-pages run' );
+$by = array();
+foreach ( $out['generated_pages'] as $row ) { $by[ (string) $row['slug'] ] = $row; }
+rms_ipb_assert( 'about' === ( $by['our-company']['type'] ?? '' ), 'result type' );
+rms_ipb_assert( 'about' === ( $sm->get_state()['generated_pages'][1]['type'] ?? '' ), 'state type' );
+$GLOBALS['_posts'][ (int) $by['our-company']['id'] ] = new WP_Post( (int) $by['our-company']['id'] );
+$GLOBALS['_build_log'] = array();
+$b = rms_ipb_builder(); $b->run( array( 'action' => 'start' ) ); $proc = $b->run( array( 'action' => 'process' ) );
+rms_ipb_assert( 'complete' === ( $proc['status'] ?? '' ) && 1 === count( $GLOBALS['_build_log'] ), 'about processes our-company' );
+echo "PASS our-company-type-about-generate-and-build\n"; ++$passed;
+rms_ipb_reset(); $GLOBALS['_posts'][12] = new WP_Post( 12 );
+$sm = new State_Manager(); $st = $sm->get_state();
+$st['generated_pages'] = array( array( 'id' => 12, 'slug' => 'about', 'type' => 'services', 'role' => '' ) ); $sm->save_state( $st );
+$coerced = rms_ipb_builder()->run( array( 'action' => 'process' ) );
+rms_ipb_assert( array() === $GLOBALS['_build_log'] && ( 'unavailable' === ( $coerced['reason'] ?? '' ) || 'skipped' === ( $coerced['status'] ?? '' ) ), 'unknown type not coerced' );
+echo "PASS unknown-type-not-coerced\n"; ++$passed;
+rms_ipb_reset(); $GLOBALS['_posts'][12] = new WP_Post( 12 );
+$sm = new State_Manager(); $st = $sm->get_state();
+$st['generated_pages'] = array( array( 'id' => 12, 'slug' => 'about-us', 'role' => '' ) ); $sm->save_state( $st );
+$b = rms_ipb_builder(); $b->run( array( 'action' => 'start' ) ); $legacy_alias = $b->run( array( 'action' => 'process' ) );
+rms_ipb_assert( 'complete' === ( $legacy_alias['status'] ?? '' ) && 1 === count( $GLOBALS['_build_log'] ), 'legacy about-us alias' );
+echo "PASS legacy-about-us-alias\n"; ++$passed;
 echo 'Harness passed: ' . $passed . " scenarios.\n";

--- a/tests/wizard-page-type-client-harness.mjs
+++ b/tests/wizard-page-type-client-harness.mjs
@@ -1,0 +1,60 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+
+const require = createRequire(import.meta.url);
+const here = dirname(fileURLToPath(import.meta.url));
+const themeRoot = resolve(here, '..');
+const ts = require('typescript');
+const helperSource = readFileSync(resolve(themeRoot, 'src/ts/admin/wizard-helpers.ts'), 'utf8');
+const transpiled = ts.transpileModule(helperSource, {
+  compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ESNext },
+}).outputText;
+const helperPath = resolve(tmpdir(), 'rms-wizard-page-type-harness.mjs');
+writeFileSync(helperPath, transpiled);
+const { buildGeneratePagePayloadItem, sanitizeWizardPageType } = await import('file:///' + helperPath.replace(/\\/g, '/'));
+
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+let passed = 0;
+
+const ui = buildGeneratePagePayloadItem({
+  slug: 'about-us',
+  title: 'About Us',
+  role: '',
+  type: 'about',
+});
+assert(ui.type === 'about' && ui.slug === 'about-us' && ui.generate === true, 'UI item must send type about with custom slug');
+console.log('PASS client-explicit-type-custom-slug');
+passed += 1;
+
+const noType = buildGeneratePagePayloadItem({ slug: 'about', title: 'About', role: '' });
+assert(!Object.prototype.hasOwnProperty.call(noType, 'type'), 'missing type must not be inferred from slug');
+console.log('PASS client-no-slug-inference');
+passed += 1;
+
+assert(sanitizeWizardPageType('../header') === 'header', 'path traversal must not survive as a type');
+assert(sanitizeWizardPageType('About') === 'about', 'catalog type is lowercased');
+console.log('PASS client-type-sanitized');
+passed += 1;
+
+const wizardSource = readFileSync(resolve(themeRoot, 'src/ts/admin/wizard.ts'), 'utf8');
+assert(wizardSource.includes('buildGeneratePagePayloadItem'), 'wizard.ts must serialize pages through the helper');
+assert(wizardSource.includes('dataset.wizardPageType'), 'wizard.ts must read immutable row type, not slug');
+assert(!/pages\[slug\]\s*=\s*\{\s*slug,\s*title:\s*rawTitle/.test(wizardSource), 'payload must not omit type');
+console.log('PASS client-wizard-reads-row-type');
+passed += 1;
+
+const initSource = readFileSync(resolve(themeRoot, 'inc/wizard/wizard-init.php'), 'utf8');
+assert(initSource.includes("'type'        => $slug"), 'common pages JSON must include immutable type');
+assert(initSource.includes('data-wizard-page-type'), 'row markup must store type off the slug inputs');
+console.log('PASS client-markup-type-identity');
+passed += 1;
+
+console.log(`Harness passed: ${passed} scenarios.`);

--- a/tests/wizard-page-type-contract-harness.php
+++ b/tests/wizard-page-type-contract-harness.php
@@ -100,15 +100,16 @@ $custom = $sel->invoke(
 	$gp,
 	array(
 		'pages' => array(
-			'our-story' => array(
-				'slug'     => 'our-story',
-				'title'    => 'Our Story',
+			'our-company' => array(
+				'type'     => 'about',
+				'slug'     => 'our-company',
+				'title'    => 'Our Company',
 				'generate' => true,
 			),
 		),
 	)
 );
-rms_type_assert( isset( $custom['our-story'] ) && '' === $custom['our-story']['type'], 'custom page has empty type' );
-echo "PASS custom-page-empty-type\n";
+rms_type_assert( isset( $custom['our-company'] ) && 'about' === $custom['our-company']['type'], 'our-company keeps about type' );
+echo "PASS our-company-explicit-about-type\n";
 
-echo "Harness passed: 5 scenarios.\n";
+echo "Harness passed: 6 scenarios.\n";

--- a/tests/wizard-page-type-contract-harness.php
+++ b/tests/wizard-page-type-contract-harness.php
@@ -112,4 +112,4 @@ $custom = $sel->invoke(
 rms_type_assert( isset( $custom['our-company'] ) && 'about' === $custom['our-company']['type'], 'our-company keeps about type' );
 echo "PASS our-company-explicit-about-type\n";
 
-echo "Harness passed: 6 scenarios.\n";
+echo "Harness passed: 5 scenarios.\n";

--- a/tests/wizard-page-type-contract-harness.php
+++ b/tests/wizard-page-type-contract-harness.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Generate Pages page-type identity contract.
+ *
+ * Usage: php tests/wizard-page-type-contract-harness.php
+ */
+
+if ( PHP_SAPI !== 'cli' ) {
+	fwrite( STDERR, "CLI only.\n" );
+	exit( 1 );
+}
+
+$theme_root = dirname( __DIR__ );
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', $theme_root . '/' );
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( $t, $d = null ) { unset( $d ); return $t; }
+}
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $v ) { return strtolower( preg_replace( '/[^a-z0-9-]+/', '-', (string) $v ) ); }
+}
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $s ) { return trim( (string) $s ); }
+}
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $k ) { return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $k ) ) ); }
+}
+
+if ( ! class_exists( 'Inc\\Wizard\\Logger', false ) ) {
+	eval( 'namespace Inc\\Wizard; class Logger { public function log( $l = "", $m = "", $c = array() ) {} } class State_Manager {} class Content_Builder { public function __construct( $a = null, $b = null ) {} }' );
+}
+
+require_once $theme_root . '/inc/wizard/class-step-generate-pages.php';
+
+function rms_type_assert( $c, string $m ): void {
+	if ( ! $c ) {
+		fwrite( STDERR, $m . "\n" );
+		exit( 1 );
+	}
+}
+
+$gp  = new \Inc\Wizard\Step_Generate_Pages( new \Inc\Wizard\Logger(), new \Inc\Wizard\State_Manager(), new \Inc\Wizard\Content_Builder() );
+$sel = new ReflectionMethod( \Inc\Wizard\Step_Generate_Pages::class, 'selected_pages' );
+$sel->setAccessible( true );
+
+$ui = $sel->invoke(
+	$gp,
+	array(
+		'pages' => array(
+			'about-us' => array(
+				'type'     => 'about',
+				'slug'     => 'about-us',
+				'title'    => 'About Us',
+				'generate' => true,
+				'role'     => '',
+			),
+		),
+	)
+);
+rms_type_assert( isset( $ui['about-us'] ) && 'about' === $ui['about-us']['type'], 'UI payload keeps about type' );
+echo "PASS ui-explicit-type-custom-slug\n";
+
+$tampered = $sel->invoke(
+	$gp,
+	array(
+		'pages' => array(
+			'about-us' => array(
+				'type'     => '../header',
+				'slug'     => 'about-us',
+				'title'    => 'About Us',
+				'generate' => true,
+			),
+		),
+	)
+);
+rms_type_assert( isset( $tampered['about-us'] ) && '' === $tampered['about-us']['type'], 'unknown type ignored' );
+echo "PASS unknown-type-ignored\n";
+
+$legacy = $sel->invoke(
+	$gp,
+	array(
+		'pages' => array(
+			'about' => array(
+				'slug'  => 'about-us',
+				'title' => 'About Us',
+			),
+		),
+	)
+);
+rms_type_assert( isset( $legacy['about-us'] ) && 'about' === $legacy['about-us']['type'], 'legacy key still maps about' );
+echo "PASS legacy-key-fallback\n";
+
+$default = $sel->invoke( $gp, array( 'pages' => array( 'services' => true ) ) );
+rms_type_assert( isset( $default['services'] ) && 'services' === $default['services']['type'], 'legacy slug catalog key' );
+echo "PASS legacy-slug-catalog\n";
+
+$custom = $sel->invoke(
+	$gp,
+	array(
+		'pages' => array(
+			'our-story' => array(
+				'slug'     => 'our-story',
+				'title'    => 'Our Story',
+				'generate' => true,
+			),
+		),
+	)
+);
+rms_type_assert( isset( $custom['our-story'] ) && '' === $custom['our-story']['type'], 'custom page has empty type' );
+echo "PASS custom-page-empty-type\n";
+
+echo "Harness passed: 5 scenarios.\n";


### PR DESCRIPTION
Closes #42

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Three coherent commits keep page **type** stable when the user customizes a slug: UI identity → Generate Pages state → About builder lookup.
- `f9dcc21` carries catalog/DOM type through the client and PHP contract. `7d8a6e0` persists `type` on `generated_pages` and locates About by `type===about`. `f697772` aligns the contract harness count (5/5).
- Custom slug `our-company` with `type:about` is stored and built. Unknown typed rows are not slug-coerced. Legacy `about` / `about-us` without type still match.

## Changes

| File | Change |
|------|--------|
| `inc/wizard/wizard-init.php` | Immutable `data-wizard-page-type` on Generate Pages rows. |
| `src/ts/admin/wizard-helpers.ts` | Client reads/sanitizes row type; no slug inference. |
| `src/ts/admin/wizard.ts` | Submit payload uses the row type, not the edited slug. |
| `inc/wizard/class-step-generate-pages.php` | `resolve_page_type()` prefers explicit catalog type; persists `type` on `generated_pages`. |
| `inc/wizard/class-step-internal-page-builder.php` | `find_about_shell()` prefers `type===about`; unknown types are not coerced. |
| `tests/wizard-page-type-client-harness.mjs` | 5 client identity scenarios. |
| `tests/wizard-page-type-contract-harness.php` | 5 PHP contract scenarios. |
| `tests/wizard-internal-page-builder-harness.php` | Adds generate/build by type, unknown-type, and legacy alias (13/13). |

## Test Plan
- [x] `npx tsc --noEmit` — exit 0.
- [x] `php -l` generate-pages, internal builder, wizard-init, contract harness, builder harness — no syntax errors, PHP 8.2.29.
- [x] `node tests/wizard-page-type-client-harness.mjs` — **5/5 pass**.
- [x] `php tests/wizard-page-type-contract-harness.php` — **5/5 pass**.
- [x] `php tests/wizard-internal-page-builder-harness.php` — **13/13 pass**.
- [x] Three-dot diff against updated tracker `feat/internal-page-builder` is exactly these 8 files (**+292 / −14 = 306 / 400**). No OpenSpec.
- [x] Scripts run without errors: N/A — no shell scripts in this PR.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts: N/A — no shell scripts
- [x] Skills tested in at least one agent: N/A — wizard domain feature, not a skill change
- [x] Docs updated if behavior changed: OpenSpec progress is on tracker #43; no public UI copy change
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Chain Context

| Field | Value |
|-------|-------|
| Chain | wizard-internal-page-builder |
| Tracker PR | #43 `feat/internal-page-builder` (draft, no-merge) |
| Position | 4A of 8 (stable page types) |
| Base | `feat/internal-page-builder` |
| Depends on | Tracker #43 / merged PR1 #44 / merged PR2A–PR2C #45–#47 / merged PR3A–PR3C #48–#50 / approved issue #42 |
| Follow-up | PR4B #52 `feat/internal-page-template-rendering` (this publish) |
| Review budget | 306 / 400 |
| Starts at | Tracker ancestor `feat/internal-page-builder` @ `4ae9ced` |
| Ends with | UI→state→builder type contract; custom slugs keep catalog identity |

### Chain Overview

```text
main
 └── #43 feat/internal-page-builder  (draft tracker, no-merge)
      └── #44 PR1 feat/internal-page-blueprints  (merged)
           └── #45–#47 PR2A–PR2C section assembler  (merged)
                └── #48–#50 PR3A–PR3C About backend  (merged)
                     └── 📍 #51 PR4A feat/wizard-stable-page-types
                          └── #52 PR4B feat/internal-page-template-rendering
                               └── PR5+ later Internal Builder phases (out of scope)
```

### Scope
- Includes: immutable page-type identity in Generate Pages UI/client, PHP type resolution, `generated_pages.type`, About shell lookup by type, and the 5/5 + 13/13 proofs.
- Excludes: template rendering, Testimonials/Blog templates, remaining backends, controller/dispatch/UI, later phases.
- Tracker #43 remains draft/no-merge.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit

### Rollback
Revert `f697772`, then `7d8a6e0`, then `f9dcc21`. Template rendering is not in this slice.
