### PR TITLE
feat(wizard): add internal page AI layer

### DIFF
--- a/inc/wizard/class-ai-content-harness.php
+++ b/inc/wizard/class-ai-content-harness.php
@@ -13,12 +13,14 @@ defined( 'ABSPATH' ) || exit;
  * Encodes prompt contracts and validates AI section copy against layout field rules.
  */
 final class AI_Content_Harness {
-	public const PAGE_HOME    = 'PAGE_HOME';
-	public const PAGE_ABOUT   = 'PAGE_ABOUT';
-	public const PAGE_SERVICE = 'PAGE_SERVICE';
-	public const PAGE_LANDING = 'PAGE_LANDING';
-	public const PAGE_BLOG    = 'PAGE_BLOG';
-	public const PAGE_CONTACT = 'PAGE_CONTACT';
+	public const PAGE_HOME         = 'PAGE_HOME';
+	public const PAGE_ABOUT        = 'PAGE_ABOUT';
+	public const PAGE_SERVICE      = 'PAGE_SERVICE';
+	public const PAGE_LANDING      = 'PAGE_LANDING';
+	public const PAGE_BLOG         = 'PAGE_BLOG';
+	public const PAGE_CONTACT      = 'PAGE_CONTACT';
+	public const PAGE_PROJECTS     = 'PAGE_PROJECTS';
+	public const PAGE_TESTIMONIALS = 'PAGE_TESTIMONIALS';
 
 	private const APPROVED_CONTEXT_FIELDS = [
 		'company_name', 'company_covered_areas', 'company_services',
@@ -358,6 +360,11 @@ Write for visitors who already have intent. Content should feel purposeful and c
 PROMPT;
 		}
 
+		$internal = $this->internal_layer2( $page_type );
+		if ( '' !== $internal ) {
+			return $internal;
+		}
+
 		if ( self::PAGE_HOME !== $page_type ) {
 			$this->log_warning( sprintf( 'Unsupported AI content harness page type "%s"; falling back to PAGE_HOME.', $page_type ) );
 		}
@@ -377,6 +384,19 @@ Tone: Professional, approachable, confident, local, and human. Never corporate, 
 
 Write for a general audience discovering this business. Content should feel like a strong first impression, not a hard sales pitch.
 PROMPT;
+	}
+
+	private function internal_layer2( string $page_type ): string {
+		$map = [
+			self::PAGE_ABOUT        => "PAGE CONTEXT: About\n\nWrite the company story and trust sections. Order: about-us, then vision/mission. Use only client-supplied facts. Do not invent years, awards, or proof.\n\nTone: Honest, local, human.",
+			self::PAGE_SERVICE      => "PAGE CONTEXT: Services\n\nOverview of services from client data only. Order: services list, then CTA. Do not invent services, prices, or guarantees.\n\nTone: Clear and specific.",
+			self::PAGE_CONTACT      => "PAGE CONTEXT: Contact\n\nHelp visitors reach the business. Use only provided contact fields. Do not invent addresses, maps, hours, or phone numbers.\n\nTone: Direct and helpful.",
+			self::PAGE_BLOG         => "PAGE CONTEXT: Blog index\n\nWrite posts-index chrome only (headline/CTA). Do not write post bodies, authors, dates, or invent posts.\n\nTone: Inviting, not salesy.",
+			self::PAGE_PROJECTS     => "PAGE CONTEXT: Projects\n\nPortfolio index chrome only. Do not invent projects, galleries, media, labels, or dates.\n\nTone: Factual and restrained.",
+			self::PAGE_TESTIMONIALS => "PAGE CONTEXT: Testimonials\n\nSocial-proof chrome only (headlines). Do not invent quotes, authors, roles, stars, or testimonial items.\n\nTone: Credible, no hype.",
+		];
+
+		return $map[ $page_type ] ?? '';
 	}
 
 	/**

--- a/inc/wizard/class-internal-page-blueprints.php
+++ b/inc/wizard/class-internal-page-blueprints.php
@@ -25,8 +25,8 @@ final class Internal_Page_Blueprints {
 	/**
 	 * Return the fixed blueprint map keyed by page type.
 	 *
-	 * PAGE_PROJECTS and PAGE_TESTIMONIALS are string identifiers until the harness
-	 * defines those constants. Existing types use AI_Content_Harness page-type constants.
+	 * All types use AI_Content_Harness page-type constants, including PAGE_PROJECTS
+	 * and PAGE_TESTIMONIALS.
 	 *
 	 * @return array<string,array{template:string,layouts:array<int,string>,page_type:string,canonical:string}>
 	 */
