### PR TITLE
feat(wizard): add internal page builder interface

### DIFF
--- a/inc/wizard/wizard-init.php
+++ b/inc/wizard/wizard-init.php
@@ -522,6 +522,8 @@ function rms_wizard_render_admin_page(): void {
 							<?php rms_wizard_render_home_page_builder_form(); ?>
 						<?php elseif ( 'landing-page-builder' === $slug ) : ?>
 							<?php rms_wizard_render_landing_page_builder_form(); ?>
+						<?php elseif ( 'internal-page-builder' === $slug ) : ?>
+							<?php rms_wizard_render_internal_page_builder_form(); ?>
 						<?php endif; ?>
 
 						<div class="rms-wizard-actions rms-wizard-step-actions">
@@ -1005,6 +1007,64 @@ function rms_wizard_render_landing_page_builder_form(): void {
 				</div>
 			</template>
 		</div>
+	</form>
+	<?php
+}
+
+/**
+ * Render the Internal Page Builder cards. Identity is page type, not slug.
+ *
+ * @return void
+ */
+function rms_wizard_render_internal_page_builder_form(): void {
+	$labels = [
+		'about'         => __( 'About', 'simple-rms-theme' ),
+		'services'      => __( 'Services', 'simple-rms-theme' ),
+		'contact'       => __( 'Contact', 'simple-rms-theme' ),
+		'projects'      => __( 'Projects', 'simple-rms-theme' ),
+		'testimonials'  => __( 'Testimonials', 'simple-rms-theme' ),
+		'blog'          => __( 'Blog', 'simple-rms-theme' ),
+	];
+	$blueprints = [];
+	foreach ( Inc\Wizard\Internal_Page_Blueprints::all() as $type => $blueprint ) {
+		$blueprints[] = [
+			'type'    => $type,
+			'label'   => $labels[ $type ] ?? $type,
+			'layouts' => is_array( $blueprint['layouts'] ?? null ) ? $blueprint['layouts'] : [],
+		];
+	}
+	?>
+	<form class="rms-wizard-fields rms-wizard-guided-form" data-wizard-internal-page-builder-form>
+		<p class="rms-wizard-fields__intro">
+			<?php esc_html_e( 'Build sections on pages already created in Generate Pages. Resume continues pending pages. Regeneration and legacy conversion need an explicit, confirmed choice and never run from a slug guess.', 'simple-rms-theme' ); ?>
+		</p>
+		<p class="rms-wizard-internal-progress" data-wizard-internal-progress aria-live="polite"></p>
+		<label class="rms-wizard-landing-skip-all">
+			<input type="checkbox" name="skip_all" value="1" data-wizard-internal-skip-all>
+			<span><?php esc_html_e( 'Skip internal pages for now (complete this step without changing pages)', 'simple-rms-theme' ); ?></span>
+		</label>
+		<script type="application/json" data-wizard-internal-blueprints><?php echo wp_json_encode( $blueprints, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT ); ?></script>
+		<div class="rms-wizard-page-rows" data-wizard-internal-cards role="list"></div>
+		<p class="rms-wizard-page-builder__empty" data-wizard-internal-empty><?php esc_html_e( 'No generated internal pages are available yet.', 'simple-rms-theme' ); ?></p>
+		<template data-wizard-internal-card-template>
+			<article class="rms-wizard-page-row rms-wizard-internal-card" role="listitem" data-wizard-internal-card data-wizard-page-type="">
+				<input type="hidden" data-wizard-internal-type value="">
+				<div>
+					<strong data-wizard-internal-label></strong>
+					<small data-wizard-internal-layouts></small>
+				</div>
+				<span data-wizard-internal-status></span>
+				<label class="rms-wizard-internal-card__action" data-wizard-internal-overwrite-wrap hidden>
+					<input type="checkbox" data-wizard-internal-overwrite>
+					<span><?php esc_html_e( 'Regenerate this page', 'simple-rms-theme' ); ?></span>
+				</label>
+				<label class="rms-wizard-internal-card__action" data-wizard-internal-convert-wrap hidden>
+					<input type="checkbox" data-wizard-internal-convert>
+					<span><?php esc_html_e( 'Convert legacy content on this page', 'simple-rms-theme' ); ?></span>
+				</label>
+				<a class="button-link" data-wizard-internal-edit hidden><?php esc_html_e( 'Edit page', 'simple-rms-theme' ); ?></a>
+			</article>
+		</template>
 	</form>
 	<?php
 }

--- a/src/scss/admin/wizard.scss
+++ b/src/scss/admin/wizard.scss
@@ -553,6 +553,21 @@
   min-height: 32px;
 }
 
