### PR TITLE
feat(theme): render internal page sections

### DIFF
--- a/inc/wizard/class-content-builder.php
+++ b/inc/wizard/class-content-builder.php
@@ -108,10 +108,12 @@ class Content_Builder {
 			return 0;
 		}
 
-		$post_id  = (int) $result;
-		$sections = $this->prepare_sections( is_array( $page['sections'] ?? null ) ? $page['sections'] : [] );
+		$post_id = (int) $result;
 
-		$this->save_page_sections( $post_id, $sections );
+		if ( array_key_exists( 'sections', $page ) ) {
+			$sections = $this->prepare_sections( is_array( $page['sections'] ) ? $page['sections'] : [] );
+			$this->save_page_sections( $post_id, $sections );
+		}
 
 		if ( is_array( $page['seo'] ?? null ) ) {
 			$this->yoast_meta_writer->write( $post_id, $page['seo'] );

--- a/inc/wizard/class-internal-page-blueprints.php
+++ b/inc/wizard/class-internal-page-blueprints.php
@@ -14,14 +14,6 @@ defined( 'ABSPATH' ) || exit;
  */
 final class Internal_Page_Blueprints {
 	/**
-	 * Return the fixed blueprint map keyed by page type.
-	 *
-	 * PAGE_PROJECTS and PAGE_TESTIMONIALS are string identifiers until the harness
-	 * defines those constants. Existing types use AI_Content_Harness page-type constants.
-	 *
-	 * @return array<string,array{template:string,layouts:array<int,string>,page_type:string,canonical:string}>
-	 */
-	/**
 	 * Page types whose `_wp_page_template` may be assigned at Generate Pages shell creation.
 	 * Testimonials wait for Phase 5 template repair; Blog waits for Phase 6 `home.php`.
 	 *
@@ -31,6 +23,14 @@ final class Internal_Page_Blueprints {
 		return [ 'about', 'services', 'contact', 'projects' ];
 	}
 
+	/**
+	 * Return the fixed blueprint map keyed by page type.
+	 *
+	 * PAGE_PROJECTS and PAGE_TESTIMONIALS are string identifiers until the harness
+	 * defines those constants. Existing types use AI_Content_Harness page-type constants.
+	 *
+	 * @return array<string,array{template:string,layouts:array<int,string>,page_type:string,canonical:string}>
+	 */
 	public static function all(): array {
 		return [
 			'about'         => [

--- a/inc/wizard/class-internal-page-blueprints.php
+++ b/inc/wizard/class-internal-page-blueprints.php
@@ -21,6 +21,16 @@ final class Internal_Page_Blueprints {
 	 *
 	 * @return array<string,array{template:string,layouts:array<int,string>,page_type:string,canonical:string}>
 	 */
+	/**
+	 * Page types whose `_wp_page_template` may be assigned at Generate Pages shell creation.
+	 * Testimonials wait for Phase 5 template repair; Blog waits for Phase 6 `home.php`.
+	 *
+	 * @return string[]
+	 */
+	public static function shell_ready_types(): array {
+		return [ 'about', 'services', 'contact', 'projects' ];
+	}
+
 	public static function all(): array {
 		return [
 			'about'         => [

--- a/inc/wizard/class-step-generate-pages.php
+++ b/inc/wizard/class-step-generate-pages.php
@@ -9,6 +9,8 @@ namespace Inc\Wizard;
 
 defined( 'ABSPATH' ) || exit;
 
+require_once __DIR__ . '/class-internal-page-blueprints.php';
+
 /**
  * Creates the wizard-selected pages and stores Home/Blog assignments.
  */
@@ -82,15 +84,23 @@ class Step_Generate_Pages {
 				return $this->landing_slug_conflict_error( $slug, (int) $existing->ID );
 			}
 
-			$post_id = $this->content_builder->build_page(
-				[
-					'id'      => $existing ? (int) $existing->ID : 0,
-					'title'   => $page['title'],
-					'slug'    => $slug,
-					'status'  => 'publish',
-					'content' => $this->generate_page_content( $page['title'], $slug, $client_data, $ai_config ),
-				]
-			);
+			$page_def = [
+				'id'      => $existing ? (int) $existing->ID : 0,
+				'title'   => $page['title'],
+				'slug'    => $slug,
+				'status'  => 'publish',
+				'content' => $this->generate_page_content( $page['title'], $slug, $client_data, $ai_config ),
+			];
+
+			$type      = \sanitize_title( (string) ( $page['type'] ?? '' ) );
+			$blueprint = $this->shell_blueprint( $type );
+			if ( is_array( $blueprint ) && ! empty( $blueprint['template'] ) ) {
+				$page_def['meta_input'] = [
+					'_wp_page_template' => (string) $blueprint['template'],
+				];
+			}
+
+			$post_id = $this->content_builder->build_page( $page_def );
 
 			if ( $post_id <= 0 ) {
 				$this->state_manager->set_step_status( self::STEP, 'failed' );
@@ -440,6 +450,21 @@ class Step_Generate_Pages {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Blueprint used at shell creation, or null when the type is not shell-ready.
+	 *
+	 * @return array{template:string,layouts:array<int,string>,page_type:string,canonical:string}|null
+	 */
+	private function shell_blueprint( string $type ) {
+		if ( ! in_array( $type, Internal_Page_Blueprints::shell_ready_types(), true ) ) {
+			return null;
+		}
+
+		$all = Internal_Page_Blueprints::all();
+
+		return is_array( $all[ $type ] ?? null ) ? $all[ $type ] : null;
 	}
 
 	private function available_pages(): array {

--- a/pages/about-us.php
+++ b/pages/about-us.php
@@ -1,12 +1,13 @@
 <?php
-/*
+/**
  * Template Name: About Us
+ *
+ * @package Simple_RMS_Theme
  */
 
-get_header(); ?>
+get_header();
 
-<?php get_template_part( 'templates/breadcrumb' ); ?>
-<?php get_template_part('templates/about-us');?>
-<?php get_template_part('templates/vision-mission-v2');?>
+get_template_part( 'templates/breadcrumb' );
+get_template_part( 'templates/page-sections-loop' );
 
-<?php get_footer(); ?>
+get_footer();

--- a/pages/contact-us.php
+++ b/pages/contact-us.php
@@ -1,12 +1,14 @@
 <?php
-/*
+/**
  * Template Name: Contact Us
+ *
+ * @package Simple_RMS_Theme
  */
 
 get_header();
 
-get_template_part('templates/breadcrumb');
-get_template_part('templates/contact-info');
-get_template_part('templates/contact-map');
+get_template_part( 'templates/breadcrumb' );
+get_template_part( 'templates/page-sections-loop' );
+get_template_part( 'templates/contact-map' );
 
 get_footer();

--- a/pages/projects.php
+++ b/pages/projects.php
@@ -1,12 +1,13 @@
 <?php
-/*
+/**
  * Template Name: Project / Gallery
+ *
+ * @package Simple_RMS_Theme
  */
 
 get_header();
-?>
 
-<?php get_template_part('templates/breadcrumb'); ?>
-<?php get_template_part('templates/gallery-grid'); ?>
+get_template_part( 'templates/breadcrumb' );
+get_template_part( 'templates/page-sections-loop' );
 
-<?php get_footer(); ?>
+get_footer();

--- a/pages/services.php
+++ b/pages/services.php
@@ -1,13 +1,13 @@
 <?php
-/*
+/**
  * Template Name: Services
+ *
+ * @package Simple_RMS_Theme
  */
 
 get_header();
-?>
 
-<?php get_template_part('templates/breadcrumb'); ?>
-<?php get_template_part('templates/services-page'); ?>
-<?php get_template_part('templates/cta-v2'); ?>
+get_template_part( 'templates/breadcrumb' );
+get_template_part( 'templates/page-sections-loop' );
 
-<?php get_footer(); ?>
+get_footer();

--- a/templates/page-sections-loop.php
+++ b/templates/page-sections-loop.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Shared flexible `page_sections` loop for wizard internal pages.
+ *
+ * @package Simple_RMS_Theme
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$acf_available = function_exists( 'have_rows' )
+	&& function_exists( 'the_row' )
+	&& function_exists( 'get_row_layout' )
+	&& function_exists( 'get_sub_field' );
+
+if ( ! $acf_available ) {
+	if ( function_exists( 'have_posts' ) && have_posts() ) {
+		echo '<main id="main" class="internal-page internal-page--acf-missing">';
+		while ( have_posts() ) {
+			the_post();
+			echo '<article class="internal-page__article">';
+			echo '<header class="internal-page__header"><h1 class="internal-page__title">' . esc_html( get_the_title() ) . '</h1></header>';
+			echo '<div class="internal-page__content entry-content">';
+			if ( function_exists( 'the_content' ) ) {
+				the_content();
+			}
+			echo '</div></article>';
+		}
+		echo '</main>';
+	}
+	return;
+}
+
+if ( ! have_rows( 'page_sections' ) ) {
+	return;
+}
+
+while ( have_rows( 'page_sections' ) ) {
+	the_row();
+	$layout = get_row_layout();
+
+	// Theme layout ids are kebab-case (`about-us`, `cta-v2`). Reject traversal before locate.
+	if ( ! is_string( $layout ) || 1 !== preg_match( '/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $layout ) ) {
+		continue;
+	}
+
+	$slug = 'templates/' . $layout;
+	if ( function_exists( 'locate_template' ) && '' === locate_template( array( $slug . '.php' ), false, false ) ) {
+		continue;
+	}
+
+	get_template_part( $slug );
+}

--- a/tests/wizard-internal-page-templates-harness.php
+++ b/tests/wizard-internal-page-templates-harness.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * Internal page flexible-loop and shell-template proofs.
+ *
+ * Usage: php tests/wizard-internal-page-templates-harness.php
+ */
+
+if ( PHP_SAPI !== 'cli' ) {
+	fwrite( STDERR, "CLI only.\n" );
+	exit( 1 );
+}
+
+$theme_root = dirname( __DIR__ );
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', $theme_root . '/' );
+}
+
+$GLOBALS['rms_loop_rows']    = array();
+$GLOBALS['rms_loop_index']   = 0;
+$GLOBALS['rms_loop_started'] = false;
+$GLOBALS['rms_parts']        = array();
+$GLOBALS['rms_build_pages']  = array();
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $t ) { return htmlspecialchars( (string) $t, ENT_QUOTES, 'UTF-8' ); }
+}
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $v ) { return strtolower( preg_replace( '/[^a-z0-9-]+/', '-', (string) $v ) ); }
+}
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $s ) { return trim( (string) $s ); }
+}
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $k ) { return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $k ) ) ); }
+}
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $v ) { return abs( (int) $v ); }
+}
+if ( ! function_exists( 'locate_template' ) ) {
+	function locate_template( $templates, $load = false, $require_once = true ) {
+		unset( $load, $require_once );
+		foreach ( is_array( $templates ) ? $templates : array( $templates ) as $rel ) {
+			$path = dirname( __DIR__ ) . '/' . ltrim( (string) $rel, '/' );
+			if ( is_readable( $path ) ) { return $path; }
+		}
+		return '';
+	}
+}
+if ( ! function_exists( 'get_template_part' ) ) { function get_template_part( $slug, $name = null ) { unset( $name ); $GLOBALS['rms_parts'][] = $slug; } }
+if ( ! function_exists( 'have_rows' ) ) {
+	function have_rows( $selector, $post_id = false ) {
+		unset( $post_id );
+		if ( 'page_sections' !== $selector ) { return false; }
+		return $GLOBALS['rms_loop_started'] ? $GLOBALS['rms_loop_index'] < count( $GLOBALS['rms_loop_rows'] ) : count( $GLOBALS['rms_loop_rows'] ) > 0;
+	}
+}
+if ( ! function_exists( 'the_row' ) ) { function the_row() { $GLOBALS['rms_loop_started'] = true; $GLOBALS['rms_loop_index']++; return true; } }
+if ( ! function_exists( 'get_row_layout' ) ) { function get_row_layout() { return (string) ( $GLOBALS['rms_loop_rows'][ $GLOBALS['rms_loop_index'] - 1 ] ?? '' ); } }
+if ( ! function_exists( 'get_sub_field' ) ) { function get_sub_field( $selector, $format_value = true ) { unset( $selector, $format_value ); return null; } }
+
+function rms_tpl_assert( $c, string $m ): void {
+	if ( ! $c ) {
+		fwrite( STDERR, $m . "\n" );
+		exit( 1 );
+	}
+}
+
+function rms_tpl_run_loop( array $rows ): array {
+	$GLOBALS['rms_loop_rows']    = $rows;
+	$GLOBALS['rms_loop_index']   = 0;
+	$GLOBALS['rms_loop_started'] = false;
+	$GLOBALS['rms_parts']        = array();
+	require dirname( __DIR__ ) . '/templates/page-sections-loop.php';
+	return $GLOBALS['rms_parts'];
+}
+
+$passed = 0;
+
+$ordered = rms_tpl_run_loop( array( 'about-us', 'vision-mission-v2', 'cta-v2' ) );
+rms_tpl_assert( array( 'templates/about-us', 'templates/vision-mission-v2', 'templates/cta-v2' ) === $ordered, 'rows render in stored order' );
+echo "PASS stored-sections-render-in-order\n";
+++$passed;
+
+$skipped = rms_tpl_run_loop( array( 'about-us', 'not-a-real-layout', 'cta-v2' ) );
+rms_tpl_assert( array( 'templates/about-us', 'templates/cta-v2' ) === $skipped, 'unknown layout skipped' );
+echo "PASS unknown-layout-skipped-safely\n";
+++$passed;
+
+foreach ( array( '../header', '..\\header', 'templates/hero', 'about.us', 'about_us', '..', 'header.php' ) as $bad ) {
+	$parts = rms_tpl_run_loop( array( 'about-us', $bad, 'cta-v2' ) );
+	rms_tpl_assert( array( 'templates/about-us', 'templates/cta-v2' ) === $parts, 'rejected layout: ' . $bad );
+}
+echo "PASS traversal-and-malformed-layouts-rejected\n";
+++$passed;
+
+$empty = rms_tpl_run_loop( array() );
+rms_tpl_assert( array() === $empty, 'empty sections emit no parts' );
+echo "PASS empty-sections-no-error\n";
+++$passed;
+
+$services = file_get_contents( dirname( __DIR__ ) . '/pages/services.php' );
+rms_tpl_assert( is_string( $services ) && false === strpos( $services, 'services-page' ), 'services does not use services-page' );
+rms_tpl_assert( false !== strpos( $services, 'page-sections-loop' ), 'services uses loop' );
+echo "PASS services-independent-of-static-demo\n";
+++$passed;
+
+$contact = file_get_contents( dirname( __DIR__ ) . '/pages/contact-us.php' );
+rms_tpl_assert( is_string( $contact ) && false !== strpos( $contact, 'page-sections-loop' ), 'contact uses loop' );
+rms_tpl_assert( false !== strpos( $contact, 'contact-map' ), 'contact keeps map chrome' );
+$loop_pos = strpos( $contact, 'page-sections-loop' );
+$map_pos  = strpos( $contact, 'contact-map' );
+rms_tpl_assert( false !== $loop_pos && false !== $map_pos && $loop_pos < $map_pos, 'map chrome after loop' );
+echo "PASS contact-map-chrome-outside-loop\n";
+++$passed;
+
+$projects = file_get_contents( dirname( __DIR__ ) . '/pages/projects.php' );
+rms_tpl_assert( is_string( $projects ) && false !== strpos( $projects, 'page-sections-loop' ), 'projects uses loop' );
+rms_tpl_assert( false === strpos( $projects, 'gallery-grid' ), 'projects does not hardcode gallery-grid' );
+echo "PASS projects-uses-flexible-loop\n";
+++$passed;
+
+require_once dirname( __DIR__ ) . '/inc/wizard/class-internal-page-blueprints.php';
+require_once dirname( __DIR__ ) . '/inc/wizard/class-ai-content-harness.php';
+$all = \Inc\Wizard\Internal_Page_Blueprints::all();
+rms_tpl_assert( 'pages/about-us.php' === $all['about']['template'], 'about registry template' );
+rms_tpl_assert( 'pages/services.php' === $all['services']['template'], 'services registry template' );
+rms_tpl_assert( array( 'services-v1', 'cta-v2' ) === $all['services']['layouts'], 'services layouts' );
+rms_tpl_assert( 'pages/contact-us.php' === $all['contact']['template'], 'contact registry template' );
+rms_tpl_assert( 'pages/projects.php' === $all['projects']['template'], 'projects registry template' );
+$ready = \Inc\Wizard\Internal_Page_Blueprints::shell_ready_types();
+rms_tpl_assert( array( 'about', 'services', 'contact', 'projects' ) === $ready && ! in_array( 'testimonials', $ready, true ) && ! in_array( 'blog', $ready, true ), 'shell-ready types' );
+echo "PASS blueprint-templates-and-shell-ready\n";
+++$passed;
+
+if ( ! class_exists( 'WP_Error', false ) ) {
+	class WP_Error {
+		public $code; public $message; public $data;
+		public function __construct( $c = '', $m = '', $d = '' ) { $this->code = $c; $this->message = $m; $this->data = $d; }
+		public function get_error_message() { return $this->message; }
+	}
+}
+if ( ! defined( 'OBJECT' ) ) { define( 'OBJECT', 'OBJECT' ); }
+foreach ( array(
+	'get_option' => static function ( $n, $d = false ) { return $GLOBALS['_options'][ $n ] ?? $d; },
+	'update_option' => static function ( $n, $v, $a = null ) { unset( $a ); $GLOBALS['_options'][ $n ] = $v; return true; },
+	'current_time' => static function ( $t, $g = false ) { unset( $t, $g ); return '2026-08-26 00:00:00'; },
+	'wp_kses_post' => static function ( $v ) { return (string) $v; },
+	'__' => static function ( $t, $d = null ) { unset( $d ); return $t; },
+	'is_wp_error' => static function ( $t ) { return $t instanceof WP_Error; },
+	'get_page_by_path' => static function ( $s, $o = null, $ty = 'page' ) { unset( $s, $o, $ty ); return null; },
+	'get_posts' => static function ( $a = array() ) { unset( $a ); return array(); },
+	'get_post' => static function ( $id ) { return $GLOBALS['_posts'][ (int) $id ] ?? null; },
+	'get_post_meta' => static function ( $id, $k, $s = false ) { unset( $s ); return $GLOBALS['_post_meta'][ (int) $id ][ $k ] ?? ''; },
+	'wp_update_post' => static function ( $data, $e = false ) { unset( $e ); return (int) ( $data['ID'] ?? 0 ); },
+	'wp_insert_post' => static function ( $d, $e = false ) { unset( $d, $e ); return 21; },
+) as $fn => $cb ) {
+	if ( ! function_exists( $fn ) ) {
+		eval( 'function ' . $fn . '() { return call_user_func_array( $GLOBALS["rms_fn"][' . var_export( $fn, true ) . '], func_get_args() ); }' );
+		$GLOBALS['rms_fn'][ $fn ] = $cb;
+	}
+}
+if ( ! function_exists( 'update_post_meta' ) ) {
+	function update_post_meta( $id, $k, $v ) {
+		$GLOBALS['rms_meta_writes'][] = $k;
+		$GLOBALS['_post_meta'][ (int) $id ][ $k ] = $v;
+		return true;
+	}
+}
+
+$GLOBALS['_options'] = $GLOBALS['_posts'] = $GLOBALS['_post_meta'] = array();
+$GLOBALS['rms_meta_writes'] = array();
+foreach ( array( 'class-logger.php', 'class-state-manager.php', 'class-yoast-meta-writer.php', 'class-content-builder.php', 'class-step-generate-pages.php' ) as $f ) {
+	require_once dirname( __DIR__ ) . '/inc/wizard/' . $f;
+}
+
+$logger = new \Inc\Wizard\Logger();
+$sm     = new \Inc\Wizard\State_Manager();
+$GLOBALS['_posts'][21] = (object) array( 'ID' => 21, 'post_type' => 'page', 'post_title' => 'About', 'post_name' => 'about', 'post_status' => 'publish', 'post_content' => '' );
+$GLOBALS['_post_meta'][21]['page_sections'] = array( array( 'acf_fc_layout' => 'about-us', 'about_headline' => 'Keep me' ) );
+( new \Inc\Wizard\Content_Builder( $logger, $sm ) )->build_page( array( 'id' => 21, 'title' => 'About', 'slug' => 'about' ) );
+rms_tpl_assert( ! in_array( 'page_sections', $GLOBALS['rms_meta_writes'], true ) && 'Keep me' === ( $GLOBALS['_post_meta'][21]['page_sections'][0]['about_headline'] ?? '' ), 'no section save' );
+echo "PASS content-builder-skips-section-save\n";
+++$passed;
+
+class RMS_Gen_Spy_Builder extends \Inc\Wizard\Content_Builder {
+	public $calls = array();
+	public function build_page( array $page ): int {
+		$this->calls[] = $page;
+		return absint( $page['id'] ?? 0 ) ?: 12;
+	}
+}
+$spy = new RMS_Gen_Spy_Builder( $logger, $sm );
+$gp  = new \Inc\Wizard\Step_Generate_Pages( $logger, $sm, $spy );
+$sel = new ReflectionMethod( \Inc\Wizard\Step_Generate_Pages::class, 'selected_pages' );
+$sel->setAccessible( true );
+$picked = $sel->invoke( $gp, array( 'pages' => array( 'about-us' => array( 'type' => 'about', 'slug' => 'about-us', 'title' => 'About Us', 'generate' => true ) ) ) );
+rms_tpl_assert( isset( $picked['about-us'] ) && 'about' === ( $picked['about-us']['type'] ?? '' ), 'UI payload keeps about type' );
+echo "PASS generate-pages-explicit-type-custom-slug\n";
+++$passed;
+
+$result = $gp->run( array( 'pages' => array( 'home' => array( 'type' => 'home', 'slug' => 'home', 'title' => 'Home', 'role' => 'home', 'generate' => true ), 'about-us' => array( 'type' => 'about', 'slug' => 'about-us', 'title' => 'About Us', 'generate' => true ), 'testimonials' => array( 'type' => 'testimonials', 'slug' => 'testimonials', 'title' => 'Testimonials', 'generate' => true ), 'blog' => array( 'type' => 'blog', 'slug' => 'blog', 'title' => 'Blog', 'role' => 'blog', 'generate' => true ) ), 'confirm_cleanup' => true ) );
+rms_tpl_assert( ! is_wp_error( $result ), 'generate-pages run succeeds' );
+$by_slug = array();
+foreach ( $spy->calls as $call ) { $by_slug[ (string) ( $call['slug'] ?? '' ) ] = $call; }
+rms_tpl_assert( 'pages/about-us.php' === ( $by_slug['about-us']['meta_input']['_wp_page_template'] ?? '' ), 'about-us slug gets About template' );
+rms_tpl_assert( ! isset( $by_slug['about-us']['sections'] ), 'about shell has no sections key' );
+rms_tpl_assert( ! isset( $by_slug['testimonials']['meta_input']['_wp_page_template'] ) && ! isset( $by_slug['blog']['meta_input']['_wp_page_template'] ) && ! isset( $by_slug['home']['meta_input']['_wp_page_template'] ), 'deferred and unblueprinted' );
+echo "PASS generate-pages-runtime-template-and-no-sections\n";
+++$passed;
+
+echo 'Harness passed: ' . $passed . " scenarios.\n";


