### PR TITLE
feat(wizard): sync placeholder provenance on ACF saves

### DIFF
--- a/inc/wizard/class-placeholder-provenance-store.php
+++ b/inc/wizard/class-placeholder-provenance-store.php
@@ -132,6 +132,84 @@ final class Placeholder_Provenance_Store {
 	}
 
 	/**
+	 * Register the ACF save adapter. Invoked from wizard-init.php.
+	 */
+	public static function register(): void {
+		\add_action( 'acf/save_post', [ self::class, 'handle_acf_save_post' ], 20, 1 );
+	}
+
+	/**
+	 * `acf/save_post` adapter (priority 20). Never syncs without a complete snapshot.
+	 *
+	 * @param mixed $post_id ACF save target (post ID, "options", "user_n", "term_n").
+	 */
+	public static function handle_acf_save_post( $post_id ): bool {
+		static $running = false;
+		if ( $running ) {
+			return false;
+		}
+		if ( ! is_numeric( $post_id ) ) {
+			return false;
+		}
+		$id = \absint( $post_id );
+		if ( $id <= 0 ) {
+			return false;
+		}
+		if ( \defined( 'DOING_AUTOSAVE' ) && \DOING_AUTOSAVE ) {
+			return false;
+		}
+		if ( function_exists( 'wp_is_post_autosave' ) && \wp_is_post_autosave( $id ) ) {
+			return false;
+		}
+		if ( function_exists( 'wp_is_post_revision' ) && \wp_is_post_revision( $id ) ) {
+			return false;
+		}
+		if ( ! function_exists( 'get_field_object' ) || ! function_exists( 'get_post' ) ) {
+			return false;
+		}
+		$post = \get_post( $id );
+		if ( ! $post || 'page' !== ( $post->post_type ?? '' ) ) {
+			return false;
+		}
+		$sections = self::complete_page_sections_snapshot( $id );
+		if ( null === $sections ) {
+			return false;
+		}
+		$running = true;
+		try {
+			return ( new self() )->sync( $id, $sections );
+		} finally {
+			$running = false;
+		}
+	}
+
+	/**
+	 * Formatted `page_sections` snapshot from a complete ACF field object.
+	 *
+	 * `get_field( 'page_sections' )` returns false for both an empty flexible-content
+	 * value and a failed read. A valid field object with loaded/formatted `value === false`
+	 * is a complete empty snapshot and becomes `[]`. Failed/incomplete reads return null.
+	 *
+	 * @return array<int,array<string,mixed>>|null
+	 */
+	private static function complete_page_sections_snapshot( int $post_id ): ?array {
+		$field = \get_field_object( 'page_sections', $post_id, true, true );
+		if ( ! is_array( $field ) || ! array_key_exists( 'value', $field ) ) {
+			return null;
+		}
+
+		$value = $field['value'];
+		if ( false === $value ) {
+			return [];
+		}
+		if ( ! is_array( $value ) ) {
+			return null;
+		}
+
+		return $value;
+	}
+
+	/**
 	 * Reconcile provenance with a complete `page_sections` snapshot.
 	 *
 	 * Compatible with `acf/save_post` (priority 20). Invalid snapshots are a no-op.

--- a/inc/wizard/wizard-init.php
+++ b/inc/wizard/wizard-init.php
@@ -101,6 +101,8 @@ if ( Inc\Wizard\Wizard_Unlock_Controller::is_controlled_unlock_enabled() ) {
 }
 add_action( 'admin_post_' . Inc\Wizard\Wizard_Unlock_Controller::RELOCK_ACTION, 'rms_wizard_handle_relock_action' );
 
+Inc\Wizard\Placeholder_Provenance_Store::register();
+
 // Always-loaded Ads landing robots + sitemap protections (front-end + sitemaps).
 add_filter( 'wp_robots', 'rms_wizard_ads_landing_wp_robots' );
 add_filter( 'wp_sitemaps_posts_query_args', 'rms_wizard_exclude_ads_landings_from_wp_sitemap', 10, 2 );

--- a/scripts/test-landing-run-orchestrator.php
+++ b/scripts/test-landing-run-orchestrator.php
@@ -184,11 +184,12 @@ namespace {
 	function wp_cache_delete( $key, $group = '' ) { return true; }
 	function get_permalink( $id ) { return ''; }
 	function add_theme_page( ...$args ) {}
-	function add_action( ...$args ) {}
+	function add_action( ...$args ) { $GLOBALS['_wp_actions'][] = $args; }
 	function add_filter( ...$args ) {}
 	function register_rest_route( ...$args ) {}
 
 	$GLOBALS['_options'] = [];
+	$GLOBALS['_wp_actions'] = [];
 	$GLOBALS['_options_added'] = [];
 	$GLOBALS['_posts'] = [];
 	$GLOBALS['_updated_posts'] = [];
@@ -556,6 +557,23 @@ namespace {
 	require_once __DIR__ . '/../inc/wizard/class-menu-builder.php';
 	require_once __DIR__ . '/../inc/wizard/class-content-builder.php';
 	require_once __DIR__ . '/../inc/wizard/class-section-assembler.php';
+	require_once __DIR__ . '/../inc/wizard/class-placeholder-provenance-store.php';
+	\Inc\Wizard\Placeholder_Provenance_Store::register();
+	$provenance_hook = false;
+	foreach ( $GLOBALS['_wp_actions'] as $args ) {
+		if ( 'acf/save_post' === ( $args[0] ?? '' )
+			&& array( \Inc\Wizard\Placeholder_Provenance_Store::class, 'handle_acf_save_post' ) === ( $args[1] ?? null )
+			&& 20 === ( $args[2] ?? 0 )
+			&& 1 === ( $args[3] ?? 0 )
+		) {
+			$provenance_hook = true;
+			break;
+		}
+	}
+	if ( ! $provenance_hook ) {
+		fwrite( STDERR, "FAIL provenance acf/save_post registration was not recorded by add_action fake\n" );
+		exit( 1 );
+	}
 
 	// Stubs for AI/provider classes that are needed but not included.
 	if ( ! class_exists( 'Inc\Wizard\AI_Provider_Registry' ) ) {

--- a/tests/wizard-provenance-hook-harness.php
+++ b/tests/wizard-provenance-hook-harness.php
@@ -1,0 +1,230 @@
+<?php
+/**
+ * acf/save_post provenance adapter guards.
+ *
+ * Usage: php tests/wizard-provenance-hook-harness.php
+ */
+
+if ( PHP_SAPI !== 'cli' ) {
+	fwrite( STDERR, "CLI only.\n" );
+	exit( 1 );
+}
+
+$theme_root = dirname( __DIR__ );
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', $theme_root . '/' );
+}
+
+$GLOBALS['_options']            = array();
+$GLOBALS['_option_autoloads']   = array();
+$GLOBALS['_option_writes']      = array();
+$GLOBALS['_wp_actions']         = array();
+$GLOBALS['_nested_save_post']   = null;
+$GLOBALS['_nested_save_result'] = null;
+$GLOBALS['_posts']              = array();
+$GLOBALS['_field_objects']      = array();
+$GLOBALS['_field_object_calls'] = array();
+$GLOBALS['_autosave']           = array();
+$GLOBALS['_revision']           = array();
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $k ) { return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $k ) ) ); }
+}
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $v ) { return abs( (int) $v ); }
+}
+if ( ! function_exists( 'current_time' ) ) {
+	function current_time( $t, $g = false ) { unset( $t, $g ); return '2026-08-27 00:00:00'; }
+}
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $d, $o = 0 ) { return json_encode( $d, $o ); }
+}
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $n, $d = false ) { return $GLOBALS['_options'][ $n ] ?? $d; }
+}
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( $n, $v, $a = null ) {
+		$GLOBALS['_options'][ $n ] = $v;
+		$GLOBALS['_option_autoloads'][ $n ] = $a;
+		$GLOBALS['_option_writes'][] = $n;
+		$nested = $GLOBALS['_nested_save_post'];
+		$GLOBALS['_nested_save_post'] = null;
+		if ( null !== $nested ) {
+			$GLOBALS['_nested_save_result'] = \Inc\Wizard\Placeholder_Provenance_Store::handle_acf_save_post( $nested );
+		}
+		return true;
+	}
+}
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		$GLOBALS['_wp_actions'][] = array( $hook, $callback, $priority, $accepted_args );
+		return true;
+	}
+}
+if ( ! function_exists( 'get_post' ) ) {
+	function get_post( $id ) { return $GLOBALS['_posts'][ (int) $id ] ?? null; }
+}
+if ( ! function_exists( 'get_field_object' ) ) {
+	function get_field_object( $selector, $post_id = false, $format_value = true, $load_value = true ) {
+		$GLOBALS['_field_object_calls'][] = array( $selector, $post_id, $format_value, $load_value );
+		$id = (int) $post_id;
+		if ( ! array_key_exists( $id, $GLOBALS['_field_objects'] ) || ! array_key_exists( $selector, $GLOBALS['_field_objects'][ $id ] ) ) {
+			return false;
+		}
+		return $GLOBALS['_field_objects'][ $id ][ $selector ];
+	}
+}
+if ( ! function_exists( 'wp_is_post_autosave' ) ) {
+	function wp_is_post_autosave( $id ) { return ! empty( $GLOBALS['_autosave'][ (int) $id ] ); }
+}
+if ( ! function_exists( 'wp_is_post_revision' ) ) {
+	function wp_is_post_revision( $id ) { return ! empty( $GLOBALS['_revision'][ (int) $id ] ); }
+}
+
+require_once $theme_root . '/inc/wizard/class-placeholder-provenance-store.php';
+
+use Inc\Wizard\Placeholder_Provenance_Store;
+
+function rms_hook_assert( $c, string $m ): void {
+	if ( ! $c ) {
+		fwrite( STDERR, $m . "\n" );
+		exit( 1 );
+	}
+}
+
+function rms_hook_set_sections( int $id, $value ): void {
+	$GLOBALS['_field_objects'][ $id ]['page_sections'] = array(
+		'name'  => 'page_sections',
+		'type'  => 'flexible_content',
+		'value' => $value,
+	);
+}
+
+function rms_hook_fresh_query( int $id ): array {
+	return ( new Placeholder_Provenance_Store() )->query( $id );
+}
+
+function rms_hook_provenance_writes(): int {
+	$n = 0;
+	foreach ( $GLOBALS['_option_writes'] as $key ) {
+		if ( Placeholder_Provenance_Store::OPTION_KEY === $key ) {
+			++$n;
+		}
+	}
+	return $n;
+}
+
+function rms_hook_last_field_object_call(): array {
+	$calls = $GLOBALS['_field_object_calls'];
+	return is_array( $calls ) && [] !== $calls ? $calls[ count( $calls ) - 1 ] : array();
+}
+
+Placeholder_Provenance_Store::register();
+$reg = $GLOBALS['_wp_actions'][0] ?? null;
+rms_hook_assert(
+	is_array( $reg )
+	&& 'acf/save_post' === $reg[0]
+	&& array( Placeholder_Provenance_Store::class, 'handle_acf_save_post' ) === $reg[1]
+	&& 20 === $reg[2]
+	&& 1 === $reg[3],
+	'runtime register acf/save_post priority 20 args 1'
+);
+echo "PASS hook-registered-priority-20\n";
+$passed = 1;
+
+$store = new Placeholder_Provenance_Store();
+$store->record( 50, 'about-us', 0, 'about_headline', 'missing_client_fact', 'Hello' );
+$GLOBALS['_posts'][50] = (object) array( 'post_type' => 'page' );
+$snapshot = array( array( 'acf_fc_layout' => 'about-us', 'about_headline' => 'Hello' ) );
+rms_hook_set_sections( 50, $snapshot );
+$GLOBALS['_option_writes'] = array();
+rms_hook_assert( Placeholder_Provenance_Store::handle_acf_save_post( 50 ), 'valid page save' );
+rms_hook_assert( isset( rms_hook_fresh_query( 50 )['0:about_headline'] ), 'valid save keeps named-key match' );
+rms_hook_assert( 1 === rms_hook_provenance_writes(), 'nonempty snapshot syncs once' );
+rms_hook_assert( array( 'page_sections', 50, true, true ) === rms_hook_last_field_object_call(), 'formatted loaded field object' );
+echo "PASS valid-full-save-sync\n";
+++$passed;
+
+$before = rms_hook_fresh_query( 50 );
+rms_hook_assert( false === Placeholder_Provenance_Store::handle_acf_save_post( 'options' ), 'options skipped' );
+rms_hook_assert( false === Placeholder_Provenance_Store::handle_acf_save_post( 'user_1' ), 'user skipped' );
+rms_hook_assert( false === Placeholder_Provenance_Store::handle_acf_save_post( 'term_3' ), 'term skipped' );
+$GLOBALS['_posts'][51] = (object) array( 'post_type' => 'post' );
+rms_hook_set_sections( 51, array() );
+rms_hook_assert( false === Placeholder_Provenance_Store::handle_acf_save_post( 51 ), 'non-page skipped' );
+$GLOBALS['_autosave'][50] = true;
+rms_hook_assert( false === Placeholder_Provenance_Store::handle_acf_save_post( 50 ), 'autosave skipped' );
+unset( $GLOBALS['_autosave'][50] );
+$GLOBALS['_revision'][50] = true;
+rms_hook_assert( false === Placeholder_Provenance_Store::handle_acf_save_post( 50 ), 'revision skipped' );
+unset( $GLOBALS['_revision'][50] );
+unset( $GLOBALS['_field_objects'][50]['page_sections'] );
+rms_hook_assert( false === Placeholder_Provenance_Store::handle_acf_save_post( 50 ) && $before === rms_hook_fresh_query( 50 ), 'missing field object no-op' );
+rms_hook_set_sections( 50, array( 'about_headline' => 'Hello' ) );
+rms_hook_assert( false === Placeholder_Provenance_Store::handle_acf_save_post( 50 ) && $before === rms_hook_fresh_query( 50 ), 'malformed snapshot no-op' );
+echo "PASS hook-guards-no-op\n";
+++$passed;
+
+rms_hook_set_sections( 50, $snapshot );
+$store->record( 60, 'contact-info', 0, 'contact_info_headline', 'missing_client_fact', 'Hi' );
+$GLOBALS['_posts'][60] = (object) array( 'post_type' => 'page' );
+rms_hook_set_sections( 60, array( array( 'acf_fc_layout' => 'contact-info', 'contact_info_headline' => 'Changed' ) ) );
+Placeholder_Provenance_Store::handle_acf_save_post( 60 );
+rms_hook_assert( array() === rms_hook_fresh_query( 60 ) && isset( rms_hook_fresh_query( 50 )['0:about_headline'] ), 'page isolation' );
+echo "PASS page-isolation-and-replace\n";
+++$passed;
+
+$store->record( 70, 'about-us', 0, 'about_headline', 'missing_client_fact', 'Keep' );
+$GLOBALS['_posts'][70] = (object) array( 'post_type' => 'page' );
+rms_hook_set_sections( 70, array( array( 'acf_fc_layout' => 'about-us', 'about_headline' => 'Keep' ) ) );
+rms_hook_set_sections( 50, false );
+$GLOBALS['_option_writes'] = array();
+rms_hook_assert( true === Placeholder_Provenance_Store::handle_acf_save_post( 50 ), 'empty complete save' );
+rms_hook_assert( array() === rms_hook_fresh_query( 50 ), 'empty value=false clears this page' );
+rms_hook_assert( isset( rms_hook_fresh_query( 70 )['0:about_headline'] ), 'empty save is page-scoped' );
+rms_hook_assert( 1 === rms_hook_provenance_writes(), 'empty snapshot syncs once' );
+echo "PASS empty-field-object-clears-only-that-page\n";
+++$passed;
+
+( new Placeholder_Provenance_Store() )->record( 50, 'about-us', 0, 'about_headline', 'missing_client_fact', 'Hello' );
+$kept = rms_hook_fresh_query( 50 );
+$GLOBALS['_field_objects'][50]['page_sections'] = false;
+rms_hook_assert( false === Placeholder_Provenance_Store::handle_acf_save_post( 50 ) && $kept === rms_hook_fresh_query( 50 ), 'false field object does not clear' );
+echo "PASS field-object-read-failure-untouched\n";
+++$passed;
+
+$GLOBALS['_field_objects'][50]['page_sections'] = array(
+	'name' => 'page_sections',
+	'type' => 'flexible_content',
+);
+rms_hook_assert( false === Placeholder_Provenance_Store::handle_acf_save_post( 50 ) && $kept === rms_hook_fresh_query( 50 ), 'missing value does not clear' );
+rms_hook_set_sections( 50, array( 'about_headline' => 'Hello' ) );
+rms_hook_assert( false === Placeholder_Provenance_Store::handle_acf_save_post( 50 ) && $kept === rms_hook_fresh_query( 50 ), 'malformed nonempty does not clear' );
+echo "PASS missing-or-malformed-value-untouched\n";
+++$passed;
+
+rms_hook_set_sections( 50, $snapshot );
+$GLOBALS['_option_writes'] = array();
+rms_hook_assert( Placeholder_Provenance_Store::handle_acf_save_post( 50 ), 'nonempty complete save' );
+rms_hook_assert( isset( rms_hook_fresh_query( 50 )['0:about_headline'] ), 'nonempty named keys still match' );
+rms_hook_assert( 1 === rms_hook_provenance_writes(), 'nonempty full snapshot syncs once' );
+echo "PASS nonempty-full-snapshot-syncs-once\n";
+++$passed;
+
+( new Placeholder_Provenance_Store() )->record( 80, 'about-us', 0, 'about_headline', 'missing_client_fact', 'Nested' );
+$GLOBALS['_posts'][80] = (object) array( 'post_type' => 'page' );
+rms_hook_set_sections( 80, false );
+$kept80 = rms_hook_fresh_query( 80 );
+rms_hook_set_sections( 50, $snapshot );
+$GLOBALS['_option_writes']      = array();
+$GLOBALS['_nested_save_post']   = 80;
+$GLOBALS['_nested_save_result'] = null;
+rms_hook_assert( Placeholder_Provenance_Store::handle_acf_save_post( 50 ), 'outer save during nested attempt' );
+rms_hook_assert( false === $GLOBALS['_nested_save_result'], 'nested handle refused' );
+rms_hook_assert( 1 === rms_hook_provenance_writes(), 'nested attempt does not write again' );
+rms_hook_assert( $kept80 === rms_hook_fresh_query( 80 ), 'nested empty snapshot does not clear other page' );
+rms_hook_assert( isset( rms_hook_fresh_query( 50 )['0:about_headline'] ), 'outer page still synced' );
+echo "PASS nested-handle-reentrancy\n";
+++$passed;
+
+echo 'Harness passed: ' . $passed . " scenarios.\n";