@@ -53,13 +53,13 @@ final class Internal_Page_Blueprints {
 			'projects'      => [
 				'template'  => 'pages/projects.php',
 				'layouts'   => [ 'gallery-grid' ],
-				'page_type' => 'PAGE_PROJECTS',
+				'page_type' => AI_Content_Harness::PAGE_PROJECTS,
 				'canonical' => 'copy',
 			],
 			'testimonials'  => [
 				'template'  => 'pages/testimonials.php',
 				'layouts'   => [ 'testimonials-v1' ],
-				'page_type' => 'PAGE_TESTIMONIALS',
+				'page_type' => AI_Content_Harness::PAGE_TESTIMONIALS,
 				'canonical' => 'copy',
 			],
 			'blog'          => [

--- a/tests/wizard-ai-layer2-harness.php
+++ b/tests/wizard-ai-layer2-harness.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Layer 2 page-type contexts and blocked factual collections.
+ *
+ * Usage: php tests/wizard-ai-layer2-harness.php
+ */
+
+if ( PHP_SAPI !== 'cli' ) {
+	fwrite( STDERR, "CLI only.\n" );
+	exit( 1 );
+}
+
+$theme_root = dirname( __DIR__ );
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', $theme_root . '/' );
+}
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $k ) { return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $k ) ) ); }
+}
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $d, $o = 0 ) { return json_encode( $d, $o ); }
+}
+if ( ! function_exists( 'wp_kses_post' ) ) {
+	function wp_kses_post( $t ) { return (string) $t; }
+}
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $t ) { return trim( (string) $t ); }
+}
+
+require_once $theme_root . '/inc/wizard/class-ai-content-harness.php';
+require_once $theme_root . '/inc/wizard/class-internal-page-blueprints.php';
+
+use Inc\Wizard\AI_Content_Harness;
+use Inc\Wizard\Internal_Page_Blueprints;
+
+function rms_l2_assert( $c, string $m ): void {
+	if ( ! $c ) {
+		fwrite( STDERR, $m . "\n" );
+		exit( 1 );
+	}
+}
+
+$h       = new AI_Content_Harness();
+$passed  = 0;
+$home    = $h->get_layer2();
+$landing = $h->get_layer2( AI_Content_Harness::PAGE_LANDING );
+rms_l2_assert( 0 === strpos( $home, 'PAGE CONTEXT: Home Page' ), 'default HOME' );
+rms_l2_assert( 0 === strpos( $landing, 'PAGE CONTEXT: Landing Page' ), 'LANDING unchanged' );
+rms_l2_assert( $home === $h->get_layer2( AI_Content_Harness::PAGE_HOME ), 'HOME explicit' );
+echo "PASS home-landing-layer2-unchanged\n";
+++$passed;
+
+foreach ( array( AI_Content_Harness::PAGE_ABOUT => 'About', AI_Content_Harness::PAGE_SERVICE => 'Services', AI_Content_Harness::PAGE_CONTACT => 'Contact', AI_Content_Harness::PAGE_BLOG => 'Blog index', AI_Content_Harness::PAGE_PROJECTS => 'Projects', AI_Content_Harness::PAGE_TESTIMONIALS => 'Testimonials' ) as $type => $needle ) {
+	$ctx = $h->get_layer2( $type );
+	rms_l2_assert( false !== strpos( $ctx, $needle ) && 0 !== strpos( $ctx, 'PAGE CONTEXT: Home Page' ), 'dedicated ' . $type );
+}
+$blog = $h->get_layer2( AI_Content_Harness::PAGE_BLOG );
+rms_l2_assert( false !== strpos( $blog, 'chrome only' ) && false !== strpos( $blog, 'Do not write post bodies' ), 'blog chrome only' );
+echo "PASS internal-layer2-dedicated-contexts\n";
+++$passed;
+
+$unknown = $h->get_layer2( 'PAGE_UNKNOWN' );
+rms_l2_assert( $home === $unknown, 'unknown falls back to HOME' );
+echo "PASS unknown-type-falls-back-home\n";
+++$passed;
+
+$fill_t = $h->get_fillable_fields( 'testimonials-v1' );
+$block_t = $h->get_blocked_fields( 'testimonials-v1' );
+rms_l2_assert( in_array( 'testimonials_v1_headline', $fill_t, true ) && in_array( 'testimonials_v1_items', $block_t, true ), 'testimonial items blocked' );
+rms_l2_assert( array() === $h->get_fillable_fields( 'gallery-grid' ) && in_array( 'gallery_items', $h->get_blocked_fields( 'gallery-grid' ), true ), 'projects gallery blocked' );
+$clean = $h->validate_fields( 'testimonials-v1', array( 'testimonials_v1_headline' => 'Hi', 'testimonials_v1_items' => array( array( 'testimonial_quote' => 'Nope' ) ) ) );
+rms_l2_assert( isset( $clean['testimonials_v1_headline'] ) && ! isset( $clean['testimonials_v1_items'] ), 'validate strips items' );
+echo "PASS blocked-factual-collections\n";
+++$passed;
+
+$l3 = $h->get_layer3( 'about-us', 1, array( 'company_name' => 'Acme' ), AI_Content_Harness::PAGE_ABOUT, array( 'primary_keyword' => 'roof repair' ) );
+rms_l2_assert( false === strpos( $l3, 'KEYWORD CONTEXT' ), 'internal types keyword-neutral' );
+$all = Internal_Page_Blueprints::all();
+rms_l2_assert( AI_Content_Harness::PAGE_PROJECTS === $all['projects']['page_type'] && AI_Content_Harness::PAGE_TESTIMONIALS === $all['testimonials']['page_type'], 'registry constants' );
+echo "PASS keyword-neutral-and-registry\n";
+++$passed;
+
+echo 'Harness passed: ' . $passed . " scenarios.\n";


