### PR TITLE
feat(wizard): activate internal page builder step

### DIFF
--- a/inc/wizard/class-step-controller.php
+++ b/inc/wizard/class-step-controller.php
@@ -30,8 +30,7 @@ class Step_Controller {
 	 * Single source of truth for currently required wizard steps.
 	 * Consumed by complete() and step services (e.g. maybe_mark_completed).
 	 *
-	 * Phase 3 activates `landing-page-builder` atomically with admin UI +
-	 * Ads noindex/menu final-state sync (tasks 3.1–3.7).
+	 * Phase 8 activates `internal-page-builder` atomically with admin UI.
 	 *
 	 * @var string[]
 	 */
@@ -44,6 +43,7 @@ class Step_Controller {
 		'ia-generation',
 		'home-page-builder',
 		'landing-page-builder',
+		'internal-page-builder',
 	];
 
 	/**

--- a/inc/wizard/wizard-init.php
+++ b/inc/wizard/wizard-init.php
@@ -362,6 +362,7 @@ function rms_wizard_render_admin_page(): void {
 		'ia-generation'        => __( 'IA Generation', 'simple-rms-theme' ),
 		'home-page-builder'    => __( 'Home Page Builder', 'simple-rms-theme' ),
 		'landing-page-builder' => __( 'Landing Page Builder', 'simple-rms-theme' ),
+		'internal-page-builder' => __( 'Internal Page Builder', 'simple-rms-theme' ),
 	];
 	$step_slugs = array_keys( $steps );
 	$descriptions = [
@@ -373,6 +374,7 @@ function rms_wizard_render_admin_page(): void {
 		'ia-generation'        => __( 'Configure the AI provider, model, and encrypted credentials for later content generation.', 'simple-rms-theme' ),
 		'home-page-builder'    => __( 'Choose Home page sections and build them from the saved client data.', 'simple-rms-theme' ),
 		'landing-page-builder' => __( 'Create SEO and Ads landing pages with keywords, reusable sections, and noindex controls.', 'simple-rms-theme' ),
+		'internal-page-builder' => __( 'Fill ACF sections on generated internal pages. Skip, resume, or convert only with an explicit choice. Completed sites stay locked until unlock.', 'simple-rms-theme' ),
 	];
 	?>
 	<div

--- a/src/ts/admin/wizard.ts
+++ b/src/ts/admin/wizard.ts
@@ -281,6 +281,7 @@ declare global {
     { slug: 'ia-generation', label: 'IA Generation' },
     { slug: 'home-page-builder', label: 'Home Page Builder' },
     { slug: 'landing-page-builder', label: 'Landing Page Builder' },
+    { slug: 'internal-page-builder', label: 'Internal Page Builder' },
   ];
 
   const destructiveWarnings: Record<string, { message: string; checkboxMessage: string }> = {

--- a/tests/wizard-internal-page-required-step-harness.php
+++ b/tests/wizard-internal-page-required-step-harness.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Ninth-step REQUIRED_STEPS proofs. These 2 cases require
+ * internal-page-builder in Step_Controller::REQUIRED_STEPS.
+ *
+ * Usage: php tests/wizard-internal-page-required-step-harness.php
+ */
+if ( PHP_SAPI !== 'cli' ) {
+	fwrite( STDERR, "CLI only.\n" );
+	exit( 1 );
+}
+
+require_once __DIR__ . '/wizard-internal-page-activation-bootstrap.php';
+
+use Inc\Wizard\Step_Controller;
+use Inc\Wizard\State_Manager;
+
+$passed = 0;
+$required = Step_Controller::get_required_steps();
+$landing_at = array_search( 'landing-page-builder', $required, true );
+$internal_at = array_search( 'internal-page-builder', $required, true );
+rms_ipa_assert( false !== $landing_at && false !== $internal_at && $internal_at === $landing_at + 1, 'internal follows landing' );
+echo "PASS required-order-after-landing\n";
+++$passed;
+
+rms_ipa_reset();
+$sm = new State_Manager();
+$st = $sm->get_state();
+foreach ( Step_Controller::get_required_steps() as $step ) {
+	$st['step_status'][ $step ] = 'complete';
+}
+$st['step_status']['internal-page-builder'] = 'failed';
+$sm->save_state( $st );
+$incomplete = ( new Step_Controller() )->complete();
+rms_ipa_assert( is_wp_error( $incomplete ) && 'rms_wizard_incomplete' === $incomplete->get_error_code(), 'complete wizard refuses failed internal step' );
+rms_ipa_assert( false === ( new State_Manager() )->has_completion_flag(), 'failed step does not lock the wizard' );
+$st['step_status']['internal-page-builder'] = 'complete';
+$sm->save_state( $st );
+$done = ( new Step_Controller() )->complete();
+rms_ipa_assert( ! is_wp_error( $done ) && ! empty( $done['success'] ), 'explicit complete wizard succeeds when every step is complete' );
+rms_ipa_assert( true === ( new State_Manager() )->has_completion_flag(), 'explicit complete sets the completion flag' );
+echo "PASS explicit-complete-wizard\n";
+++$passed;
+
+echo 'Harness passed: ' . $passed . " scenarios.\n";


### PR DESCRIPTION
Closes #42

Depends on PR8C [#62](https://github.com/glacayo/simple-rms-theme/pull/62). Do not merge until PR8C lands. Do not retarget this PR to the tracker until PR8C merges.

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Activates the Internal Page Builder as the ninth required **and** visible step in one atomic commit.
- `REQUIRED_STEPS` comment+element, wizard `$steps` + `$descriptions`, and the client `steps` entry land together.
- Explicit Complete succeeds only when the internal step is complete; a failed internal step keeps the wizard unlocked.

## Changes

| File | Change |
|------|--------|
| `inc/wizard/class-step-controller.php` | REQUIRED_STEPS comment rewrite + `'internal-page-builder'` element (**+2 / −2 = 4**). |
| `inc/wizard/wizard-init.php` | `$steps` + `$descriptions` keys (**+2**). |
| `src/ts/admin/wizard.ts` | Client `steps` entry (**+1**). |
| `tests/wizard-internal-page-required-step-harness.php` | Order-after-landing + explicit Complete (2/2). |

## Atomic activation

Required and visible change together. Do not land this slice without both. `complete()` now requires the ninth step.

## Test Plan
- [x] `php -l` on changed PHP — no syntax errors, PHP 8.2.29.
- [x] `php tests/wizard-internal-page-required-step-harness.php` — **2/2 pass**.
- [x] `php tests/wizard-internal-page-activation-harness.php` — **8/8 pass**.
- [x] `php tests/wizard-internal-page-ui-harness.php` — **2/2 pass**.
- [x] `php tests/wizard-internal-page-builder-harness.php` — **19/19 pass**.
- [x] `php tests/wizard-mutation-fence-harness.php` — **4/4 pass**.
- [x] `npx tsc --noEmit` — **0 errors**.
- [x] `php tests/wizard-ai-layer2-harness.php` — **5/5 pass**.
- [x] `php tests/wizard-provenance-hook-harness.php` — **9/9 pass**.
- [x] `php tests/wizard-placeholder-provenance-harness.php` — **6/6 pass**.
- [x] `php tests/wizard-internal-page-templates-harness.php` — **11/11 pass**.
- [x] `php tests/wizard-blog-index-harness.php` — **7/7 pass**.
- [x] `php scripts/test-landing-run-orchestrator.php` — **293 passed, 0 failed**.
- [x] `php tests/acf-inactive-frontend-harness.php` — **11/11 pass**.
- [x] `php tests/wizard-home-seo-targeting-harness.php` — **9/9 pass**.
- [x] `php tests/wizard-integration-truth-harness.php` — **8/8 pass**.
- [x] Three-dot diff against PR8C `feat/internal-page-builder-ui` is exactly these 4 files (**+50 / −2 = 52 / 400**). No inherited earlier files. No OpenSpec.
- [x] Scripts run without errors: N/A — no shell scripts in this PR.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts: N/A — no shell scripts
- [x] Skills tested in at least one agent: N/A — wizard domain feature, not a skill change
- [x] Docs updated if behavior changed: OpenSpec progress is on tracker #43; this slice adds the visible step label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Chain Context

| Field | Value |
|-------|-------|
| Chain | wizard-internal-page-builder |
| Tracker PR | #43 `feat/internal-page-builder` (draft, no-merge) |
| Position | 8D of 8 (atomic required+visible activation) |
| Base | `feat/internal-page-builder-ui` (PR8C) |
| Depends on | PR8C [#62](https://github.com/glacayo/simple-rms-theme/pull/62) / PR8B [#61](https://github.com/glacayo/simple-rms-theme/pull/61) / PR8A [#60](https://github.com/glacayo/simple-rms-theme/pull/60) / tracker #43 / merged PR1–PR7 #44–#59 / approved issue #42 |
| Follow-up | None. After 8A–8D merge into the tracker, do **not** merge tracker #43 to `main` until the chain is reviewed. |
| Review budget | 52 / 400 |
| Starts at | PR8C `feat/internal-page-builder-ui` @ `7a92117` |
| Ends with | Ninth step required and visible together; explicit Complete proven |

### Chain Overview

```text
main
 └── #43 feat/internal-page-builder  (draft tracker, no-merge)
      └── #44 PR1 feat/internal-page-blueprints  (merged)
           └── #45–#47 PR2A–PR2C section assembler  (merged)
                └── #48–#50 PR3A–PR3C About backend  (merged)
                     └── #51–#52 PR4A–PR4B type + templates  (merged)
                          └── #53–#54 PR5A–PR5B remaining types + provenance  (merged)
                               └── #57 PR6 feat/internal-page-blog-index  (merged)
                                    └── #58–#59 PR7A–PR7B AI Layer 2 + provenance hook  (merged)
                                         └── #60 PR8A feat/internal-page-builder-core
                                              └── #61 PR8B feat/internal-page-builder-controller
                                                   └── #62 PR8C feat/internal-page-builder-ui
                                                        └── 📍 #63 PR8D feat/internal-page-builder-activation-final
```

### Scope
- Includes: REQUIRED_STEPS comment+element, `$steps`+`$descriptions`, client `steps` entry, explicit Complete 2/2.
- Excludes: builder/fence (PR8A), hidden dispatch (PR8B), renderer/TS/SCSS (PR8C). No further child slice.
- Tracker #43 remains draft/no-merge. Do not merge this PR to `main`. No `size:exception`.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit

### Security
Required and visible change together so the step cannot be required-but-hidden or visible-but-optional. Completed sites stay locked until unlock. Explicit Complete is the only path that sets the completion flag.

### Rollback
Revert `818845e`. Drops the ninth required/visible keys and the required-step harness. PR8C UI stays dormant. Sequence returns to 8 required steps.
