### PR TITLE
feat(wizard): build remaining internal page types

### DIFF
--- a/inc/wizard/class-internal-page-blueprints.php
+++ b/inc/wizard/class-internal-page-blueprints.php
@@ -15,12 +15,12 @@ defined( 'ABSPATH' ) || exit;
 final class Internal_Page_Blueprints {
 	/**
 	 * Page types whose `_wp_page_template` may be assigned at Generate Pages shell creation.
-	 * Testimonials wait for Phase 5 template repair; Blog waits for Phase 6 `home.php`.
+	 * Blog waits for Phase 6 `home.php`.
 	 *
 	 * @return string[]
 	 */
 	public static function shell_ready_types(): array {
-		return [ 'about', 'services', 'contact', 'projects' ];
+		return [ 'about', 'services', 'contact', 'projects', 'testimonials' ];
 	}
 
 	/**

--- a/inc/wizard/class-section-assembler.php
+++ b/inc/wizard/class-section-assembler.php
@@ -55,6 +55,16 @@ final class Section_Assembler {
 		return $section;
 	}
 
+	/**
+	 * Fields produced by placeholder fallback (excludes company_services rows).
+	 *
+	 * @param array<string,mixed> $client_data Wizard client data.
+	 * @return array<string,mixed>
+	 */
+	public function placeholder_fields( string $section_key, array $client_data, int $item_count ): array {
+		return $this->placeholder_copy( $section_key, $client_data, $item_count );
+	}
+
 	private function placeholder_copy( string $section_key, array $client_data, int $item_count ): array {
 		// Layouts with no fillable fields must not produce invented fallback copy.
 		if ( ! $this->harness->has_fillable_fields( $section_key ) ) {

--- a/inc/wizard/class-step-internal-page-builder.php
+++ b/inc/wizard/class-step-internal-page-builder.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Wizard internal page builder — About core slice.
+ * Wizard internal page builder — About plus remaining ready types.
  *
  * @package Simple_RMS_Theme
  */
@@ -12,11 +12,13 @@ defined( 'ABSPATH' ) || exit;
 require_once __DIR__ . '/class-section-assembler.php';
 require_once __DIR__ . '/class-placeholder-provenance-store.php';
 
-/** About-only start/process under execute_step. Does not acquire the fence. */
+/** Start/process under execute_step. Does not acquire the fence. */
 class Step_Internal_Page_Builder {
 	private const STEP        = 'internal-page-builder';
-	private const SCOPE_TYPE  = 'about';
-	private const SCOPE_SLUGS = [ 'about', 'about-us' ];
+	private const READY_TYPES = [ 'about', 'services', 'contact', 'projects', 'testimonials' ];
+	private const LEGACY_SLUGS = [
+		'about' => [ 'about', 'about-us' ],
+	];
 	private $logger;
 	private $state_manager;
 	private $content_builder;
@@ -96,7 +98,7 @@ class Step_Internal_Page_Builder {
 	 */
 	private function start( array $payload ): array {
 		$fresh = $this->state_manager->get_state();
-		$plan  = $this->ensure_about_plan( $fresh, $this->truthy( $payload['retry_failed'] ?? false ) );
+		$plan  = $this->ensure_plan( $fresh, $this->truthy( $payload['retry_failed'] ?? false ) );
 		$fresh['internal_pages'] = $plan;
 		$this->state_manager->save_state( $fresh );
 		$pending = $this->is_pending( $plan );
@@ -111,23 +113,25 @@ class Step_Internal_Page_Builder {
 	 */
 	private function process( array $payload ): array {
 		$fresh = $this->state_manager->get_state();
-		$plan  = $this->ensure_about_plan( $fresh, $this->truthy( $payload['retry_failed'] ?? false ) );
-		$entry = is_array( $plan[ self::SCOPE_TYPE ] ?? null ) ? $plan[ self::SCOPE_TYPE ] : null;
+		$plan  = $this->ensure_plan( $fresh, $this->truthy( $payload['retry_failed'] ?? false ) );
+		$type  = $this->next_actionable_type( $plan, $payload );
 
-		if ( null === $entry ) {
+		if ( null === $type ) {
 			$fresh['internal_pages'] = $plan;
 			$this->state_manager->save_state( $fresh );
 			$this->state_manager->set_step_status( self::STEP, 'complete' );
 
-			return [ 'internal_pages' => $plan, 'status' => 'complete', 'unavailable' => true ];
+			return [ 'internal_pages' => $plan, 'status' => 'complete', 'unavailable' => true, 'reason' => 'unavailable' ];
 		}
 
-		$entry                    = $this->process_about(
+		$entry         = is_array( $plan[ $type ] ?? null ) ? $plan[ $type ] : State_Manager::INTERNAL_PAGE_ENTRY;
+		$entry         = $this->process_page(
+			$type,
 			$entry,
-			$this->type_requested( $payload['overwrite'] ?? [], self::SCOPE_TYPE ),
-			$this->type_requested( $payload['convert_legacy'] ?? [], self::SCOPE_TYPE )
+			$this->type_requested( $payload['overwrite'] ?? [], $type ),
+			$this->type_requested( $payload['convert_legacy'] ?? [], $type )
 		);
-		$plan[ self::SCOPE_TYPE ] = $entry;
+		$plan[ $type ] = $entry;
 		$fresh                    = $this->state_manager->get_state();
 		$fresh['internal_pages']  = $plan;
 		$this->state_manager->save_state( $fresh );
@@ -137,7 +141,7 @@ class Step_Internal_Page_Builder {
 
 		return [
 			'internal_pages' => $plan,
-			'processed'      => self::SCOPE_TYPE,
+			'processed'      => $type,
 			'status'         => (string) ( $entry['status'] ?? '' ),
 			'reason'         => (string) ( $entry['reason'] ?? '' ),
 		];
@@ -147,32 +151,35 @@ class Step_Internal_Page_Builder {
 	 * @param array<string,mixed> $state
 	 * @return array<string,array<string,mixed>>
 	 */
-	private function ensure_about_plan( array $state, bool $retry_failed = false ): array {
+	private function ensure_plan( array $state, bool $retry_failed = false ): array {
 		$plan  = is_array( $state['internal_pages'] ?? null ) ? $state['internal_pages'] : [];
-		$shell = $this->find_about_shell( is_array( $state['generated_pages'] ?? null ) ? $state['generated_pages'] : [] );
-		$entry = is_array( $plan[ self::SCOPE_TYPE ] ?? null )
-			? array_merge( State_Manager::INTERNAL_PAGE_ENTRY, $plan[ self::SCOPE_TYPE ] )
-			: State_Manager::INTERNAL_PAGE_ENTRY;
+		$pages = is_array( $state['generated_pages'] ?? null ) ? $state['generated_pages'] : [];
 
-		if ( null === $shell ) {
-			$entry['post_id']         = 0;
-			$entry['status']          = 'skipped';
-			$entry['reason']          = 'unavailable';
-			$entry['updated_at']      = \current_time( 'mysql', true );
-			$plan[ self::SCOPE_TYPE ] = $entry;
+		foreach ( self::READY_TYPES as $type ) {
+			$shell = $this->find_shell( $type, $pages );
+			$entry = is_array( $plan[ $type ] ?? null )
+				? array_merge( State_Manager::INTERNAL_PAGE_ENTRY, $plan[ $type ] )
+				: State_Manager::INTERNAL_PAGE_ENTRY;
 
-			return $plan;
-		}
+			if ( null === $shell ) {
+				$entry['post_id']    = 0;
+				$entry['status']     = 'skipped';
+				$entry['reason']     = 'unavailable';
+				$entry['updated_at'] = \current_time( 'mysql', true );
+				$plan[ $type ]       = $entry;
+				continue;
+			}
 
-		$entry['post_id'] = (int) $shell['id'];
-		if ( $retry_failed && 'failed' === (string) ( $entry['status'] ?? '' ) ) {
-			$entry['status'] = 'pending';
-			$entry['reason'] = '';
+			$entry['post_id'] = (int) $shell['id'];
+			if ( $retry_failed && 'failed' === (string) ( $entry['status'] ?? '' ) ) {
+				$entry['status'] = 'pending';
+				$entry['reason'] = '';
+			}
+			if ( '' === (string) ( $entry['status'] ?? '' ) ) {
+				$entry['status'] = 'pending';
+			}
+			$plan[ $type ] = $entry;
 		}
-		if ( '' === (string) ( $entry['status'] ?? '' ) ) {
-			$entry['status'] = 'pending';
-		}
-		$plan[ self::SCOPE_TYPE ] = $entry;
 
 		return $plan;
 	}
@@ -181,17 +188,19 @@ class Step_Internal_Page_Builder {
 	 * @param array<int,array<string,mixed>> $generated_pages
 	 * @return array{id:int,slug:string}|null
 	 */
-	private function find_about_shell( array $generated_pages ) {
+	private function find_shell( string $want, array $generated_pages ) {
+		$aliases = self::LEGACY_SLUGS[ $want ] ?? [ $want ];
+
 		foreach ( $generated_pages as $page ) {
 			if ( ! is_array( $page ) ) {
 				continue;
 			}
 			$slug = \sanitize_title( (string) ( $page['slug'] ?? '' ) );
 			$type = \sanitize_title( (string) ( $page['type'] ?? '' ) );
-			if ( '' !== $type && self::SCOPE_TYPE !== $type ) {
+			if ( '' !== $type && $want !== $type ) {
 				continue;
 			}
-			if ( '' === $type && ! in_array( $slug, self::SCOPE_SLUGS, true ) ) {
+			if ( '' === $type && ! in_array( $slug, $aliases, true ) ) {
 				continue;
 			}
 			$id = \absint( $page['id'] ?? 0 );
@@ -211,7 +220,7 @@ class Step_Internal_Page_Builder {
 	 * @param array<string,mixed> $entry
 	 * @return array<string,mixed>
 	 */
-	private function process_about( array $entry, bool $overwrite = false, bool $convert = false ): array {
+	private function process_page( string $type, array $entry, bool $overwrite = false, bool $convert = false ): array {
 		$post_id = \absint( $entry['post_id'] ?? 0 );
 		$now     = \current_time( 'mysql', true );
 
@@ -250,9 +259,18 @@ class Step_Internal_Page_Builder {
 			return $entry;
 		}
 
-		$blueprint = Internal_Page_Blueprints::all()[ self::SCOPE_TYPE ];
-		$built     = $this->assemble_about_rows( $blueprint, $post_id );
-		$saved     = $this->content_builder->build_page(
+		$all       = Internal_Page_Blueprints::all();
+		$blueprint = is_array( $all[ $type ] ?? null ) ? $all[ $type ] : null;
+		if ( ! is_array( $blueprint ) ) {
+			$entry['status']     = 'skipped';
+			$entry['reason']     = 'unavailable';
+			$entry['updated_at'] = $now;
+
+			return $entry;
+		}
+
+		$built = $this->assemble_rows( $blueprint, $post_id );
+		$saved = $this->content_builder->build_page(
 			[
 				'id'           => $post_id,
 				'section_only' => true,
@@ -282,7 +300,7 @@ class Step_Internal_Page_Builder {
 	 * @param array{template:string,layouts:array<int,string>,page_type:string,canonical:string} $blueprint
 	 * @return array{rows:array<int,array<string,mixed>>,layouts:array<int,string>}
 	 */
-	private function assemble_about_rows( array $blueprint, int $post_id ): array {
+	private function assemble_rows( array $blueprint, int $post_id ): array {
 		$client  = is_array( $this->state_manager->get_state()['client_data'] ?? null ) ? $this->state_manager->get_state()['client_data'] : [];
 		$rows    = [];
 		$layouts = [];
@@ -301,12 +319,14 @@ class Step_Internal_Page_Builder {
 					continue;
 				}
 			}
-			$count  = $this->harness->has_fillable_fields( $layout ) ? ( 'vision-mission-v2' === $layout ? 3 : 1 ) : 0;
-			$row    = $this->content_builder->prepare_image_fallbacks( $this->section_assembler->section_data( $layout, $client, [], $count ) );
-			$rows[] = $row;
-			foreach ( $this->harness->get_fillable_fields( $layout ) as $field ) {
+			$count        = $this->harness->has_fillable_fields( $layout ) ? ( 'vision-mission-v2' === $layout ? 3 : 1 ) : 0;
+			$placeholders = $this->section_assembler->placeholder_fields( $layout, $client, $count );
+			$row          = $this->content_builder->prepare_image_fallbacks( $this->section_assembler->section_data( $layout, $client, [], $count ) );
+			$rows[]       = $row;
+			foreach ( $placeholders as $field => $_unused ) {
+				$field = (string) $field;
 				if ( isset( $row[ $field ] ) ) {
-					$this->provenance->record( $post_id, $layout, (int) $index, (string) $field, 'missing_client_fact', $row[ $field ] );
+					$this->provenance->record( $post_id, $layout, (int) $index, $field, 'missing_client_fact', $row[ $field ] );
 				}
 			}
 		}
@@ -327,9 +347,46 @@ class Step_Internal_Page_Builder {
 	 * @param array<string,array<string,mixed>> $plan
 	 */
 	private function is_pending( array $plan ): bool {
-		$status = (string) ( ( is_array( $plan[ self::SCOPE_TYPE ] ?? null ) ? $plan[ self::SCOPE_TYPE ] : [] )['status'] ?? '' );
+		return null !== $this->next_pending_type( $plan );
+	}
 
-		return in_array( $status, [ 'pending', 'failed' ], true );
+	/**
+	 * @param array<string,array<string,mixed>> $plan
+	 */
+	private function next_pending_type( array $plan ): ?string {
+		foreach ( self::READY_TYPES as $type ) {
+			$status = (string) ( ( is_array( $plan[ $type ] ?? null ) ? $plan[ $type ] : [] )['status'] ?? '' );
+			if ( in_array( $status, [ 'pending', 'failed' ], true ) ) {
+				return $type;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param array<string,array<string,mixed>> $plan
+	 * @param array<string,mixed>               $payload
+	 */
+	private function next_actionable_type( array $plan, array $payload ): ?string {
+		$pending = $this->next_pending_type( $plan );
+		if ( null !== $pending ) {
+			return $pending;
+		}
+
+		foreach ( self::READY_TYPES as $type ) {
+			$entry  = is_array( $plan[ $type ] ?? null ) ? $plan[ $type ] : [];
+			$status = (string) ( $entry['status'] ?? '' );
+			$reason = (string) ( $entry['reason'] ?? '' );
+			if ( 'complete' === $status && $this->type_requested( $payload['overwrite'] ?? [], $type ) ) {
+				return $type;
+			}
+			if ( 'skipped' === $status && 'legacy_unconfirmed' === $reason && $this->type_requested( $payload['convert_legacy'] ?? [], $type ) ) {
+				return $type;
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/pages/testimonials.php
+++ b/pages/testimonials.php
@@ -1,3 +1,13 @@
-/*
+<?php
+/**
  * Template Name: Testimonials
+ *
+ * @package Simple_RMS_Theme
  */
+
+get_header();
+
+get_template_part( 'templates/breadcrumb' );
+get_template_part( 'templates/page-sections-loop' );
+
+get_footer();

--- a/tests/wizard-internal-page-builder-harness.php
+++ b/tests/wizard-internal-page-builder-harness.php
@@ -1,6 +1,7 @@
 <?php
 /**
- * About core builder proofs.
+ * Internal page builder proofs.
+ *
  * Usage: php tests/wizard-internal-page-builder-harness.php
  */
 if ( PHP_SAPI !== 'cli' ) { fwrite( STDERR, "CLI only.\n" ); exit( 1 ); }
@@ -135,7 +136,7 @@ rms_ipb_assert( 'complete' === ( $proc['status'] ?? '' ) && 1 === count( $GLOBAL
 echo "PASS our-company-type-about-generate-and-build\n"; ++$passed;
 rms_ipb_reset(); $GLOBALS['_posts'][12] = new WP_Post( 12 );
 $sm = new State_Manager(); $st = $sm->get_state();
-$st['generated_pages'] = array( array( 'id' => 12, 'slug' => 'about', 'type' => 'services', 'role' => '' ) ); $sm->save_state( $st );
+$st['generated_pages'] = array( array( 'id' => 12, 'slug' => 'about', 'type' => 'evil', 'role' => '' ) ); $sm->save_state( $st );
 $coerced = rms_ipb_builder()->run( array( 'action' => 'process' ) );
 rms_ipb_assert( array() === $GLOBALS['_build_log'] && ( 'unavailable' === ( $coerced['reason'] ?? '' ) || 'skipped' === ( $coerced['status'] ?? '' ) ), 'unknown type not coerced' );
 echo "PASS unknown-type-not-coerced\n"; ++$passed;
@@ -145,4 +146,66 @@ $st['generated_pages'] = array( array( 'id' => 12, 'slug' => 'about-us', 'role' 
 $b = rms_ipb_builder(); $b->run( array( 'action' => 'start' ) ); $legacy_alias = $b->run( array( 'action' => 'process' ) );
 rms_ipb_assert( 'complete' === ( $legacy_alias['status'] ?? '' ) && 1 === count( $GLOBALS['_build_log'] ), 'legacy about-us alias' );
 echo "PASS legacy-about-us-alias\n"; ++$passed;
+rms_ipb_reset();
+foreach ( array( 12 => 'about', 13 => 'services', 14 => 'contact', 15 => 'projects', 16 => 'testimonials' ) as $id => $type ) {
+	$GLOBALS['_posts'][ $id ] = new WP_Post( $id );
+}
+$sm = new State_Manager(); $st = $sm->get_state();
+$st['generated_pages'] = array(
+	array( 'id' => 12, 'slug' => 'about', 'type' => 'about' ),
+	array( 'id' => 13, 'slug' => 'what-we-do', 'type' => 'services' ),
+	array( 'id' => 14, 'slug' => 'contact', 'type' => 'contact' ),
+	array( 'id' => 15, 'slug' => 'our-work', 'type' => 'projects' ),
+	array( 'id' => 16, 'slug' => 'reviews', 'type' => 'testimonials' ),
+);
+$sm->save_state( $st );
+$b = rms_ipb_builder(); $b->run( array( 'action' => 'start' ) );
+$got = array();
+for ( $i = 0; $i < 5; $i++ ) {
+	$r = $b->run( array( 'action' => 'process' ) );
+	$got[ (string) ( $r['processed'] ?? '' ) ] = $r;
+}
+rms_ipb_assert( array( 'about', 'services', 'contact', 'projects', 'testimonials' ) === array_keys( $got ), 'five types processed' );
+$by_id = array();
+foreach ( $GLOBALS['_build_log'] as $call ) { $by_id[ (int) ( $call['id'] ?? 0 ) ] = $call; }
+rms_ipb_assert( 'pages/services.php' === ( $by_id[13]['meta_input']['_wp_page_template'] ?? '' ), 'services custom slug' );
+rms_ipb_assert( array( 'services-v1', 'cta-v2' ) === array_column( $by_id[13]['sections'] ?? array(), 'acf_fc_layout' ), 'services layouts' );
+rms_ipb_assert( 'pages/contact-us.php' === ( $by_id[14]['meta_input']['_wp_page_template'] ?? '' ), 'contact template' );
+rms_ipb_assert( array( 'gallery-grid' ) === array_column( $by_id[15]['sections'] ?? array(), 'acf_fc_layout' ), 'projects layouts' );
+rms_ipb_assert( 'pages/testimonials.php' === ( $by_id[16]['meta_input']['_wp_page_template'] ?? '' ), 'testimonials template' );
+rms_ipb_assert( array( 'testimonials-v1' ) === array_column( $by_id[16]['sections'] ?? array(), 'acf_fc_layout' ), 'testimonials layouts' );
+echo "PASS remaining-ready-types-and-custom-slugs\n"; ++$passed;
+rms_ipb_reset();
+$GLOBALS['_posts'][13] = new WP_Post( 13 );
+$sm = new State_Manager(); $st = $sm->get_state();
+$st['generated_pages'] = array( array( 'id' => 13, 'slug' => 'services', 'type' => 'services' ) ); $sm->save_state( $st );
+$b = rms_ipb_builder(); $b->run( array( 'action' => 'start' ) ); $b->run( array( 'action' => 'process' ) );
+$st = ( new State_Manager() )->get_state();
+rms_ipb_assert( 'skipped' === ( $st['internal_pages']['testimonials']['status'] ?? '' ) && 'unavailable' === ( $st['internal_pages']['testimonials']['reason'] ?? '' ), 'unselected testimonials skipped' );
+$GLOBALS['_build_log'] = array();
+$noop = $b->run( array( 'action' => 'process' ) );
+rms_ipb_assert( array() === $GLOBALS['_build_log'] && 'complete' === ( $noop['status'] ?? '' ), 'complete is no-op' );
+$over = $b->run( array( 'action' => 'process', 'overwrite' => array( 'services' ) ) );
+rms_ipb_assert( 1 === count( $GLOBALS['_build_log'] ) && 'complete' === ( $over['status'] ?? '' ), 'overwrite services' );
+echo "PASS missing-shell-preserve-overwrite-remaining\n"; ++$passed;
+rms_ipb_reset();
+$GLOBALS['_posts'][13] = new WP_Post( 13 );
+$sm = new State_Manager(); $st = $sm->get_state();
+$st['generated_pages'] = array( array( 'id' => 13, 'slug' => 'services', 'type' => 'services' ) );
+$st['client_data'] = array( 'company_name' => 'Acme', 'company_services' => array( array( 'service_name' => 'Roofing', 'service_short_description' => 'We roof.' ) ) );
+$sm->save_state( $st );
+$b = rms_ipb_builder(); $b->run( array( 'action' => 'start' ) ); $b->run( array( 'action' => 'process' ) );
+$prov = ( new Placeholder_Provenance_Store() )->query( 13 );
+rms_ipb_assert( ! isset( $prov['0:services_v1_services'] ), 'company services not placeholder' );
+rms_ipb_assert( isset( $prov['0:services_v1_headline'] ), 'placeholder headline recorded' );
+rms_ipb_reset();
+$GLOBALS['_posts'][12] = new WP_Post( 12 );
+( new Canonical_Section_Store() )->set_if_empty( 'about-us', array( 'acf_fc_layout' => 'about-us', 'about_headline' => 'Canonical About' ) );
+$sm = new State_Manager(); $st = $sm->get_state();
+$st['generated_pages'] = array( array( 'id' => 12, 'slug' => 'about', 'type' => 'about' ) ); $sm->save_state( $st );
+$b = rms_ipb_builder(); $b->run( array( 'action' => 'start' ) ); $b->run( array( 'action' => 'process' ) );
+$about_prov = ( new Placeholder_Provenance_Store() )->query( 12 );
+rms_ipb_assert( ! isset( $about_prov['0:about_headline'] ), 'canonical row not recorded' );
+rms_ipb_assert( isset( $about_prov['1:vm_v2_headline'] ), 'non-canonical placeholder recorded' );
+echo "PASS real-facts-not-recorded-as-placeholders\n"; ++$passed;
 echo 'Harness passed: ' . $passed . " scenarios.\n";

--- a/tests/wizard-internal-page-templates-harness.php
+++ b/tests/wizard-internal-page-templates-harness.php
@@ -128,7 +128,10 @@ rms_tpl_assert( array( 'services-v1', 'cta-v2' ) === $all['services']['layouts']
 rms_tpl_assert( 'pages/contact-us.php' === $all['contact']['template'], 'contact registry template' );
 rms_tpl_assert( 'pages/projects.php' === $all['projects']['template'], 'projects registry template' );
 $ready = \Inc\Wizard\Internal_Page_Blueprints::shell_ready_types();
-rms_tpl_assert( array( 'about', 'services', 'contact', 'projects' ) === $ready && ! in_array( 'testimonials', $ready, true ) && ! in_array( 'blog', $ready, true ), 'shell-ready types' );
+rms_tpl_assert( array( 'about', 'services', 'contact', 'projects', 'testimonials' ) === $ready && ! in_array( 'blog', $ready, true ), 'shell-ready types' );
+$testimonials = file_get_contents( dirname( __DIR__ ) . '/pages/testimonials.php' );
+rms_tpl_assert( is_string( $testimonials ) && 0 === strpos( ltrim( $testimonials ), '<?php' ), 'testimonials php opener' );
+rms_tpl_assert( false === strpos( $testimonials, 'services-page' ) && false !== strpos( $testimonials, 'page-sections-loop' ), 'testimonials uses loop' );
 echo "PASS blueprint-templates-and-shell-ready\n";
 ++$passed;
 
@@ -204,7 +207,8 @@ $by_slug = array();
 foreach ( $spy->calls as $call ) { $by_slug[ (string) ( $call['slug'] ?? '' ) ] = $call; }
 rms_tpl_assert( 'pages/about-us.php' === ( $by_slug['about-us']['meta_input']['_wp_page_template'] ?? '' ), 'about-us slug gets About template' );
 rms_tpl_assert( ! isset( $by_slug['about-us']['sections'] ), 'about shell has no sections key' );
-rms_tpl_assert( ! isset( $by_slug['testimonials']['meta_input']['_wp_page_template'] ) && ! isset( $by_slug['blog']['meta_input']['_wp_page_template'] ) && ! isset( $by_slug['home']['meta_input']['_wp_page_template'] ), 'deferred and unblueprinted' );
+rms_tpl_assert( 'pages/testimonials.php' === ( $by_slug['testimonials']['meta_input']['_wp_page_template'] ?? '' ), 'testimonials shell assigned' );
+rms_tpl_assert( ! isset( $by_slug['blog']['meta_input']['_wp_page_template'] ) && ! isset( $by_slug['home']['meta_input']['_wp_page_template'] ), 'blog and home unblueprinted' );
 echo "PASS generate-pages-runtime-template-and-no-sections\n";
 ++$passed;
 


### PR DESCRIPTION
Closes #42

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Builds remaining ready internal page types — Services, Contact, Projects, Testimonials — from `generated_pages[].type`, including custom slugs.
- Testimonials becomes valid PHP with the shared loop partial and receives `_wp_page_template` at Generate Pages shell creation. Blog stays deferred.
- Placeholder attribution uses `placeholder_fields()` so `company_services` rows and other canonical facts are not recorded as placeholders.

## Changes

| File | Change |
|------|--------|
| `inc/wizard/class-internal-page-blueprints.php` | Enable Testimonials as a shell-ready blueprint type. |
| `inc/wizard/class-section-assembler.php` | Expose `placeholder_fields()` so sourced/canonical facts are excluded from provenance. |
| `inc/wizard/class-step-internal-page-builder.php` | Plan/process Services, Contact, Projects, and Testimonials by stable type. |
| `pages/testimonials.php` | Valid PHP opener + shared loop partial; drop `services-page` reference. |
| `tests/wizard-internal-page-builder-harness.php` | Remaining-type, custom-slug, preserve/overwrite, and real-fact exclusion proofs (16/16). |
| `tests/wizard-internal-page-templates-harness.php` | Testimonials/shell-ready coverage (11/11). |

## Test Plan
- [x] `php tests/wizard-internal-page-builder-harness.php` — **16/16 pass**, including `real-facts-not-recorded-as-placeholders`.
- [x] `php tests/wizard-internal-page-templates-harness.php` — **11/11 pass**.
- [x] `php tests/wizard-placeholder-provenance-harness.php` — **4/4 pass** (sync not in this slice). Provenance source exclusion: canonical/`company_services` facts are not recorded as placeholders.
- [x] `php scripts/test-landing-run-orchestrator.php` — **293 passed, 0 failed**.
- [x] `php -l` on the 6 changed files — no syntax errors, PHP 8.2.29.
- [x] Three-dot diff against updated tracker `feat/internal-page-builder` is exactly these 6 files (**+204 / −60 = 264 / 400**). No OpenSpec.
- [x] Scripts run without errors: N/A — no shell scripts in this PR.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts: N/A — no shell scripts
- [x] Skills tested in at least one agent: N/A — wizard domain feature, not a skill change
- [x] Docs updated if behavior changed: OpenSpec progress is on tracker #43; no public UI copy change
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Chain Context

| Field | Value |
|-------|-------|
| Chain | wizard-internal-page-builder |
| Tracker PR | #43 `feat/internal-page-builder` (draft, no-merge) |
| Position | 5A of 8 (remaining internal page types) |
| Base | `feat/internal-page-builder` |
| Depends on | Tracker #43 / merged PR1–PR4B #44–#52 / approved issue #42 |
| Follow-up | PR5B #54 `fix/internal-page-provenance-sync` (this publish) |
| Review budget | 264 / 400 |
| Starts at | Tracker ancestor `feat/internal-page-builder` @ `85bc1bd` |
| Ends with | Services/Contact/Projects/Testimonials build by stable type; source-safe placeholder attribution |

### Chain Overview

```text
main
 └── #43 feat/internal-page-builder  (draft tracker, no-merge)
      └── #44 PR1 feat/internal-page-blueprints  (merged)
           └── #45–#47 PR2A–PR2C section assembler  (merged)
                └── #48–#50 PR3A–PR3C About backend  (merged)
                     └── #51–#52 PR4A–PR4B type + templates  (merged)
                          └── 📍 #53 PR5A feat/internal-page-remaining-types
                               └── #54 PR5B fix/internal-page-provenance-sync
                                    └── PR6 Blog chrome
                                         └── PR7 harness L2 + acf/save_post sync wiring
                                              └── PR8 UI + activation
```

### Scope
- Includes: remaining ready types (Services, Contact, Projects, Testimonials), Testimonials template + shell assignment, source-safe `placeholder_fields()` attribution, and the 16/16 + 11/11 proofs.
- Excludes: Blog index chrome, AI Layer 2, controller/dispatch/UI, activation. **Hook wiring of `sync()` on `acf/save_post`(20) remains Phase 7.2** and is not in this PR.
- Tracker #43 remains draft/no-merge. No `size:exception`.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit

### Rollback
Revert `54f268e`. Provenance sync hardening is not in this slice.