### PR DESCRIPTION
Closes #42

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds Layer 2 AI page-type contexts for About, Services, Contact, Blog, Projects, and Testimonials. Home and Landing Layer 2 stay byte-identical.
- Projects and Testimonials now use `AI_Content_Harness::PAGE_PROJECTS` / `PAGE_TESTIMONIALS` in the blueprint registry instead of bare strings.
- Factual collections stay blocked: gallery items and testimonial quotes/authors/stars are not invented. Unknown types fall back to `PAGE_HOME` with a warning.

## Changes

| File | Change |
|------|--------|
| `inc/wizard/class-ai-content-harness.php` | Add `PAGE_PROJECTS` / `PAGE_TESTIMONIALS` and dedicated Layer 2 contexts; Home/Landing unchanged. |
| `inc/wizard/class-internal-page-blueprints.php` | Bind projects/testimonials `page_type` to harness constants. |
| `tests/wizard-ai-layer2-harness.php` | Per-type matrix, Home/Landing unchanged, blocked collections, unknown fallback (5/5). |

## Layer 2 per-type matrix

| Type | Context | Must not invent |
|------|---------|-----------------|
| `PAGE_ABOUT` | Company story; about-us then vision/mission | Years, awards, proof |
| `PAGE_SERVICE` | Services overview from client data | Services, prices, guarantees |
| `PAGE_CONTACT` | Reach the business from provided fields | Addresses, maps, hours, phones |
| `PAGE_BLOG` | Posts-index chrome only (headline/CTA) | Post bodies, authors, dates, posts |
| `PAGE_PROJECTS` | Portfolio index chrome only | Projects, galleries, media, labels, dates |
| `PAGE_TESTIMONIALS` | Social-proof chrome only (headlines) | Quotes, authors, roles, stars, items |
| `PAGE_HOME` / `PAGE_LANDING` | Unchanged | — |
| Unknown | Falls back to `PAGE_HOME` + warning | — |