### PR DESCRIPTION
Closes #42

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Two commits render stored flexible sections on About/Services/Contact/Projects without wiping existing `page_sections`.
- `b3c2b17` adds `templates/page-sections-loop.php`, converts the four page templates, assigns blueprint `_wp_page_template` at Generate Pages shell creation, and skips section writes there.
- `42dc3f1` restores the `all()` docblock and keeps `shell_ready_types()` for About/Services/Contact/Projects only. Testimonials and Blog stay deferred.

## Changes

| File | Change |
|------|--------|
| `templates/page-sections-loop.php` | Shared loop: ordered layouts, unknown skipped, traversal/malformed rejected before locate. |
| `pages/about-us.php` | Uses the shared loop. |
| `pages/services.php` | Uses the shared loop; independent of static demo markup. |
| `pages/contact-us.php` | Uses the shared loop; map chrome stays outside the loop. |
| `pages/projects.php` | Uses the shared loop. |
| `inc/wizard/class-internal-page-blueprints.php` | `shell_ready_types()`; `all()` docblock restored on `all()`. |
| `inc/wizard/class-step-generate-pages.php` | Assigns blueprint `_wp_page_template` for shell-ready types only. |
| `inc/wizard/class-content-builder.php` | Generate Pages path does not save/wipe `page_sections`. |
| `tests/wizard-internal-page-templates-harness.php` | 11-scenario render/template/shell harness. |