+.rms-wizard-internal-card {
+  grid-template-columns: minmax(160px, 1fr) auto minmax(180px, auto) auto;
+}
+
+.rms-wizard-internal-card__action {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.rms-wizard-internal-progress {
+  min-height: 1.4em;
+  margin: 0 0 8px;
+}
+
 .rms-wizard-page-builder__empty {
   padding: 16px;
   margin: 0;

--- a/src/ts/admin/wizard.ts
+++ b/src/ts/admin/wizard.ts
@@ -48,6 +48,7 @@ interface GeneratedPage {
   title?: string;
   slug?: string;
   role?: string;
+  type?: string;
 }
 
 interface LandingPageState {
@@ -160,6 +161,13 @@ interface WizardState {
     configured_at?: string;
   };
   generated_pages?: GeneratedPage[];
+  internal_pages?: Record<string, {
+    post_id?: number;
+    layouts?: string[];
+    status?: string;
+    reason?: string;
+    updated_at?: string;
+  }>;
   home_seo_targeting?: {
     enabled?: boolean;
     primary_keyword?: string;
@@ -287,6 +295,10 @@ declare global {
     'landing-page-builder': {
       message: 'Replacing canonical reusable sections overwrites shared copy used by future landings. This cannot be undone.',
       checkboxMessage: 'Confirm replace canonical before overwriting shared reusable sections.',
+    },
+    'internal-page-builder': {
+      message: 'Regenerating or converting a page replaces its current content. Edited ACF fields on unselected pages are kept. This cannot be undone.',
+      checkboxMessage: 'Confirm regeneration or conversion for the selected internal pages.',
     },
   };
 
@@ -458,6 +470,99 @@ declare global {
     });
   };
 
+  const hydrateInternalPageCards = (): void => {
+    const form = root.querySelector<HTMLFormElement>('[data-wizard-internal-page-builder-form]');
+    const list = form?.querySelector<HTMLElement>('[data-wizard-internal-cards]');
+    const empty = form?.querySelector<HTMLElement>('[data-wizard-internal-empty]');
+    const template = form?.querySelector<HTMLTemplateElement>('[data-wizard-internal-card-template]');
+    const progress = form?.querySelector<HTMLElement>('[data-wizard-internal-progress]');
+    const raw = form?.querySelector<HTMLScriptElement>('[data-wizard-internal-blueprints]')?.textContent ?? '[]';
+
+    if (!form || !list || !template) {
+      return;
+    }
+
+    let blueprints: Array<{ type: string; label: string; layouts: string[] }> = [];
+    try {
+      blueprints = JSON.parse(raw) as Array<{ type: string; label: string; layouts: string[] }>;
+    } catch {
+      blueprints = [];
+    }
+
+    const plan = state.internal_pages ?? {};
+    const pages = Array.isArray(state.generated_pages) ? state.generated_pages : [];
+    list.replaceChildren();
+    let visible = 0;
+    let pending = 0;
+    let complete = 0;
+
+    blueprints.forEach((blueprint) => {
+      const entry = plan[blueprint.type] ?? {};
+      const postId = Number(entry.post_id ?? 0);
+      const generated = pages.find((page) => (page.type || '') === blueprint.type);
+      if (!generated && postId <= 0 && !entry.status) {
+        return;
+      }
+
+      const node = template.content.firstElementChild?.cloneNode(true);
+      if (!(node instanceof HTMLElement)) {
+        return;
+      }
+
+      visible += 1;
+      const status = String(entry.status ?? (generated ? 'pending' : 'skipped'));
+      if (status === 'pending' || status === 'failed') {
+        pending += 1;
+      }
+      if (status === 'complete') {
+        complete += 1;
+      }
+
+      node.dataset.wizardPageType = blueprint.type;
+      const typeInput = node.querySelector<HTMLInputElement>('[data-wizard-internal-type]');
+      const labelNode = node.querySelector('[data-wizard-internal-label]');
+      const layoutNode = node.querySelector('[data-wizard-internal-layouts]');
+      const statusNode = node.querySelector('[data-wizard-internal-status]');
+      const overwriteWrap = node.querySelector<HTMLElement>('[data-wizard-internal-overwrite-wrap]');
+      const convertWrap = node.querySelector<HTMLElement>('[data-wizard-internal-convert-wrap]');
+      const editLink = node.querySelector<HTMLAnchorElement>('[data-wizard-internal-edit]');
+
+      if (typeInput) {
+        typeInput.value = blueprint.type;
+      }
+      if (labelNode) {
+        labelNode.textContent = blueprint.label;
+      }
+      if (layoutNode) {
+        layoutNode.textContent = (Array.isArray(entry.layouts) && entry.layouts.length > 0 ? entry.layouts : blueprint.layouts).join(', ');
+      }
+      if (statusNode) {
+        const reason = String(entry.reason ?? '');
+        statusNode.textContent = reason && status !== 'complete' ? `${status} (${reason})` : status;
+      }
+      if (overwriteWrap) {
+        overwriteWrap.hidden = status !== 'complete';
+      }
+      if (convertWrap) {
+        convertWrap.hidden = !(status === 'skipped' && String(entry.reason ?? '') === 'legacy_unconfirmed');
+      }
+      if (editLink) {
+        const canEdit = postId > 0;
+        editLink.hidden = !canEdit;
+        editLink.href = canEdit ? `post.php?post=${postId}&action=edit` : '#';
+      }
+
+      list.append(node);
+    });
+
+    if (empty) {
+      empty.hidden = visible > 0;
+    }
+    if (progress) {
+      progress.textContent = visible > 0 ? `${complete} of ${visible} internal pages complete` : '';
+    }
+  };
+
   const render = (options?: { replaceHomeSeo?: boolean }): void => {
     const nextStep = state.current_step && steps.some((step) => step.slug === state.current_step)
       ? state.current_step
@@ -469,6 +574,7 @@ declare global {
     hydrateLandingRowsFromState();
     renderLandingReplaceOptions();
     renderLandingRunProgressFromState();
+    hydrateInternalPageCards();
     syncGuidedControlState();
     setActiveStep(nextStep);
     updateNav();
@@ -598,6 +704,65 @@ declare global {
     setNotice(summary, 'error');
   };
 
+  const runInternalPageBuilderStep = async (payload: StepPayload, intent: LandingClientIntent): Promise<void> => {
+    const step = 'internal-page-builder';
+
+    if (payload.skip_all) {
+      const skipped = await request<StepResponse>(`steps/${step}/run`, {
+        method: 'POST',
+        body: JSON.stringify({ skip_all: true }),
+      }, 1);
+
+      if (skipped.state) {
+        state = skipped.state;
+      }
+
+      setStepResult(step, skipped.result ?? skipped);
+      applyStepOutcomePresentation(step, skipped, 'Internal pages skipped without changing pages.');
+      return;
+    }
+
+    const startResponse = await request<StepResponse>(`steps/${step}/run`, {
+      method: 'POST',
+      body: JSON.stringify({
+        ...payload,
+        action: 'start',
+        retry_failed: intent === 'retry',
+      }),
+    }, 1);
+
+    if (startResponse.state) {
+      state = startResponse.state;
+    }
+
+    hydrateInternalPageCards();
+    let guard = 0;
+    let lastResponse = startResponse;
+
+    while (statusFor(step) === 'running' && guard < 8) {
+      guard += 1;
+      setStepActionStatus(step, 'Building the next internal page...', 'info');
+      const processed = await request<StepResponse>(`steps/${step}/run`, {
+        method: 'POST',
+        body: JSON.stringify({
+          ...payload,
+          action: 'process',
+          retry_failed: false,
+        }),
+      }, 1);
+
+      lastResponse = processed;
+
+      if (processed.state) {
+        state = processed.state;
+      }
+
+      hydrateInternalPageCards();
+    }
+
+    applyStepOutcomePresentation(step, lastResponse);
+  };
+
   const runStep = async (step: string, intent: LandingClientIntent = 'run'): Promise<void> => {
     runningStep = step;
     setActiveStep(step);
@@ -651,6 +816,12 @@ declare global {
           return;
         }
 
+        return;
+      }
+
+      if (step === 'internal-page-builder') {
+        await runInternalPageBuilderStep(payload, intent);
+        persisted = true;
         return;
       }
 
@@ -1145,6 +1316,10 @@ declare global {
       return collectLandingPageBuilderPayload(form);
     }
 
+    if (step === 'internal-page-builder') {
+      return collectInternalPageBuilderPayload(form);
+    }
+
     return collectFormPayload(form);
   };
 
@@ -1305,7 +1480,45 @@ declare global {
     };
   };
 
+  const collectInternalPageBuilderPayload = (form: HTMLFormElement): StepPayload => {
+    if (form.querySelector<HTMLInputElement>('[data-wizard-internal-skip-all]')?.checked) {
+      return { skip_all: true };
+    }
+
+    const overwrite: string[] = [];
+    const convertLegacy: string[] = [];
+
+    form.querySelectorAll<HTMLElement>('[data-wizard-internal-card]').forEach((card) => {
+      const type = card.dataset.wizardPageType || card.querySelector<HTMLInputElement>('[data-wizard-internal-type]')?.value || '';
+      if (!type) {
+        return;
+      }
+      if (card.querySelector<HTMLInputElement>('[data-wizard-internal-overwrite]')?.checked) {
+        overwrite.push(type);
+      }
+      if (card.querySelector<HTMLInputElement>('[data-wizard-internal-convert]')?.checked) {
+        convertLegacy.push(type);
+      }
+    });
+
+    return {
+      overwrite,
+      convert_legacy: convertLegacy,
+    };
+  };
+
   const ensureDestructiveConfirmation = async (step: string, payload: StepPayload): Promise<boolean> => {
+    if (step === 'internal-page-builder') {
+      const overwrite = Array.isArray(payload.overwrite) ? payload.overwrite : [];
+      const convertLegacy = Array.isArray(payload.convert_legacy) ? payload.convert_legacy : [];
+      if (overwrite.length === 0 && convertLegacy.length === 0) {
+        return true;
+      }
+
+      const warning = destructiveWarnings[step];
+      return openConfirmationModal(warning.message);
+    }
+
     if (step === 'landing-page-builder') {
       const replaceMap = (payload.replace_canonical ?? {}) as Record<string, boolean>;
       const needsReplaceConfirm = Object.values(replaceMap).some(Boolean);

--- a/tests/wizard-internal-page-ui-harness.php
+++ b/tests/wizard-internal-page-ui-harness.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Internal Page Builder admin registration and server-rendered form.
+ *
+ * Usage: php tests/wizard-internal-page-ui-harness.php
+ */
+if ( PHP_SAPI !== 'cli' ) {
+	fwrite( STDERR, "CLI only.\n" );
+	exit( 1 );
+}
+
+$theme_root = dirname( __DIR__ );
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', $theme_root . '/' );
+}
+
+$GLOBALS['_actions'] = array();
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $k ) {
+		return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $k ) ) );
+	}
+}
+if ( ! function_exists( '__' ) ) {
+	function __( $t, $d = null ) {
+		unset( $d );
+		return $t;
+	}
+}
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $t ) {
+		return htmlspecialchars( (string) $t, ENT_QUOTES, 'UTF-8' );
+	}
+}
+if ( ! function_exists( 'esc_html_e' ) ) {
+	function esc_html_e( $t, $d = null ) {
+		unset( $d );
+		echo esc_html( $t );
+	}
+}
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $d, $o = 0 ) {
+		return json_encode( $d, $o );
+	}
+}
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( $v ) {
+		return rtrim( (string) $v, '/\\' ) . '/';
+	}
+}
+if ( ! function_exists( 'get_template_directory_uri' ) ) {
+	function get_template_directory_uri() {
+		return 'https://example.test/theme';
+	}
+}
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( $hook, $cb, $pri = 10, $args = 1 ) {
+		$GLOBALS['_actions'][] = array( $hook, $cb, $pri, $args );
+		return true;
+	}
+}
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( $hook, $cb, $pri = 10, $args = 1 ) {
+		return add_action( $hook, $cb, $pri, $args );
+	}
+}
+
+require_once $theme_root . '/inc/wizard/class-ai-content-harness.php';
+require_once $theme_root . '/inc/wizard/class-internal-page-blueprints.php';
+require_once $theme_root . '/inc/wizard/wizard-init.php';
+
+function rms_ipui_assert( $c, string $m ): void {
+	if ( ! $c ) {
+		fwrite( STDERR, $m . "\n" );
+		exit( 1 );
+	}
+}
+
+$passed = 0;
+$hooks  = array();
+foreach ( $GLOBALS['_actions'] as $row ) {
+	$hooks[] = (string) $row[0];
+}
+rms_ipui_assert( in_array( 'admin_menu', $hooks, true ), 'admin_menu registered' );
+rms_ipui_assert( in_array( 'rest_api_init', $hooks, true ), 'REST routes registered' );
+rms_ipui_assert( in_array( 'acf/save_post', $hooks, true ), 'acf/save_post registered' );
+rms_ipui_assert( function_exists( 'rms_wizard_render_internal_page_builder_form' ), 'form renderer exists' );
+echo "PASS production-registration\n";
+++$passed;
+
+ob_start();
+rms_wizard_render_internal_page_builder_form();
+$markup = (string) ob_get_clean();
+rms_ipui_assert( false !== strpos( $markup, 'data-wizard-internal-page-builder-form' ), 'form hook' );
+rms_ipui_assert( false !== strpos( $markup, 'data-wizard-internal-skip-all' ), 'skip-all control' );
+rms_ipui_assert( false !== strpos( $markup, 'data-wizard-page-type' ), 'stable type attribute' );
+rms_ipui_assert( false !== strpos( $markup, 'role="list"' ), 'list semantics' );
+rms_ipui_assert( false !== strpos( $markup, 'aria-live="polite"' ), 'live progress region' );
+rms_ipui_assert( false !== strpos( $markup, 'About' ) && false !== strpos( $markup, 'Services' ), 'escaped blueprint labels' );
+echo "PASS server-rendered-form-accessibility\n";
+++$passed;
+
+echo 'Harness passed: ' . $passed . " scenarios.\n";