Blocked collections: `testimonials_v1_items` and `gallery_items` remain non-fillable; `validate_fields()` strips them.

## Test Plan
- [x] `php -l` on the 3 changed files — no syntax errors, PHP 8.2.29.
- [x] `php tests/wizard-ai-layer2-harness.php` — **5/5 pass**.
- [x] `php tests/wizard-internal-page-builder-harness.php` — **16/16 pass**.
- [x] `php tests/wizard-internal-page-templates-harness.php` — **11/11 pass**.
- [x] `php tests/wizard-blog-index-harness.php` — **7/7 pass**.
- [x] `php scripts/test-landing-run-orchestrator.php` — **293 passed, 0 failed**.
- [x] `php tests/wizard-home-seo-targeting-harness.php` — **9/9 pass**.
- [x] `php tests/wizard-integration-truth-harness.php` — **8/8 pass**.
- [x] Shared regression: `php tests/acf-inactive-frontend-harness.php` — **11/11 pass**.
- [x] Three-dot diff against tracker `feat/internal-page-builder` is exactly these 3 files (**+113 / −10 = 123 / 400**). No OpenSpec.
- [x] Scripts run without errors: N/A — no shell scripts in this PR.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts: N/A — no shell scripts
- [x] Skills tested in at least one agent: N/A — wizard domain feature, not a skill change
- [x] Docs updated if behavior changed: OpenSpec progress is on tracker #43; no public UI copy change
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Chain Context

| Field | Value |
|-------|-------|
| Chain | wizard-internal-page-builder |
| Tracker PR | #43 `feat/internal-page-builder` (draft, no-merge) |
| Position | 7A of 8 (internal page AI Layer 2) |
| Base | `feat/internal-page-builder` |
| Depends on | Tracker #43 / merged PR1–PR6 #44–#57 / approved issue #42 |
| Follow-up | PR7B [#59](https://github.com/glacayo/simple-rms-theme/pull/59) `feat/internal-page-provenance-hook` |
| Review budget | 123 / 400 |
| Starts at | Tracker ancestor `feat/internal-page-builder` @ `3d776c6` |
| Ends with | Dedicated Layer 2 contexts for six internal types; Home/Landing unchanged; blocked factual collections |

### Chain Overview

```text
main
 └── #43 feat/internal-page-builder  (draft tracker, no-merge)
      └── #44 PR1 feat/internal-page-blueprints  (merged)
           └── #45–#47 PR2A–PR2C section assembler  (merged)
                └── #48–#50 PR3A–PR3C About backend  (merged)
                     └── #51–#52 PR4A–PR4B type + templates  (merged)
                          └── #53–#54 PR5A–PR5B remaining types + provenance  (merged)
                               └── #57 PR6 feat/internal-page-blog-index  (merged)
                                    └── 📍 #58 PR7A feat/internal-page-ai-layer2
                                         └── #59 PR7B feat/internal-page-provenance-hook
                                              └── PR8 UI + activation
```

### Scope
- Includes: Layer 2 per-type matrix, `PAGE_PROJECTS`/`PAGE_TESTIMONIALS` constants, blocked gallery/testimonial collections, unknown-type fallback, and the 5/5 + regression proofs.
- Excludes: `acf/save_post` provenance hook wiring, empty-vs-read-failure completeness envelope, controller/dispatch/UI, activation, mutation fence. **Hook wiring remains PR7B.**
- Tracker #43 remains draft/no-merge. No `size:exception`.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit

### Rollback
Revert `473c2e9`. Removes Layer 2 internal contexts, `PAGE_PROJECTS`/`PAGE_TESTIMONIALS` constants, blueprint constant binding, and the Layer 2 harness. Does not touch provenance hook wiring, OpenSpec, or UI.