### PR DESCRIPTION
Closes #42

Depends on PR7A [#58](https://github.com/glacayo/simple-rms-theme/pull/58). Do not merge until PR7A lands on the tracker. Do not retarget this PR to the tracker until PR7A merges.

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Wires existing placeholder provenance `sync()` to ACF saves via `Placeholder_Provenance_Store::register()` → `add_action( 'acf/save_post', [ self::class, 'handle_acf_save_post' ], 20, 1 )`.
- Completeness envelope: a valid field object with formatted/loaded `value === false` is an empty snapshot (`[]`) and syncs once, page-scoped. Read failure, missing `value`, or malformed nonempty snapshots are no-ops.
- Invalid contexts (options/user/term/non-page/autosave/revision) no-op. Nested `handle_acf_save_post()` during persist is refused (one write, no cross-page mutation). No UI, controller, or mutation fence.

## Changes

| File | Change |
|------|--------|
| `inc/wizard/class-placeholder-provenance-store.php` | `register()`, `handle_acf_save_post()`, `complete_page_sections_snapshot()` completeness envelope + reentrancy guard. |
| `inc/wizard/wizard-init.php` | Call `Placeholder_Provenance_Store::register()` at bootstrap. |
| `scripts/test-landing-run-orchestrator.php` | Fake `add_action` records args; bootstrap asserts runtime `register()` (priority 20, args 1). |
| `tests/wizard-provenance-hook-harness.php` | Runtime registration, empty-vs-read-failure, invalid contexts, page isolation, reentrancy (9/9). |

## Runtime contract

- Registration: `acf/save_post` priority **20**, accepted args **1**, callback `[ Placeholder_Provenance_Store::class, 'handle_acf_save_post' ]`. Proven by fake `add_action`, not source grep.
- Empty vs read failure: `get_field_object( 'page_sections', $id, true, true )` with `value === false` → `sync( $id, [] )` once. `get_field_object()` returning false, missing `value`, or a non-array nonempty value → no-op, provenance untouched.
- Invalid contexts: `'options'`, `'user_n'`, `'term_n'`, non-page, autosave, revision → no-op.
- Page isolation: empty or replace syncs only the saved page.
- Reentrancy: nested `handle_acf_save_post()` during `update_option` persist returns false, one write, no cross-page mutation.

Explicitly **not** in this PR: admin UI, controller/dispatch, mutation fence, AI Layer 2 (that is PR7A #58).

## Test Plan
- [x] `php -l` on the 4 changed files — no syntax errors, PHP 8.2.29.
- [x] `php tests/wizard-provenance-hook-harness.php` — **9/9 pass**.
- [x] `php tests/wizard-placeholder-provenance-harness.php` — **6/6 pass**.
- [x] `php tests/wizard-internal-page-builder-harness.php` — **16/16 pass**.
- [x] `php scripts/test-landing-run-orchestrator.php` — **293 passed, 0 failed** (bootstrap asserts `register()` via fake `add_action`).
- [x] `php tests/acf-inactive-frontend-harness.php` — **11/11 pass**.
- [x] `php tests/wizard-home-seo-targeting-harness.php` — **9/9 pass**.
- [x] `php tests/wizard-integration-truth-harness.php` — **8/8 pass**.
- [x] Shared regression: `php tests/wizard-ai-layer2-harness.php` — **5/5 pass**.
- [x] Three-dot diff against PR7A `feat/internal-page-ai-layer2` is exactly these 4 files (**+329 / −1 = 330 / 400**). No inherited PR7A files. No OpenSpec.
- [x] Scripts run without errors: N/A — no shell scripts in this PR.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts: N/A — no shell scripts
- [x] Skills tested in at least one agent: N/A — wizard domain feature, not a skill change
- [x] Docs updated if behavior changed: OpenSpec progress is on tracker #43; no public UI copy change
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Chain Context

| Field | Value |
|-------|-------|
| Chain | wizard-internal-page-builder |
| Tracker PR | #43 `feat/internal-page-builder` (draft, no-merge) |
| Position | 7B of 8 (placeholder provenance ACF save hook) |
| Base | `feat/internal-page-ai-layer2` (PR7A #58) |
| Depends on | PR7A [#58](https://github.com/glacayo/simple-rms-theme/pull/58) / tracker #43 / merged PR1–PR6 #44–#57 / approved issue #42 |
| Follow-up | PR8 UI + activation (out of scope) |
| Review budget | 330 / 400 |
| Starts at | PR7A #58 `feat/internal-page-ai-layer2` @ `473c2e9` |
| Ends with | Runtime `acf/save_post`(20, args 1) provenance sync with empty-vs-read-failure completeness, invalid-context no-ops, page isolation, and reentrancy guard |

### Chain Overview

```text
main
 └── #43 feat/internal-page-builder  (draft tracker, no-merge)
      └── #44 PR1 feat/internal-page-blueprints  (merged)
           └── #45–#47 PR2A–PR2C section assembler  (merged)
                └── #48–#50 PR3A–PR3C About backend  (merged)
                     └── #51–#52 PR4A–PR4B type + templates  (merged)
                          └── #53–#54 PR5A–PR5B remaining types + provenance  (merged)
                               └── #57 PR6 feat/internal-page-blog-index  (merged)
                                    └── #58 PR7A feat/internal-page-ai-layer2
                                         └── 📍 PR7B feat/internal-page-provenance-hook
                                              └── PR8 UI + activation
```

### Scope
- Includes: ACF `register()` runtime contract, completeness envelope, invalid-context guards, page isolation, runtime reentrancy, Landing fake-path registration proof, and the 9/9 + 6/6 + regression proofs.
- Excludes: UI, controller/dispatch, mutation fence, AI Layer 2 (PR7A). Do not re-add store `sync()` methods; this slice only wires the existing service.
- Tracker #43 remains draft/no-merge. No `size:exception`.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit

### Rollback
Revert `7c81280`. Drops `register()` / `handle_acf_save_post()` / `complete_page_sections_snapshot()`, the wizard-init call, landing `add_action` fake + registration assert, and the hook harness. PR7A Layer 2 stays. Does not touch OpenSpec or UI.