### PR DESCRIPTION
Closes #42

Depends on PR8B [#61](https://github.com/glacayo/simple-rms-theme/pull/61). Do not merge until PR8B lands. Do not retarget this PR to the tracker until PR8B merges.

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds the Internal Page Builder form renderer, TypeScript helpers, and SCSS. Cards, skip-all, overwrite/convert confirmation, and edit link exist.
- The ninth slug is **omitted** from `$steps`, `$descriptions`, and the client `steps` array, so the UI stays dormant in the normal 8-step sequence.
- The UI harness calls the form renderer directly. It does not claim sidebar visibility.

## Changes

| File | Change |
|------|--------|
| `inc/wizard/wizard-init.php` | `rms_wizard_render_internal_page_builder_form()` + `elseif` branch. `$steps` / `$descriptions` keys deferred. |
| `src/ts/admin/wizard.ts` | Hydration, run/collect payload, destructive confirm. Client `steps` entry deferred. |
| `src/scss/admin/wizard.scss` | Internal card layout. |
| `tests/wizard-internal-page-ui-harness.php` | Renderer callable + accessible cards (2/2). Does not claim sidebar visibility. |

## Dormant UI contract

- Normal sequence remains 8 steps. Sidebar/`steps` omit `internal-page-builder`.
- Renderer is callable and tested. Cards are accessible when the form is rendered.
- Visual Local admin click-through was **not** claimed: Local returned HTTP 502, so this slice is proven by harness + `tsc`, not by a live screenshot.

## Test Plan
- [x] `php -l` on changed PHP — no syntax errors, PHP 8.2.29.
- [x] `php tests/wizard-internal-page-ui-harness.php` — **2/2 pass**.
- [x] `npx tsc --noEmit` — **0 errors**.
- [x] `php tests/wizard-internal-page-activation-harness.php` — **8/8 pass**.
- [x] `php tests/wizard-integration-truth-harness.php` — **8/8 pass**.
- [x] `php scripts/test-landing-run-orchestrator.php` — **293 passed, 0 failed**.
- [x] Three-dot diff against PR8B `feat/internal-page-builder-controller` is exactly these 4 files (**+391 / −0 = 391 / 400**). No inherited PR8A/PR8B files. No OpenSpec.
- [x] Scripts run without errors: N/A — no shell scripts in this PR.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts: N/A — no shell scripts
- [x] Skills tested in at least one agent: N/A — wizard domain feature, not a skill change
- [x] Docs updated if behavior changed: OpenSpec progress is on tracker #43; public step label is deferred to PR8D
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Chain Context

| Field | Value |
|-------|-------|
| Chain | wizard-internal-page-builder |
| Tracker PR | #43 `feat/internal-page-builder` (draft, no-merge) |
| Position | 8C of 8 (dormant accessible interface) |
| Base | `feat/internal-page-builder-controller` (PR8B) |
| Depends on | PR8B [#61](https://github.com/glacayo/simple-rms-theme/pull/61) / PR8A [#60](https://github.com/glacayo/simple-rms-theme/pull/60) / tracker #43 / merged PR1–PR7 #44–#59 / approved issue #42 |
| Follow-up | PR8D [#63](https://github.com/glacayo/simple-rms-theme/pull/63) `feat/internal-page-builder-activation-final` |
| Review budget | 391 / 400 |
| Starts at | PR8B `feat/internal-page-builder-controller` @ `84c40d1` |
| Ends with | Dormant accessible cards/modal/TS/SCSS/renderer; still 8 required and 8 visible steps |

### Chain Overview

```text
main
 └── #43 feat/internal-page-builder  (draft tracker, no-merge)
      └── #44 PR1 feat/internal-page-blueprints  (merged)
           └── #45–#47 PR2A–PR2C section assembler  (merged)
                └── #48–#50 PR3A–PR3C About backend  (merged)
                     └── #51–#52 PR4A–PR4B type + templates  (merged)
                          └── #53–#54 PR5A–PR5B remaining types + provenance  (merged)
                               └── #57 PR6 feat/internal-page-blog-index  (merged)
                                    └── #58–#59 PR7A–PR7B AI Layer 2 + provenance hook  (merged)
                                         └── #60 PR8A feat/internal-page-builder-core
                                              └── #61 PR8B feat/internal-page-builder-controller
                                                   └── 📍 #62 PR8C feat/internal-page-builder-ui
                                                        └── #63 PR8D feat/internal-page-builder-activation-final
```

### Scope
- Includes: form renderer, TS helpers, SCSS, 2/2 UI harness (renderer callable; no sidebar-visibility claim).
- Excludes: `$steps`/`$descriptions` keys, client `steps` entry, REQUIRED_STEPS ninth element. **Those land together in PR8D.**
- Tracker #43 remains draft/no-merge. Do not merge this PR to `main`. No `size:exception`.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit

### Security
No new REST route. Destructive regenerate/convert still requires the existing confirmation modal. Skip-all remains a no-mutation complete. Visual Local 502 is an honest test boundary, not a pass.

### Rollback
Revert `7a92117`. Drops renderer/elseif, TS helpers, SCSS, and the UI harness. Hidden dispatch from PR8B stays. Sequence remains 8.
