### PR TITLE
feat(wizard): add secure internal page dispatch

### DIFF
--- a/inc/wizard/class-step-controller.php
+++ b/inc/wizard/class-step-controller.php
@@ -61,6 +61,7 @@ class Step_Controller {
 		'ia-generation',
 		'home-page-builder',
 		'landing-page-builder',
+		'internal-page-builder',
 		'unlock',
 		'relock',
 	];
@@ -176,7 +177,7 @@ class Step_Controller {
 			return $fence_owner;
 		}
 
-		$this->mutation_fence_owner = (string) $fence_owner;
+		$this->enter_authorized_mutation_scope( (string) $fence_owner );
 
 		// Orchestrated landing actions keep the per-run lease for run ownership.
 		// The legacy UI state lock is compatibility-only and is not acquired for
@@ -200,10 +201,12 @@ class Step_Controller {
 			}
 		}
 
+		$is_internal_skip_all = 'internal-page-builder' === $step
+			&& $this->payload_is_truthy( $payload['skip_all'] ?? false );
+
 		if ( ! $is_landing_orchestrated ) {
 			if ( ! $this->state_manager->acquire_lock( self::LOCK_NAME ) ) {
-				$mutation_fence->release( (string) $fence_owner );
-				$this->mutation_fence_owner = '';
+				$this->leave_authorized_mutation_scope( $mutation_fence, (string) $fence_owner );
 
 				return new \WP_Error( 'rms_wizard_busy', \__( 'Another setup wizard action is already running.', 'simple-rms-theme' ), [ 'status' => 409 ] );
 			}
@@ -212,12 +215,16 @@ class Step_Controller {
 		}
 
 		$progress_status_written = false;
+		$prior_step_status       = (string) ( $this->state_manager->get_state()['step_status'][ $step ] ?? 'pending' );
+		if ( '' === $prior_step_status ) {
+			$prior_step_status = 'pending';
+		}
 
 		try {
 			// Pseudo-steps (unlock/relock) must not pollute current_step or step_status.
 			// Landing start/process persist their own run/public state.
 			// Skip-all either 409s without mutation or marks complete itself.
-			if ( ! $this->is_completed_gate_allowlisted( $step ) && ! $is_landing_orchestrated && ! $is_landing_skip_all ) {
+			if ( ! $this->is_completed_gate_allowlisted( $step ) && ! $is_landing_orchestrated && ! $is_landing_skip_all && ! $is_internal_skip_all ) {
 				$this->state_manager->set_current_step( $step );
 				$this->state_manager->set_step_status( $step, 'running' );
 				$progress_status_written = true;
@@ -226,6 +233,10 @@ class Step_Controller {
 			$result = $this->dispatch_step( $step, $payload );
 
 			if ( \is_wp_error( $result ) ) {
+				if ( $progress_status_written && 'internal-page-builder' === $step ) {
+					$this->state_manager->set_step_status( $step, $prior_step_status );
+				}
+
 				return $result;
 			}
 
@@ -296,6 +307,7 @@ class Step_Controller {
 					$this->state_manager->release_lock( self::LOCK_NAME );
 				}
 			} finally {
+				$mutation_fence->clear_agent( (string) $fence_owner );
 				$mutation_fence->release( (string) $fence_owner );
 				$this->mutation_fence_owner = '';
 			}
@@ -437,6 +449,11 @@ class Step_Controller {
 			case 'landing-page-builder':
 				return ( new Step_Landing_Page_Builder( $this->logger, $this->state_manager ) )->run( $payload );
 
+			case 'internal-page-builder':
+				$builder = new Step_Internal_Page_Builder( $this->logger, $this->state_manager );
+				$this->authorize_internal_builder( $builder );
+				return $builder->run( $payload );
+
 			case 'unlock':
 				return ( new Wizard_Unlock_Controller( $this->state_manager, $this->logger ) )->unlock();
 
@@ -537,6 +554,29 @@ class Step_Controller {
 		return true === $value || 1 === $value || '1' === $value || 'true' === $value || 'yes' === $value || 'on' === $value;
 	}
 
+	private function enter_authorized_mutation_scope( string $owner ): void {
+		$this->mutation_fence_owner = $owner;
+	}
+
+	private function leave_authorized_mutation_scope( Wizard_Mutation_Fence $fence, string $owner ): void {
+		$fence->clear_agent( $owner );
+		$fence->release( $owner );
+
+		if ( $this->mutation_fence_owner === $owner ) {
+			$this->mutation_fence_owner = '';
+		}
+	}
+
+	private function authorize_internal_builder( Step_Internal_Page_Builder $builder ): void {
+		$owner = $this->mutation_fence_owner;
+		if ( '' === $owner ) {
+			return;
+		}
+
+		$builder->accept_mutation_owner( $owner );
+		( new Wizard_Mutation_Fence() )->authorize_agent( $builder, $owner );
+	}
+
 	private function normalize_step( string $step ): string {
 		$step = \sanitize_key( $step );
 
@@ -550,6 +590,7 @@ class Step_Controller {
 			'menu_setup'        => 'menu-setup',
 			'home_page_builder' => 'home-page-builder',
 			'landing_page_builder' => 'landing-page-builder',
+			'internal_page_builder' => 'internal-page-builder',
 		];
 
 		return $aliases[ $step ] ?? $step;

--- a/tests/wizard-internal-page-activation-bootstrap.php
+++ b/tests/wizard-internal-page-activation-bootstrap.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Shared stubs for Internal Page Builder activation harnesses.
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+if ( ! class_exists( 'WP_Error', false ) ) {
+	class WP_Error {
+		public $code;
+		public $message;
+		public $data;
+		public function __construct( $c = '', $m = '', $d = '' ) {
+			$this->code    = $c;
+			$this->message = $m;
+			$this->data    = $d;
+		}
+		public function get_error_code() {
+			return $this->code;
+		}
+	}
+}
+if ( ! class_exists( 'WP_Post', false ) ) {
+	class WP_Post {
+		public $ID;
+		public $post_type    = 'page';
+		public $post_content = '';
+		public $post_name    = '';
+		public function __construct( $id = 0 ) {
+			$this->ID = (int) $id;
+		}
+	}
+}
+
+$GLOBALS['_options']      = array();
+$GLOBALS['_db_options']   = array();
+$GLOBALS['_can']          = true;
+$GLOBALS['_wpdb_inserts'] = 0;
+$GLOBALS['_posts']        = array();
+$GLOBALS['_post_meta']    = array();
+$GLOBALS['_page_writes']  = 0;
+
+if ( ! function_exists( 'sanitize_key' ) ) { function sanitize_key( $k ) { return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $k ) ) ); } }
+if ( ! function_exists( 'sanitize_title' ) ) { function sanitize_title( $v ) { return strtolower( preg_replace( '/[^a-z0-9-]+/', '-', (string) $v ) ); } }
+if ( ! function_exists( 'sanitize_text_field' ) ) { function sanitize_text_field( $s ) { return trim( (string) $s ); } }
+if ( ! function_exists( '__' ) ) { function __( $t, $d = null ) { unset( $d ); return $t; } }
+if ( ! function_exists( 'absint' ) ) { function absint( $v ) { return abs( (int) $v ); } }
+if ( ! function_exists( 'current_time' ) ) { function current_time( $t, $g = false ) { unset( $t, $g ); return '2026-08-27 00:00:00'; } }
+if ( ! function_exists( 'get_option' ) ) { function get_option( $n, $d = false ) { return $GLOBALS['_options'][ $n ] ?? $d; } }
+if ( ! function_exists( 'update_option' ) ) { function update_option( $n, $v, $a = null ) { unset( $a ); $GLOBALS['_options'][ $n ] = $v; return true; } }
+if ( ! function_exists( 'delete_option' ) ) { function delete_option( $n ) { unset( $GLOBALS['_options'][ $n ] ); return true; } }
+if ( ! function_exists( 'current_user_can' ) ) { function current_user_can( $c ) { unset( $c ); return ! empty( $GLOBALS['_can'] ); } }
+if ( ! function_exists( 'get_current_user_id' ) ) { function get_current_user_id() { return 1; } }
+if ( ! function_exists( 'is_wp_error' ) ) { function is_wp_error( $t ) { return $t instanceof WP_Error; } }
+if ( ! function_exists( 'wp_json_encode' ) ) { function wp_json_encode( $d, $o = 0 ) { return json_encode( $d, $o ); } }
+if ( ! function_exists( 'maybe_serialize' ) ) { function maybe_serialize( $v ) { return is_array( $v ) || is_object( $v ) ? serialize( $v ) : $v; } }
+if ( ! function_exists( 'maybe_unserialize' ) ) {
+	function maybe_unserialize( $v ) {
+		if ( ! is_string( $v ) ) { return $v; }
+		$d = @unserialize( $v );
+		return false === $d && 'b:0;' !== $v ? $v : $d;
+	}
+}
+if ( ! function_exists( 'wp_cache_delete' ) ) { function wp_cache_delete( $k, $g = '' ) { unset( $k, $g ); return true; } }
+if ( ! function_exists( 'wp_generate_uuid4' ) ) { function wp_generate_uuid4() { return 'owner-' . ( $GLOBALS['_wpdb_inserts'] + 1 ); } }
+if ( ! function_exists( 'get_post' ) ) { function get_post( $id ) { return $GLOBALS['_posts'][ (int) $id ] ?? null; } }
+if ( ! function_exists( 'get_post_meta' ) ) { function get_post_meta( $id, $k, $s = false ) { unset( $s ); return $GLOBALS['_post_meta'][ (int) $id ][ $k ] ?? ''; } }
+if ( ! function_exists( 'wp_update_post' ) ) {
+	function wp_update_post( $data, $wp_error = false ) {
+		unset( $wp_error );
+		$GLOBALS['_page_writes']++;
+		$id = absint( $data['ID'] ?? 0 );
+		return $id > 0 ? $id : new WP_Error( 'update_failed', 'missing id' );
+	}
+}
+
+if ( ! isset( $GLOBALS['wpdb'] ) ) {
+	$GLOBALS['wpdb'] = new class {
+		public $options = 'wp_options';
+		public function prepare( $q, ...$a ) {
+			return array( 'sql' => (string) $q, 'args' => $a );
+		}
+		public function get_var( $q ) {
+			$name = is_array( $q ) ? (string) ( $q['args'][0] ?? '' ) : '';
+			return $GLOBALS['_db_options'][ $name ] ?? null;
+		}
+		public function query( $q ) {
+			$sql  = is_array( $q ) ? (string) $q['sql'] : (string) $q;
+			$args = is_array( $q ) ? $q['args'] : array();
+			$name = (string) ( $args[0] ?? '' );
+			if ( false !== stripos( $sql, 'INSERT' ) ) {
+				if ( isset( $GLOBALS['_db_options'][ $name ] ) ) {
+					return 0;
+				}
+				$GLOBALS['_db_options'][ $name ] = (string) ( $args[1] ?? '' );
+				$GLOBALS['_wpdb_inserts']++;
+				return 1;
+			}
+			if ( false !== stripos( $sql, 'DELETE' ) ) {
+				$raw = (string) ( $args[1] ?? '' );
+				if ( ( $GLOBALS['_db_options'][ $name ] ?? null ) === $raw ) {
+					unset( $GLOBALS['_db_options'][ $name ] );
+					return 1;
+				}
+				return 0;
+			}
+			return 0;
+		}
+	};
+}
+
+$theme_root = dirname( __DIR__ );
+foreach ( array(
+	'class-logger.php',
+	'class-state-manager.php',
+	'class-wizard-mutation-fence.php',
+	'class-wizard-unlock-controller.php',
+	'class-step-controller.php',
+	'class-internal-page-blueprints.php',
+	'class-ai-content-harness.php',
+	'class-canonical-section-store.php',
+	'class-yoast-meta-writer.php',
+	'class-content-builder.php',
+	'class-section-assembler.php',
+	'class-placeholder-provenance-store.php',
+	'class-step-internal-page-builder.php',
+) as $file ) {
+	require_once $theme_root . '/inc/wizard/' . $file;
+}
+
+if ( ! function_exists( 'rms_ipa_assert' ) ) {
+	function rms_ipa_assert( $c, string $m ): void {
+		if ( ! $c ) {
+			fwrite( STDERR, $m . "\n" );
+			exit( 1 );
+		}
+	}
+}
+
+if ( ! function_exists( 'rms_ipa_reset' ) ) {
+	function rms_ipa_reset(): void {
+		$GLOBALS['_options']      = array();
+		$GLOBALS['_db_options']   = array();
+		$GLOBALS['_wpdb_inserts'] = 0;
+		$GLOBALS['_posts']        = array();
+		$GLOBALS['_post_meta']    = array();
+		$GLOBALS['_page_writes']  = 0;
+		$GLOBALS['_can']          = true;
+	}
+}
+
+if ( ! function_exists( 'rms_ipa_seed_about' ) ) {
+	function rms_ipa_seed_about(): void {
+		$post             = new WP_Post( 12 );
+		$post->post_name  = 'about';
+		$GLOBALS['_posts'][12] = $post;
+		$GLOBALS['_post_meta'][12]['page_sections'] = array(
+			array(
+				'acf_fc_layout'  => 'about-us',
+				'about_headline' => 'Keep this copy',
+			),
+		);
+		$sm = new \Inc\Wizard\State_Manager();
+		$st = $sm->get_state();
+		$st['generated_pages'] = array(
+			array(
+				'id'   => 12,
+				'slug' => 'about',
+				'type' => 'about',
+			),
+		);
+		$st['internal_pages']['about'] = array_merge(
+			\Inc\Wizard\State_Manager::INTERNAL_PAGE_ENTRY,
+			array(
+				'post_id' => 12,
+				'status'  => 'pending',
+			)
+		);
+		$sm->save_state( $st );
+	}
+}
+
+if ( ! class_exists( 'Inc\\Wizard\\Landing_Run_Orchestrator', false ) ) {
+	eval( 'namespace Inc\\Wizard; class Landing_Run_Orchestrator { public function __construct( ...$a ) {} public function get_public_run() { return null; } public function recover_stale_lease() {} }' );
+}

--- a/tests/wizard-internal-page-activation-harness.php
+++ b/tests/wizard-internal-page-activation-harness.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Hidden-dispatch activation proofs. These 8 cases must pass whether or not
+ * internal-page-builder is in REQUIRED_STEPS.
+ *
+ * Usage: php tests/wizard-internal-page-activation-harness.php
+ */
+if ( PHP_SAPI !== 'cli' ) {
+	fwrite( STDERR, "CLI only.\n" );
+	exit( 1 );
+}
+
+require_once __DIR__ . '/wizard-internal-page-activation-bootstrap.php';
+
+use Inc\Wizard\Step_Controller;
+use Inc\Wizard\State_Manager;
+use Inc\Wizard\Step_Internal_Page_Builder;
+use Inc\Wizard\Wizard_Mutation_Fence;
+
+$passed = 0;
+
+$GLOBALS['_can'] = false;
+$denied = ( new Step_Controller() )->execute_step( 'internal-page-builder', array( 'skip_all' => true ) );
+rms_ipa_assert( is_wp_error( $denied ) && 'rms_wizard_forbidden' === $denied->get_error_code(), 'capability gate' );
+$GLOBALS['_can'] = true;
+echo "PASS capability-forbidden\n";
+++$passed;
+
+$unknown = ( new Step_Controller() )->execute_step( 'not-a-real-step', array() );
+rms_ipa_assert( is_wp_error( $unknown ) && 'rms_wizard_unknown_step' === $unknown->get_error_code(), 'unknown step' );
+echo "PASS unknown-step-rejected\n";
+++$passed;
+
+rms_ipa_reset();
+( new State_Manager() )->mark_completed();
+$locked = ( new Step_Controller() )->execute_step( 'internal-page-builder', array( 'skip_all' => true ) );
+rms_ipa_assert( is_wp_error( $locked ) && 'rms_wizard_locked' === $locked->get_error_code(), 'completed sites stay locked' );
+$unlock = ( new Step_Controller() )->execute_step( 'unlock', array() );
+rms_ipa_assert( ! is_wp_error( $unlock ) && ! empty( $unlock['success'] ), 'unlock via execute_step' );
+$after_unlock = ( new Step_Controller() )->execute_step( 'internal-page-builder', array( 'skip_all' => true ) );
+rms_ipa_assert( ! is_wp_error( $after_unlock ) && ! empty( $after_unlock['success'] ), 'unlocked completed site can skip-all' );
+echo "PASS completed-site-locked-until-unlock\n";
+++$passed;
+
+rms_ipa_reset();
+rms_ipa_seed_about();
+$meta_before  = $GLOBALS['_post_meta'];
+$pages_before = ( new State_Manager() )->get_state()['generated_pages'];
+$direct       = ( new Step_Internal_Page_Builder() )->run( array( 'skip_all' => true ) );
+rms_ipa_assert( is_wp_error( $direct ) && 'rms_wizard_mutation_unfenced' === $direct->get_error_code(), 'direct run rejected' );
+rms_ipa_assert( $meta_before === $GLOBALS['_post_meta'], 'direct skip-all writes no ACF' );
+rms_ipa_assert( $pages_before === ( new State_Manager() )->get_state()['generated_pages'], 'direct skip-all writes no pages' );
+rms_ipa_assert( 0 === $GLOBALS['_page_writes'], 'direct skip-all writes no posts' );
+echo "PASS direct-builder-unfenced\n";
+++$passed;
+
+$skip = ( new Step_Controller() )->execute_step( 'internal-page-builder', array( 'skip_all' => true ) );
+rms_ipa_assert( ! is_wp_error( $skip ) && ! empty( $skip['success'] ) && ! empty( $skip['result']['skipped'] ), 'skip-all through execute_step' );
+rms_ipa_assert( 'complete' === ( ( new State_Manager() )->get_state()['step_status']['internal-page-builder'] ?? '' ), 'skip-all completes step' );
+rms_ipa_assert( $meta_before === $GLOBALS['_post_meta'], 'seeded skip-all writes no ACF' );
+rms_ipa_assert( $pages_before === ( new State_Manager() )->get_state()['generated_pages'], 'seeded skip-all writes no generated pages' );
+rms_ipa_assert( 0 === $GLOBALS['_page_writes'], 'seeded skip-all writes no posts' );
+rms_ipa_assert( $GLOBALS['_wpdb_inserts'] > 0, 'mutation fence acquired' );
+$held = ( new Wizard_Mutation_Fence() )->is_held();
+rms_ipa_assert( false === $held, 'fence released after skip-all' );
+echo "PASS skip-all-via-controller-fence\n";
+++$passed;
+
+rms_ipa_reset();
+rms_ipa_seed_about();
+$start = ( new Step_Controller() )->execute_step( 'internal-page-builder', array( 'action' => 'start' ) );
+rms_ipa_assert( ! is_wp_error( $start ) && 'running' === ( $start['state']['step_status']['internal-page-builder'] ?? '' ), 'authorized start is running' );
+$forged = ( new Step_Controller() )->execute_step(
+	'internal-page-builder',
+	array(
+		'action'    => 'process',
+		'page_type' => 'services',
+		'post_id'   => 99,
+		'slug'      => 'home',
+	)
+);
+rms_ipa_assert( is_wp_error( $forged ) && 'rms_wizard_internal_identity' === $forged->get_error_code(), 'forged identity rejected' );
+rms_ipa_assert( 0 === $GLOBALS['_page_writes'], 'forged identity writes no posts' );
+rms_ipa_assert( 'Keep this copy' === ( $GLOBALS['_post_meta'][12]['page_sections'][0]['about_headline'] ?? '' ), 'forged identity writes no ACF' );
+$after_fail = ( new Wizard_Mutation_Fence() )->is_held();
+rms_ipa_assert( false === $after_fail, 'fence released after identity failure' );
+$stale_owner = ( new Wizard_Mutation_Fence() );
+$stale_owner->release( 'forged-owner' );
+rms_ipa_assert( false === ( new Wizard_Mutation_Fence() )->is_held(), 'stale owner cannot keep the fence' );
+echo "PASS forged-identity-zero-writes\n";
+++$passed;
+
+foreach ( array( 'pending', 'failed', 'complete' ) as $prior ) {
+	rms_ipa_reset();
+	rms_ipa_seed_about();
+	$sm = new State_Manager();
+	$st = $sm->get_state();
+	$st['step_status']['internal-page-builder'] = $prior;
+	if ( 'complete' === $prior ) {
+		$st['internal_pages']['about']['status'] = 'complete';
+	}
+	if ( 'failed' === $prior ) {
+		$st['internal_pages']['about']['status'] = 'failed';
+		$st['internal_pages']['about']['reason'] = 'persist_failed';
+	}
+	$sm->save_state( $st );
+	$meta_before = $GLOBALS['_post_meta'];
+	$err         = ( new Step_Controller() )->execute_step(
+		'internal-page-builder',
+		array(
+			'action'    => 'process',
+			'page_type' => 'services',
+			'post_id'   => 99,
+		)
+	);
+	$actual = (string) ( ( new State_Manager() )->get_state()['step_status']['internal-page-builder'] ?? '' );
+	rms_ipa_assert( is_wp_error( $err ) && 'rms_wizard_internal_identity' === $err->get_error_code(), 'identity error for prior ' . $prior );
+	rms_ipa_assert( $prior === $actual, 'identity restores ' . $prior . ' not running' );
+	rms_ipa_assert( 0 === $GLOBALS['_page_writes'] && $meta_before === $GLOBALS['_post_meta'], 'identity keeps pages for ' . $prior );
+	rms_ipa_assert( false === ( new Wizard_Mutation_Fence() )->is_held(), 'fence released after identity ' . $prior );
+}
+echo "PASS identity-restores-prior-status\n";
+++$passed;
+
+rms_ipa_reset();
+$held_owner = ( new Wizard_Mutation_Fence() )->acquire();
+rms_ipa_assert( ! is_wp_error( $held_owner ), 'outer fence acquired' );
+$nested = ( new Step_Controller() )->execute_step( 'internal-page-builder', array( 'skip_all' => true ) );
+rms_ipa_assert( is_wp_error( $nested ) && 'rms_wizard_busy' === $nested->get_error_code(), 'nested execute_step is busy' );
+rms_ipa_assert( ! isset( ( new State_Manager() )->get_state()['step_status']['internal-page-builder'] ) || 'complete' !== ( ( new State_Manager() )->get_state()['step_status']['internal-page-builder'] ?? '' ), 'nested busy writes no complete status' );
+( new Wizard_Mutation_Fence() )->release( (string) $held_owner );
+echo "PASS nested-fence-zero-writes\n";
+++$passed;
+
+echo 'Harness passed: ' . $passed . " scenarios.\n";


### PR DESCRIPTION
Closes #42

Depends on PR8A [#60](https://github.com/glacayo/simple-rms-theme/pull/60). Do not merge until PR8A lands on the tracker. Do not retarget this PR to the tracker until PR8A merges.

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds secure hidden `execute_step('internal-page-builder')` dispatch. The ninth step is **not** in `REQUIRED_STEPS`; `complete()` still requires 8 steps.
- Capability gate, existing REST nonce, completed-site `423` lock until unlock, `finally` fence release, and identity `WP_Error` restores prior step status.
- Direct builder runs stay unfenced. Nested fence writes are refused.

## Changes

| File | Change |
|------|--------|
| `inc/wizard/class-step-controller.php` | DISPATCHABLE entry, skip-all, identity status restore, dispatch case, alias, authorize/leave fence scope. REQUIRED_STEPS unchanged (still 8). |
| `tests/wizard-internal-page-activation-bootstrap.php` | Shared stubs for hidden-dispatch proofs. |
| `tests/wizard-internal-page-activation-harness.php` | 8/8 independent of REQUIRED_STEPS: capability, lock, unfenced direct, skip-all, forged identity, status restore, nested fence. |

## Runtime contract

- Hidden dispatch only. `REQUIRED_STEPS` still has 8 entries; `internal-page-builder` is DISPATCHABLE, not required.
- Capability: `current_user_can` failure → `rms_wizard_forbidden`.
- Completed sites: `rms_wizard_locked` (`423`) until `unlock`.
- REST nonce remains the existing step-run permission callback (no new unauthenticated route).
- Identity `WP_Error` restores the prior step status. `finally` always `clear_agent` + release.

Explicitly **not** in this PR: REQUIRED_STEPS ninth element, sidebar/`$steps` visibility, client `steps` entry.

## Test Plan
- [x] `php -l` on the 3 changed files — no syntax errors, PHP 8.2.29.
- [x] `php tests/wizard-internal-page-activation-harness.php` — **8/8 pass** (hidden dispatch; independent of REQUIRED_STEPS).
- [x] `php tests/wizard-mutation-fence-harness.php` — **4/4 pass**.
- [x] `php tests/wizard-internal-page-builder-harness.php` — **19/19 pass**.
- [x] `php scripts/test-landing-run-orchestrator.php` — **293 passed, 0 failed** (`complete()` still succeeds with 8 required steps).
- [x] `php tests/wizard-integration-truth-harness.php` — **8/8 pass**.
- [x] Three-dot diff against PR8A `feat/internal-page-builder-core` is exactly these 3 files (**+365 / −4 = 369 / 400**). Controller **+45 / −4 = 49**. No inherited PR8A files. No OpenSpec.
- [x] Scripts run without errors: N/A — no shell scripts in this PR.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts: N/A — no shell scripts
- [x] Skills tested in at least one agent: N/A — wizard domain feature, not a skill change
- [x] Docs updated if behavior changed: OpenSpec progress is on tracker #43; no public UI copy change
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Chain Context

| Field | Value |
|-------|-------|
| Chain | wizard-internal-page-builder |
| Tracker PR | #43 `feat/internal-page-builder` (draft, no-merge) |
| Position | 8B of 8 (secure hidden dispatch) |
| Base | `feat/internal-page-builder-core` (PR8A) |
| Depends on | PR8A [#60](https://github.com/glacayo/simple-rms-theme/pull/60) / tracker #43 / merged PR1–PR7 #44–#59 / approved issue #42 |
| Follow-up | PR8C [#62](https://github.com/glacayo/simple-rms-theme/pull/62) `feat/internal-page-builder-ui` |
| Review budget | 369 / 400 |
| Starts at | PR8A `feat/internal-page-builder-core` @ `e00977e` |
| Ends with | Hidden secure dispatch with nonce/capability/423/finally/status restore; required steps remain 8 |

### Chain Overview

```text
main
 └── #43 feat/internal-page-builder  (draft tracker, no-merge)
      └── #44 PR1 feat/internal-page-blueprints  (merged)
           └── #45–#47 PR2A–PR2C section assembler  (merged)
                └── #48–#50 PR3A–PR3C About backend  (merged)
                     └── #51–#52 PR4A–PR4B type + templates  (merged)
                          └── #53–#54 PR5A–PR5B remaining types + provenance  (merged)
                               └── #57 PR6 feat/internal-page-blog-index  (merged)
                                    └── #58–#59 PR7A–PR7B AI Layer 2 + provenance hook  (merged)
                                         └── #60 PR8A feat/internal-page-builder-core
                                              └── 📍 #61 PR8B feat/internal-page-builder-controller
                                                   └── #62 PR8C feat/internal-page-builder-ui
                                                        └── #63 PR8D feat/internal-page-builder-activation-final
```

### Scope
- Includes: DISPATCHABLE + dispatch case + authorize fence + skip-all + identity restore + 8/8 activation proofs.
- Excludes: REQUIRED_STEPS comment/element, `$steps`/`$descriptions`, client `steps` entry, SCSS/UI renderer. **UI remains PR8C. Activation remains PR8D.**
- Tracker #43 remains draft/no-merge. Do not merge this PR to `main`. No `size:exception`.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit

### Security
Capability forbidden, completed-site lock (`423`) until unlock, existing REST nonce on step-run, fence `finally` always releases, identity errors restore prior status and write nothing.

### Rollback
Revert `84c40d1`. Drops hidden dispatch hunks and the two activation test files. PR8A builder/fence stays. REQUIRED_STEPS stays 8. Does not touch UI or OpenSpec.
