### PR TITLE
fix(wizard): harden placeholder provenance sync

### DIFF
--- a/inc/wizard/class-placeholder-provenance-store.php
+++ b/inc/wizard/class-placeholder-provenance-store.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Records unmarked placeholder fields so owners can find and replace them.
  *
- * Backed by a non-autoloaded option. sync() is intentionally not implemented here.
+ * Backed by a non-autoloaded option. sync() matches layout+field+hash, not row index.
  */
 final class Placeholder_Provenance_Store {
 	public const OPTION_KEY = 'rms_wizard_placeholder_provenance';
@@ -25,7 +25,7 @@ final class Placeholder_Provenance_Store {
 	/**
 	 * Persist one placeholder field on a page.
 	 *
-	 * @param array<string,mixed> $value Field value used to compute value_hash.
+	 * @param mixed $value Field value used to compute value_hash.
 	 */
 	public function record( int $post_id, string $layout, int $row, string $field, string $reason, $value ): bool {
 		$post_id = \absint( $post_id );
@@ -49,7 +49,7 @@ final class Placeholder_Provenance_Store {
 			'row'        => $row,
 			'field'      => $field,
 			'reason'     => '' !== $reason ? $reason : 'missing_client_fact',
-			'value_hash' => sha1( (string) \wp_json_encode( $value ) ),
+			'value_hash' => $this->value_hash( $value ),
 			'written_at' => \current_time( 'mysql', true ),
 		];
 
@@ -121,12 +121,150 @@ final class Placeholder_Provenance_Store {
 		return $queue;
 	}
 
+	public function value_hash( $value ): string {
+		$json = \wp_json_encode( $this->canonicalize( $value ) );
+
+		return sha1( false === $json ? '' : $json );
+	}
+
+	public function is_placeholder_payload( $value, string $hash ): bool {
+		return '' !== $hash && $this->value_hash( $value ) === $hash;
+	}
+
+	/**
+	 * Reconcile provenance with a complete `page_sections` snapshot.
+	 *
+	 * Compatible with `acf/save_post` (priority 20). Invalid snapshots are a no-op.
+	 * A valid empty list clears this page only.
+	 *
+	 * @param array<int,array<string,mixed>> $sections
+	 */
+	public function sync( int $post_id, array $sections ): bool {
+		$post_id = \absint( $post_id );
+		if ( $post_id <= 0 || ! $this->is_valid_snapshot( $sections ) ) {
+			return false;
+		}
+
+		$this->ensure_loaded();
+		$entries = is_array( $this->entries ) ? $this->entries : [];
+		$page    = is_array( $entries[ $post_id ] ?? null ) ? $entries[ $post_id ] : [];
+		$pool    = $this->occurrence_pool( $sections );
+		$kept    = [];
+
+		foreach ( $page as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$layout = \sanitize_key( (string) ( $entry['layout'] ?? '' ) );
+			$field  = \sanitize_key( (string) ( $entry['field'] ?? '' ) );
+			$hash   = (string) ( $entry['value_hash'] ?? '' );
+			$token  = $layout . "\0" . $field . "\0" . $hash;
+
+			if ( [] === ( $pool[ $token ] ?? [] ) ) {
+				continue;
+			}
+
+			$new_row          = (int) array_shift( $pool[ $token ] );
+			$entry['row']     = $new_row;
+			$kept[ $new_row . ':' . $field ] = $entry;
+		}
+
+		if ( [] === $kept ) {
+			unset( $entries[ $post_id ] );
+		} else {
+			$entries[ $post_id ] = $kept;
+		}
+
+		return $this->persist( $entries );
+	}
+
+	/**
+	 * @param array<int,mixed> $sections
+	 */
+	private function is_valid_snapshot( array $sections ): bool {
+		if ( ! $this->is_list( $sections ) ) {
+			return false;
+		}
+
+		foreach ( $sections as $row ) {
+			if ( ! is_array( $row ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $sections
+	 * @return array<string,array<int,int>>
+	 */
+	private function occurrence_pool( array $sections ): array {
+		$pool = [];
+
+		foreach ( $sections as $index => $row ) {
+			$layout = \sanitize_key( (string) ( $row['acf_fc_layout'] ?? '' ) );
+			if ( '' === $layout ) {
+				continue;
+			}
+
+			foreach ( $row as $field => $value ) {
+				$field = \sanitize_key( (string) $field );
+				if ( '' === $field || 'acf_fc_layout' === $field ) {
+					continue;
+				}
+
+				$token            = $layout . "\0" . $field . "\0" . $this->value_hash( $value );
+				$pool[ $token ][] = (int) $index;
+			}
+		}
+
+		return $pool;
+	}
+
+	private function canonicalize( $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		if ( $this->is_list( $value ) ) {
+			$out = [];
+			foreach ( $value as $item ) {
+				$out[] = $this->canonicalize( $item );
+			}
+
+			return $out;
+		}
+
+		$keys = array_keys( $value );
+		sort( $keys, SORT_STRING );
+		$out = [];
+		foreach ( $keys as $key ) {
+			$out[ $key ] = $this->canonicalize( $value[ $key ] );
+		}
+
+		return $out;
+	}
+
+	private function is_list( array $value ): bool {
+		$expected = 0;
+		foreach ( $value as $key => $_item ) {
+			if ( $expected !== $key ) {
+				return false;
+			}
+			++$expected;
+		}
+
+		return true;
+	}
+
 	private function ensure_loaded(): void {
 		if ( null !== $this->entries ) {
 			return;
 		}
 
-		$stored = \get_option( self::OPTION_KEY, [] );
+		$stored        = \get_option( self::OPTION_KEY, [] );
 		$this->entries = is_array( $stored ) ? $stored : [];
 	}
 

--- a/inc/wizard/class-step-internal-page-builder.php
+++ b/inc/wizard/class-step-internal-page-builder.php
@@ -121,6 +121,12 @@ class Step_Internal_Page_Builder {
 			$this->state_manager->save_state( $fresh );
 			$this->state_manager->set_step_status( self::STEP, 'complete' );
 
+			foreach ( self::READY_TYPES as $ready ) {
+				if ( 'complete' === (string) ( ( is_array( $plan[ $ready ] ?? null ) ? $plan[ $ready ] : [] )['status'] ?? '' ) ) {
+					return [ 'internal_pages' => $plan, 'status' => 'complete' ];
+				}
+			}
+
 			return [ 'internal_pages' => $plan, 'status' => 'complete', 'unavailable' => true, 'reason' => 'unavailable' ];
 		}
 

--- a/tests/wizard-internal-page-builder-harness.php
+++ b/tests/wizard-internal-page-builder-harness.php
@@ -174,6 +174,8 @@ rms_ipb_assert( 'pages/contact-us.php' === ( $by_id[14]['meta_input']['_wp_page_
 rms_ipb_assert( array( 'gallery-grid' ) === array_column( $by_id[15]['sections'] ?? array(), 'acf_fc_layout' ), 'projects layouts' );
 rms_ipb_assert( 'pages/testimonials.php' === ( $by_id[16]['meta_input']['_wp_page_template'] ?? '' ), 'testimonials template' );
 rms_ipb_assert( array( 'testimonials-v1' ) === array_column( $by_id[16]['sections'] ?? array(), 'acf_fc_layout' ), 'testimonials layouts' );
+$tick = $b->run( array( 'action' => 'process' ) );
+rms_ipb_assert( 'complete' === ( $tick['status'] ?? '' ) && empty( $tick['unavailable'] ) && array() === array_column( array_slice( $GLOBALS['_build_log'], 5 ), 'id' ), 'extra process is complete no-op' );
 echo "PASS remaining-ready-types-and-custom-slugs\n"; ++$passed;
 rms_ipb_reset();
 $GLOBALS['_posts'][13] = new WP_Post( 13 );

--- a/tests/wizard-placeholder-provenance-harness.php
+++ b/tests/wizard-placeholder-provenance-harness.php
@@ -97,4 +97,50 @@ rms_prov_assert( false === $autoload, 'provenance option must be written with au
 echo "PASS provenance-option-autoload-false\n";
 ++$passed;
 
+$store = new Placeholder_Provenance_Store();
+rms_prov_assert( $store->is_placeholder_payload( 'Hello', $store->value_hash( 'Hello' ) ), 'hash matches placeholder' );
+rms_prov_assert( ! $store->is_placeholder_payload( 'Real', $store->value_hash( 'Hello' ) ), 'changed value is not placeholder' );
+$assoc_a = array( 'b' => 1, 'a' => 2 );
+$assoc_b = array( 'a' => 2, 'b' => 1 );
+rms_prov_assert( $store->value_hash( $assoc_a ) === $store->value_hash( $assoc_b ), 'assoc key order stable' );
+rms_prov_assert( $store->value_hash( array( 'x', 'y' ) ) !== $store->value_hash( array( 'y', 'x' ) ), 'list order changes hash' );
+$nested = array( array( 'quote' => 'Hi', 'author' => 'A' ) );
+$store->record( 30, 'testimonials-v1', 0, 'testimonials_v1_items', 'missing_client_fact', $nested );
+$store->record( 30, 'about-us', 1, 'about_headline', 'missing_client_fact', 'Hello' );
+$store->record( 30, 'about-us', 1, 'about_text', 'missing_client_fact', 'Body' );
+$store->record( 31, 'contact-info', 0, 'contact_info_headline', 'missing_client_fact', 'Hi' );
+$reordered = array(
+	array( 'acf_fc_layout' => 'about-us', 'about_headline' => 'Hello', 'about_text' => 'Body' ),
+	array( 'acf_fc_layout' => 'testimonials-v1', 'testimonials_v1_items' => $nested ),
+);
+rms_prov_assert( $store->sync( 30, $reordered ), 'reorder sync' );
+$page30 = $store->query( 30 );
+rms_prov_assert( isset( $page30['0:about_headline'] ) && 0 === (int) $page30['0:about_headline']['row'] && isset( $page30['1:testimonials_v1_items'] ) && 1 === (int) $page30['1:testimonials_v1_items']['row'], 'reorder reindexes' );
+$before = $page30;
+rms_prov_assert( $store->sync( 30, $reordered ) && $before === $store->query( 30 ), 'sync idempotent' );
+$inserted = array(
+	array( 'acf_fc_layout' => 'cta-v2', 'cta_v2_headline' => 'New' ),
+	array( 'acf_fc_layout' => 'about-us', 'about_headline' => 'Hello', 'about_text' => 'Body' ),
+	array( 'acf_fc_layout' => 'testimonials-v1', 'testimonials_v1_items' => $nested ),
+);
+rms_prov_assert( $store->sync( 30, $inserted ), 'insert sync' );
+$page30 = $store->query( 30 );
+rms_prov_assert( isset( $page30['1:about_headline'] ) && isset( $page30['2:testimonials_v1_items'] ) && 3 === count( $page30 ), 'insert shifts rows' );
+$deleted = array(
+	array( 'acf_fc_layout' => 'about-us', 'about_headline' => 'Hello', 'about_text' => 'Body' ),
+);
+rms_prov_assert( $store->sync( 30, $deleted ), 'delete sync' );
+$page30 = $store->query( 30 );
+rms_prov_assert( isset( $page30['0:about_headline'] ) && isset( $page30['0:about_text'] ) && ! isset( $page30['1:testimonials_v1_items'] ) && ! isset( $page30['2:testimonials_v1_items'] ), 'deleted layout cleared' );
+$other = $store->query( 31 );
+rms_prov_assert( isset( $other['0:contact_info_headline'] ), 'other page preserved' );
+$snapshot = $store->query( 30 );
+rms_prov_assert( false === $store->sync( 30, array( 'about_headline' => 'Hello' ) ) && $snapshot === $store->query( 30 ), 'malformed assoc no-op' );
+rms_prov_assert( false === $store->sync( 30, array( 'not-a-row' ) ) && $snapshot === $store->query( 30 ), 'malformed scalar row no-op' );
+rms_prov_assert( $store->sync( 30, array() ) && array() === $store->query( 30 ), 'valid empty snapshot clears page' );
+rms_prov_assert( isset( $store->query( 31 )['0:contact_info_headline'] ), 'empty snapshot is page-scoped' );
+rms_prov_assert( false === ( $GLOBALS['_option_autoloads'][ Placeholder_Provenance_Store::OPTION_KEY ] ?? null ), 'sync keeps autoload false' );
+echo "PASS provenance-sync-reorder-hash-malformed-empty\n";
+++$passed;
+
 echo 'Harness passed: ' . $passed . " scenarios.\n";

--- a/tests/wizard-placeholder-provenance-harness.php
+++ b/tests/wizard-placeholder-provenance-harness.php
@@ -143,4 +143,24 @@ rms_prov_assert( false === ( $GLOBALS['_option_autoloads'][ Placeholder_Provenan
 echo "PASS provenance-sync-reorder-hash-malformed-empty\n";
 ++$passed;
 
+$dup = new Placeholder_Provenance_Store();
+rms_prov_assert( $dup->record( 40, 'about-us', 0, 'about_headline', 'missing_client_fact', 'Dup' ), 'dup row 0' );
+rms_prov_assert( $dup->record( 40, 'about-us', 1, 'about_headline', 'missing_client_fact', 'Dup' ), 'dup row 1' );
+rms_prov_assert( $dup->record( 41, 'contact-info', 0, 'contact_info_headline', 'missing_client_fact', 'Keep' ), 'other page' );
+rms_prov_assert( 2 === count( $dup->query( 40, 'about_headline' ) ), 'two identical occurrences recorded' );
+$dup_snap = array(
+	array( 'acf_fc_layout' => 'about-us', 'about_headline' => 'Replaced' ),
+	array( 'acf_fc_layout' => 'about-us', 'about_headline' => 'Dup' ),
+);
+rms_prov_assert( $dup->sync( 40, $dup_snap ), 'dup sync' );
+$page40 = $dup->query( 40 );
+rms_prov_assert( 1 === count( $page40 ) && isset( $page40['1:about_headline'] ) && 1 === (int) $page40['1:about_headline']['row'], 'exactly one occurrence at current row' );
+$q40 = array_values( array_filter( $dup->queue(), static function ( $row ) { return 40 === (int) $row['post_id']; } ) );
+rms_prov_assert( 1 === count( $q40 ) && 'about_headline' === ( $q40[0]['field'] ?? '' ) && 1 === (int) $q40[0]['row'], 'queue has one remaining' );
+rms_prov_assert( isset( $dup->query( 41 )['0:contact_info_headline'] ), 'other page untouched' );
+$after = $dup->query( 40 );
+rms_prov_assert( $dup->sync( 40, $dup_snap ) && $after === $dup->query( 40 ), 'dup sync idempotent' );
+echo "PASS provenance-sync-duplicate-occurrence-multiset\n";
+++$passed;
+
 echo 'Harness passed: ' . $passed . " scenarios.\n";


### PR DESCRIPTION
Closes #42

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Hardens placeholder provenance `sync()` so layout+field+canonical-hash matching is a multiset: reorder reindexes, duplicate identical occurrences consume one remaining row, malformed snapshots are no-ops, and empty snapshots stay page-scoped.
- Extra builder process after a complete remaining-type page is complete/no-op (idempotent).
- Two commits: `aaae5ad` production fix, then `7d1e997` duplicate-occurrence harness (no amend).

## Changes

| File | Change |
|------|--------|
| `inc/wizard/class-placeholder-provenance-store.php` | Multiset `sync()`: reorder, hash canonicalization, invalid snapshot no-op, empty page-scoped replace, duplicate occurrence. |
| `inc/wizard/class-step-internal-page-builder.php` | Extra process after complete remaining-type pages is complete/no-op. |
| `tests/wizard-internal-page-builder-harness.php` | Extra-process idempotency coverage (16/16). |
| `tests/wizard-placeholder-provenance-harness.php` | Reorder/hash/malformed/empty + duplicate-occurrence proofs (6/6). |

## Test Plan
- [x] `php tests/wizard-placeholder-provenance-harness.php` — **6/6 pass** (`provenance-sync-reorder-hash-malformed-empty`, `provenance-sync-duplicate-occurrence-multiset`).
- [x] `php tests/wizard-internal-page-builder-harness.php` — **16/16 pass**.
- [x] `php tests/wizard-internal-page-templates-harness.php` — **11/11 pass**.
- [x] Cumulative smoke: ACF-inactive **11/11**; Home SEO **9/9**; integration **8/8**.
- [x] `php -l` on the 4 changed files — no syntax errors, PHP 8.2.29.
- [x] Three-dot diff against PR5A `feat/internal-page-remaining-types` is exactly these 4 files (**+216 / −4 = 220 / 400**). No OpenSpec.
- [x] Scripts run without errors: N/A — no shell scripts in this PR.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts: N/A — no shell scripts
- [x] Skills tested in at least one agent: N/A — wizard domain fix, not a skill change
- [x] Docs updated if behavior changed: OpenSpec progress is on tracker #43; no public UI copy change
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Chain Context

| Field | Value |
|-------|-------|
| Chain | wizard-internal-page-builder |
| Tracker PR | #43 `feat/internal-page-builder` (draft, no-merge) |
| Position | 5B of 8 (placeholder provenance sync) |
| Base | `feat/internal-page-remaining-types` |
| Depends on | PR5A #53 `feat/internal-page-remaining-types` / tracker #43 / merged PR1–PR4B #44–#52 / approved issue #42 |
| Follow-up | PR6 Blog chrome (out of scope) |
| Review budget | 220 / 400 |
| Starts at | PR5A #53 `feat/internal-page-remaining-types` @ `54f268e` |
| Ends with | Hardened provenance sync + extra-process idempotency; 6/6 harness |

### Chain Overview

```text
main
 └── #43 feat/internal-page-builder  (draft tracker, no-merge)
      └── #44 PR1 feat/internal-page-blueprints  (merged)
           └── #45–#47 PR2A–PR2C section assembler  (merged)
                └── #48–#50 PR3A–PR3C About backend  (merged)
                     └── #51–#52 PR4A–PR4B type + templates  (merged)
                          └── #53 PR5A feat/internal-page-remaining-types
                               └── 📍 #54 PR5B fix/internal-page-provenance-sync
                                    └── PR6 Blog chrome
                                         └── PR7 harness L2 + acf/save_post sync wiring
                                              └── PR8 UI + activation
```

### Scope
- Includes: provenance store `sync()` multiset matching (reorder, hash, malformed no-op, empty snapshot, duplicates, idempotency) and builder extra-process no-op, with 6/6 + 16/16 proofs.
- Excludes: Blog index chrome, AI Layer 2, controller/dispatch/UI, activation. **Hook wiring of existing `sync()` / `is_placeholder_payload()` on `acf/save_post`(20) in `wizard-init.php` remains Phase 7.2** and is not in this PR. Do not re-add store methods there.
- Tracker #43 remains draft/no-merge. No `size:exception`.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit

### Rollback
Revert `7d1e997`, then `aaae5ad`. Remaining-type builders stay on PR5A.