## Test Plan
- [x] `php -l` loop, 4 templates, generate-pages, content-builder, blueprints, template harness — no syntax errors, PHP 8.2.29.
- [x] `php tests/wizard-internal-page-templates-harness.php` — **11/11 pass**.
- [x] `php tests/acf-inactive-frontend-harness.php` — **11/11 pass**.
- [x] `php tests/wizard-home-seo-targeting-harness.php` — **9/9 pass**.
- [x] `php tests/wizard-integration-truth-harness.php` — **8/8 pass**.
- [x] `php scripts/test-landing-run-orchestrator.php` — **293 passed, 0 failed**.
- [x] Three-dot diff against `feat/wizard-stable-page-types` is exactly these 9 files (**+337 / −33 = 370 / 400**). No OpenSpec.
- [x] Scripts run without errors: N/A — no shell scripts in this PR.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts: N/A — no shell scripts
- [x] Skills tested in at least one agent: N/A — wizard domain feature, not a skill change
- [x] Docs updated if behavior changed: OpenSpec progress is on tracker #43; `all()` / `shell_ready_types()` docblocks only
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Chain Context

| Field | Value |
|-------|-------|
| Chain | wizard-internal-page-builder |
| Tracker PR | #43 `feat/internal-page-builder` (draft, no-merge) |
| Position | 4B of 8 (internal page template rendering) |
| Base | `feat/wizard-stable-page-types` |
| Depends on | PR4A #51 `feat/wizard-stable-page-types` / tracker #43 / merged PR1–PR3C #44–#50 / approved issue #42 |
| Follow-up | PR5 remaining backends + Testimonials (out of this publish) |
| Review budget | 370 / 400 |
| Starts at | PR4A `feat/wizard-stable-page-types` @ `f697772` |
| Ends with | Shared section loop + shell-ready template assignment; no section wipe |

### Chain Overview

```text
main
 └── #43 feat/internal-page-builder  (draft tracker, no-merge)
      └── #44 PR1 feat/internal-page-blueprints  (merged)
           └── #45–#47 PR2A–PR2C section assembler  (merged)
                └── #48–#50 PR3A–PR3C About backend  (merged)
                     └── #51 PR4A feat/wizard-stable-page-types
                          └── 📍 #52 PR4B feat/internal-page-template-rendering
                               └── PR5+ later Internal Builder phases (out of scope)
```

### Scope
- Includes: shared loop partial, four page templates, shell-ready `_wp_page_template` assignment, no Generate Pages section writes, traversal protection, 11-scenario harness.
- Excludes: Testimonials/Blog template assignment, remaining backends, controller/dispatch/UI, later phases.
- Placeholders stay unmarked. Nothing is hidden and completion is not blocked.
- Tracker #43 remains draft/no-merge.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit

### Rollback
Revert `42dc3f1` then `b3c2b17`. Stable page-type identity stays on PR4A.
