### PR TITLE
fix(header): consume Theme Options in variants

### DIFF
--- a/inc/acf-theme-options.php
+++ b/inc/acf-theme-options.php
@@ -224,6 +224,52 @@ function rms_get_social_links(): array {
     return $active;
 }
 
+/**
+ * Format a phone number as a sanitized `tel:` URI fragment.
+ *
+ * Keeps digits and, when present, a single leading `+` (international dialing
+ * prefix). All other characters are dropped so the value is safe to place in a
+ * `tel:` href after attribute escaping.
+ *
+ * @param string $phone Raw phone number from Theme Options.
+ * @return string Digits (optionally preceded by a single leading `+`), or ''.
+ */
+function rms_format_tel_uri(string $phone): string {
+    $raw    = trim($phone);
+    $digits = preg_replace('/[^0-9+]/', '', $raw);
+    $digits = is_string($digits) ? $digits : '';
+
+    $has_leading_plus = ('' !== $digits && '+' === $digits[0]);
+    $digits           = str_replace('+', '', $digits);
+
+    return ($has_leading_plus ? '+' : '') . $digits;
+}
+
+/**
+ * Resolve the Contact page permalink for header estimate CTAs.
+ *
+ * Looks up the known contact slugs via the established `get_page_by_path`
+ * pattern and returns the first resolvable permalink. When no Contact page
+ * exists, falls back to the on-page `#contact` anchor on the site home URL.
+ *
+ * @return string Resolved URL (permalink or fallback). Never empty.
+ */
+function rms_get_contact_page_url(): string {
+    if (function_exists('get_page_by_path') && function_exists('get_permalink')) {
+        foreach (array('contact-us', 'contact') as $slug) {
+            $page = get_page_by_path($slug);
+            if (is_object($page) && !empty($page->ID)) {
+                $url = get_permalink($page->ID);
+                if (is_string($url) && '' !== $url) {
+                    return $url;
+                }
+            }
+        }
+    }
+
+    return home_url('/#contact');
+}
+
 // ─── Company Palette → CSS Custom Properties Bridge ────────────────────────
 
 /**

--- a/templates/header-one.php
+++ b/templates/header-one.php
@@ -1,10 +1,30 @@
+<?php
+$header_phone       = rms_get_primary_phone();
+$header_phone_clean = rms_format_tel_uri($header_phone);
+
+$header_addr_line1 = rms_get_option('company_address_line_1');
+$header_addr_line2 = rms_get_option('company_address_line_2');
+$header_addr_city  = rms_get_option('company_city');
+$header_addr_state = rms_get_option('company_state');
+$header_addr_zip   = rms_get_option('company_postal_code');
+
+$header_address = implode(', ', array_filter(array(
+    is_string($header_addr_line1) ? $header_addr_line1 : '',
+    is_string($header_addr_line2) ? $header_addr_line2 : '',
+    is_string($header_addr_city) ? $header_addr_city : '',
+    is_string($header_addr_state) ? $header_addr_state : '',
+    is_string($header_addr_zip) ? $header_addr_zip : '',
+)));
+
+$header_cta_url = rms_get_contact_page_url();
+?>
 <header class="rms-header" role="banner">
     <!-- Top Bar -->
     <div class="rms-header__top-bar">
         <div class="container">
             <div class="rms-header__top-bar-inner">
                 <div class="rms-header__top-bar-left">
-                    <a href="#" class="rms-header__cta-btn">GET A FREE ESTIMATE</a>
+                    <a href="<?php echo esc_url($header_cta_url); ?>" class="rms-header__cta-btn">GET A FREE ESTIMATE</a>
                 </div>
                 <div class="rms-header__top-bar-right">
                     <span class="rms-header__social-label">Follow us on:</span>
@@ -83,14 +103,18 @@
                 </div>
                 <div class="rms-header__contact-info">
                     <ul class="rms-header__contact-list">
+                        <?php if ($header_phone !== '' && $header_phone_clean !== '') : ?>
                         <li>
                             <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07A19.5 19.5 0 0 1 4.82 12a19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 3.73 1h3a2 2 0 0 1 2 1.72c.127.96.361 1.903.7 2.81a2 2 0 0 1-.45 2.11L8.09 8.91a16 16 0 0 0 5.78 5.78l.91-.91a2 2 0 0 1 2.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0 1 22 16.92z"/></svg>
-                            <span>(414) 246-8257</span>
+                            <a href="tel:<?php echo esc_attr($header_phone_clean); ?>"><?php echo esc_html($header_phone); ?></a>
                         </li>
+                        <?php endif; ?>
+                        <?php if ($header_address !== '') : ?>
                         <li>
                             <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
-                            <span>1234 Oak Ridge Ave, Milwaukee, WI 53211</span>
+                            <span><?php echo esc_html($header_address); ?></span>
                         </li>
+                        <?php endif; ?>
                     </ul>
                 </div>
             </div>

--- a/templates/header-three.php
+++ b/templates/header-three.php
@@ -1,3 +1,7 @@
+<?php
+$header_phone       = rms_get_primary_phone();
+$header_phone_clean = rms_format_tel_uri($header_phone);
+?>
 <header class="rms-header-v3" role="banner">
     <div class="rms-header-v3__inner">
         <!-- Logo Area -->
@@ -24,12 +28,14 @@
         <div class="rms-header-v3__menu-area">
             <!-- Meta row: phone + socials -->
             <div class="rms-header-v3__meta">
-                <a href="tel:+14075550199" class="rms-header-v3__phone">
+                <?php if ($header_phone !== '' && $header_phone_clean !== '') : ?>
+                <a href="tel:<?php echo esc_attr($header_phone_clean); ?>" class="rms-header-v3__phone">
                     <svg class="rms-header-v3__icon" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                         <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/>
                     </svg>
-                    <span>(407) 555-0199</span>
+                    <span><?php echo esc_html($header_phone); ?></span>
                 </a>
+                <?php endif; ?>
                 <?php
                         $socials = rms_get_social_links();
                         if (!empty($socials)) :
@@ -123,12 +129,14 @@
         ]);
         ?>
         <div class="rms-header-v3__mobile-footer">
-            <a href="tel:+14075550199" class="rms-header-v3__mobile-phone">
+            <?php if ($header_phone !== '' && $header_phone_clean !== '') : ?>
+            <a href="tel:<?php echo esc_attr($header_phone_clean); ?>" class="rms-header-v3__mobile-phone">
                 <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                     <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/>
                 </svg>
-                <span>(407) 555-0199</span>
+                <span><?php echo esc_html($header_phone); ?></span>
             </a>
+            <?php endif; ?>
             <?php
                             $socials = rms_get_social_links();
                             if (!empty($socials)) :

--- a/templates/header-two.php
+++ b/templates/header-two.php
@@ -1,11 +1,21 @@
+<?php
+$header_phone       = rms_get_primary_phone();
+$header_phone_clean = rms_format_tel_uri($header_phone);
+$header_email       = trim(rms_get_primary_email());
+$header_cta_url     = rms_get_contact_page_url();
+?>
 <header class="rms-header-v2" role="banner">
     <!-- Top Bar -->
     <div class="rms-header-v2__top-bar">
         <div class="container">
             <div class="rms-header-v2__top-bar-inner">
                 <div class="rms-header-v2__top-bar-left">
-                    <span class="rms-header-v2__phone">(407) 555-0199</span>
-                    <span class="rms-header-v2__email">hello@example.com</span>
+                    <?php if ($header_phone !== '' && $header_phone_clean !== '') : ?>
+                    <a href="tel:<?php echo esc_attr($header_phone_clean); ?>" class="rms-header-v2__phone"><?php echo esc_html($header_phone); ?></a>
+                    <?php endif; ?>
+                    <?php if ($header_email !== '') : ?>
+                    <a href="mailto:<?php echo esc_attr($header_email); ?>" class="rms-header-v2__email"><?php echo esc_html($header_email); ?></a>
+                    <?php endif; ?>
                 </div>
                 <div class="rms-header-v2__top-bar-right">
                     <?php
@@ -40,7 +50,7 @@
                         <?php endforeach; ?>
                     </div>
                     <?php endif; ?>
-                    <a href="#" class="btn rms-header-v2__cta-btn">Get a Free Estimate</a>
+                    <a href="<?php echo esc_url($header_cta_url); ?>" class="btn rms-header-v2__cta-btn">Get a Free Estimate</a>
                 </div>
             </div>
         </div>

--- a/tests/header-variants-contact-harness.php
+++ b/tests/header-variants-contact-harness.php
@@ -1,0 +1,393 @@
+<?php
+/**
+ * Focused regression harness for issue #55 (header variants contact wiring).
+ *
+ * Proves the shipped header variants consume existing Theme Options contact
+ * facts instead of hardcoded demo literals, and that estimate CTAs resolve to
+ * the Contact page permalink (or a safe fallback) rather than a dead `href="#"`.
+ *
+ * No framework. Single process; `get_field` and the page resolver are stubbed
+ * via globals and toggled between scenarios.
+ *
+ * Usage: php tests/header-variants-contact-harness.php
+ */
+
+if ( PHP_SAPI !== 'cli' ) {
+    fwrite( STDERR, "CLI only.\n" );
+    exit( 1 );
+}
+
+$theme_root = dirname( __DIR__ );
+$failures   = 0;
+
+function rms_header_fail( string $name, string $detail ): void {
+    global $failures;
+    $failures++;
+    fwrite( STDERR, "FAIL {$name}: {$detail}\n" );
+}
+
+function rms_header_pass( string $name ): void {
+    fwrite( STDOUT, "PASS {$name}\n" );
+}
+
+function rms_header_assert( $condition, string $name, string $detail ): void {
+    if ( $condition ) {
+        rms_header_pass( $name );
+        return;
+    }
+    rms_header_fail( $name, $detail );
+}
+
+function rms_header_render( string $template ): string {
+    global $theme_root;
+    $path = $theme_root . '/templates/' . $template;
+    if ( ! is_readable( $path ) ) {
+        return '';
+    }
+    ob_start();
+    include $path;
+    $out = ob_get_clean();
+    return is_string( $out ) ? $out : '';
+}
+
+function rms_header_setup( array $fields, array $pages = array(), array $permalinks = array() ): void {
+    $GLOBALS['rms_header_fields']     = $fields;
+    $GLOBALS['rms_header_pages']      = $pages;
+    $GLOBALS['rms_header_permalinks'] = $permalinks;
+}
+
+// ─── WordPress + ACF stubs ─────────────────────────────────────────────────
+
+if ( ! function_exists( '__' ) ) {
+    function __( $text, $domain = 'default' ) {
+        return $text;
+    }
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+    function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+        return true;
+    }
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+    function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+        return true;
+    }
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+    function sanitize_key( $key ) {
+        $key = strtolower( (string) $key );
+        return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+    }
+}
+
+if ( ! function_exists( 'get_field' ) ) {
+    function get_field( $selector, $post_id = false ) {
+        return $GLOBALS['rms_header_fields'][ $selector ] ?? null;
+    }
+}
+
+if ( ! function_exists( 'get_page_by_path' ) ) {
+    function get_page_by_path( $slug, $output = null, $post_type = 'page' ) {
+        $id = $GLOBALS['rms_header_pages'][ $slug ] ?? null;
+        if ( null === $id ) {
+            return null;
+        }
+        return (object) array( 'ID' => $id );
+    }
+}
+
+if ( ! function_exists( 'get_permalink' ) ) {
+    function get_permalink( $id ) {
+        return $GLOBALS['rms_header_permalinks'][ $id ] ?? '';
+    }
+}
+
+if ( ! function_exists( 'home_url' ) ) {
+    function home_url( $path = '/' ) {
+        return 'https://example.test' . $path;
+    }
+}
+
+if ( ! function_exists( 'esc_url' ) ) {
+    function esc_url( $url ) {
+        $url = trim( (string) $url );
+        if ( '' === $url || preg_match( '#^(javascript|data):#i', $url ) ) {
+            return '';
+        }
+        return $url;
+    }
+}
+
+if ( ! function_exists( 'esc_attr' ) ) {
+    function esc_attr( $text ) {
+        return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' );
+    }
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+    function esc_html( $text ) {
+        return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' );
+    }
+}
+
+if ( ! function_exists( 'esc_attr_e' ) ) {
+    function esc_attr_e( $text, $domain = 'default' ) {
+        echo esc_attr( $text );
+    }
+}
+
+if ( ! function_exists( 'esc_html_e' ) ) {
+    function esc_html_e( $text, $domain = 'default' ) {
+        echo esc_html( $text );
+    }
+}
+
+if ( ! function_exists( 'esc_attr__' ) ) {
+    function esc_attr__( $text, $domain = 'default' ) {
+        return esc_attr( $text );
+    }
+}
+
+if ( ! function_exists( 'esc_html__' ) ) {
+    function esc_html__( $text, $domain = 'default' ) {
+        return esc_html( $text );
+    }
+}
+
+if ( ! function_exists( 'get_bloginfo' ) ) {
+    function get_bloginfo( $show = '' ) {
+        return 'name' === $show ? 'Simple RMS' : ( 'charset' === $show ? 'UTF-8' : '' );
+    }
+}
+
+if ( ! function_exists( 'bloginfo' ) ) {
+    function bloginfo( $show = '' ) {
+        echo get_bloginfo( $show );
+    }
+}
+
+if ( ! function_exists( 'has_custom_logo' ) ) {
+    function has_custom_logo() {
+        return false;
+    }
+}
+
+if ( ! function_exists( 'the_custom_logo' ) ) {
+    function the_custom_logo() {}
+}
+
+if ( ! function_exists( 'wp_nav_menu' ) ) {
+    function wp_nav_menu( $args = array() ) {
+        return '';
+    }
+}
+
+if ( ! class_exists( 'RMS_Walker_Nav_Primary' ) ) {
+    class RMS_Walker_Nav_Primary {}
+}
+if ( ! class_exists( 'RMS_Walker_Nav_Mobile' ) ) {
+    class RMS_Walker_Nav_Mobile {}
+}
+if ( ! class_exists( 'RMS_Walker_Nav_V2_Desktop' ) ) {
+    class RMS_Walker_Nav_V2_Desktop {}
+}
+if ( ! class_exists( 'RMS_Walker_Nav_V2_Mobile' ) ) {
+    class RMS_Walker_Nav_V2_Mobile {}
+}
+if ( ! class_exists( 'RMS_Walker_Nav_V3_Desktop' ) ) {
+    class RMS_Walker_Nav_V3_Desktop {}
+}
+if ( ! class_exists( 'RMS_Walker_Nav_V3_Mobile' ) ) {
+    class RMS_Walker_Nav_V3_Mobile {}
+}
+
+require $theme_root . '/inc/acf-theme-options.php';
+
+// ─── Scenario 1: configured contact facts are consumed ─────────────────────
+
+rms_header_setup(
+    array(
+        'company_phones'         => array( array( 'phone_number' => '(407) 555-0100' ) ),
+        'company_emails'         => array( array( 'email_address' => 'contact@example.com' ) ),
+        'company_social_media'   => array(),
+        'company_address_line_1' => '1 Test Way',
+        'company_address_line_2' => '',
+        'company_city'           => 'Testville',
+        'company_state'          => 'TX',
+        'company_postal_code'    => '75001',
+    ),
+    array( 'contact-us' => 42 ),
+    array( 42 => 'https://example.test/contact-us/' )
+);
+
+$h1 = rms_header_render( 'header-one.php' );
+$h2 = rms_header_render( 'header-two.php' );
+$h3 = rms_header_render( 'header-three.php' );
+
+// 1. Phone consumes rms_get_primary_phone() in every variant; old literals gone.
+rms_header_assert( false !== strpos( $h1, 'tel:4075550100' ), 'test_header_variants_phone_consume_theme_options (header-one tel)', 'header-one missing sanitized tel URI for configured phone' );
+rms_header_assert( false !== strpos( $h1, '(407) 555-0100' ), 'test_header_variants_phone_consume_theme_options (header-one text)', 'header-one missing configured phone text' );
+rms_header_assert( false === strpos( $h1, '(414) 246-8257' ), 'test_header_variants_phone_consume_theme_options (header-one no old literal)', 'header-one still shows hardcoded (414) 246-8257' );
+
+rms_header_assert( false !== strpos( $h2, 'tel:4075550100' ), 'test_header_variants_phone_consume_theme_options (header-two tel)', 'header-two missing sanitized tel URI' );
+rms_header_assert( false !== strpos( $h2, '(407) 555-0100' ), 'test_header_variants_phone_consume_theme_options (header-two text)', 'header-two missing configured phone text' );
+rms_header_assert( false === strpos( $h2, '(407) 555-0199' ), 'test_header_variants_phone_consume_theme_options (header-two no old literal)', 'header-two still shows hardcoded (407) 555-0199' );
+
+rms_header_assert( 2 === substr_count( $h3, 'tel:4075550100' ), 'test_header_variants_phone_consume_theme_options (header-three desktop+mobile)', 'header-three must render tel:4075550100 exactly twice' );
+rms_header_assert( false === strpos( $h3, '(407) 555-0199' ), 'test_header_variants_phone_consume_theme_options (header-three no old literal)', 'header-three still shows hardcoded (407) 555-0199' );
+rms_header_assert( false === strpos( $h3, 'tel:+14075550199' ), 'test_header_variants_phone_consume_theme_options (header-three no old href)', 'header-three still shows hardcoded tel:+14075550199' );
+
+// 2. Header-two email consumes rms_get_primary_email().
+rms_header_assert( false !== strpos( $h2, 'mailto:contact@example.com' ), 'test_header_v2_email_consume_theme_options (mailto)', 'header-two missing mailto URI for configured email' );
+rms_header_assert( false !== strpos( $h2, 'contact@example.com' ), 'test_header_v2_email_consume_theme_options (text)', 'header-two missing configured email text' );
+rms_header_assert( false === strpos( $h2, 'hello@example.com' ), 'test_header_v2_email_consume_theme_options (no old literal)', 'header-two still shows hardcoded hello@example.com' );
+
+// 3. Header-one address consumes company address option fields.
+rms_header_assert( false !== strpos( $h1, '1 Test Way, Testville, TX, 75001' ), 'test_header_one_address_consume_theme_options', 'header-one missing assembled address from option fields' );
+rms_header_assert( false === strpos( $h1, '1234 Oak Ridge Ave' ), 'test_header_one_address_consume_theme_options (no old literal)', 'header-one still shows hardcoded 1234 Oak Ridge Ave' );
+
+// 6. Estimate CTAs resolve to the Contact permalink; never href="#".
+rms_header_assert( false !== strpos( $h1, 'https://example.test/contact-us/' ), 'test_header_one_and_v2_estimate_cta_resolves (header-one permalink)', 'header-one CTA did not resolve to contact permalink' );
+rms_header_assert( false !== strpos( $h2, 'https://example.test/contact-us/' ), 'test_header_one_and_v2_estimate_cta_resolves (header-two permalink)', 'header-two CTA did not resolve to contact permalink' );
+rms_header_assert( false === strpos( $h1, 'href="#"' ), 'test_header_one_and_v2_estimate_cta_resolves (header-one no dead href)', 'header-one CTA still has dead href="#"' );
+rms_header_assert( false === strpos( $h2, 'href="#"' ), 'test_header_one_and_v2_estimate_cta_resolves (header-two no dead href)', 'header-two CTA still has dead href="#"' );
+
+// ─── Scenario 2: empty contact values omit matching items ──────────────────
+
+rms_header_setup(
+    array(
+        'company_phones'       => array(),
+        'company_emails'       => array(),
+        'company_social_media' => array(),
+    ),
+    array( 'contact-us' => 42 ),
+    array( 42 => 'https://example.test/contact-us/' )
+);
+
+$h1 = rms_header_render( 'header-one.php' );
+$h2 = rms_header_render( 'header-two.php' );
+$h3 = rms_header_render( 'header-three.php' );
+
+// 4. Empty phone/email/address omit the corresponding header nodes.
+rms_header_assert( false === strpos( $h1, 'tel:' ), 'test_header_variants_empty_contact_values_omit_items (header-one phone omitted)', 'header-one rendered a phone item with empty phone' );
+rms_header_assert( false === strpos( $h1, 'Testville' ) && false === strpos( $h1, '1234 Oak Ridge Ave' ), 'test_header_variants_empty_contact_values_omit_items (header-one address omitted)', 'header-one rendered an address item with empty address' );
+
+rms_header_assert( false === strpos( $h2, 'rms-header-v2__phone' ), 'test_header_variants_empty_contact_values_omit_items (header-two phone omitted)', 'header-two rendered phone with empty phone' );
+rms_header_assert( false === strpos( $h2, 'rms-header-v2__email' ), 'test_header_variants_empty_contact_values_omit_items (header-two email omitted)', 'header-two rendered email with empty email' );
+rms_header_assert( false === strpos( $h2, 'mailto:' ), 'test_header_variants_empty_contact_values_omit_items (header-two no mailto)', 'header-two rendered a mailto link with empty email' );
+
+rms_header_assert( false === strpos( $h3, 'rms-header-v3__phone' ), 'test_header_variants_empty_contact_values_omit_items (header-three desktop omitted)', 'header-three rendered desktop phone with empty phone' );
+rms_header_assert( false === strpos( $h3, 'rms-header-v3__mobile-phone' ), 'test_header_variants_empty_contact_values_omit_items (header-three mobile omitted)', 'header-three rendered mobile phone with empty phone' );
+rms_header_assert( false === strpos( $h3, 'tel:' ), 'test_header_variants_empty_contact_values_omit_items (header-three no tel)', 'header-three rendered a tel link with empty phone' );
+
+// ─── Scenario 3: sanitized + escaped protocols ─────────────────────────────
+
+rms_header_setup(
+    array(
+        'company_phones'         => array( array( 'phone_number' => '+1 (407) 555-0100' ) ),
+        'company_emails'         => array( array( 'email_address' => 'contact@example.com' ) ),
+        'company_social_media'   => array(),
+        'company_address_line_1' => '1 <b>Test</b> Way',
+        'company_city'           => 'Testville',
+        'company_state'          => 'TX',
+        'company_postal_code'    => '75001',
+    ),
+    array(),
+    array()
+);
+
+$h1 = rms_header_render( 'header-one.php' );
+$h2 = rms_header_render( 'header-two.php' );
+$h3 = rms_header_render( 'header-three.php' );
+
+// 5a. Leading plus preserved, non-digits stripped: tel:+14075550100.
+rms_header_assert( false !== strpos( $h1, 'tel:+14075550100' ), 'test_header_variants_contact_links_use_sanitized_protocols (header-one leading plus)', 'header-one tel URI did not preserve leading + and digits' );
+rms_header_assert( 2 === substr_count( $h3, 'tel:+14075550100' ), 'test_header_variants_contact_links_use_sanitized_protocols (header-three leading plus)', 'header-three tel URI did not preserve leading + and digits in both surfaces' );
+
+// 5b. Visible text escaped; address HTML escaped.
+rms_header_assert( false === strpos( $h1, '<b>Test</b>' ), 'test_header_variants_contact_links_use_sanitized_protocols (address escaped)', 'header-one address HTML was not escaped' );
+rms_header_assert( false !== strpos( $h1, '&lt;b&gt;Test&lt;/b&gt;' ), 'test_header_variants_contact_links_use_sanitized_protocols (address entities)', 'header-one address did not emit escaped entities' );
+
+// 5c. Injection payload is stripped from href and escaped in text.
+rms_header_setup(
+    array(
+        'company_phones'       => array( array( 'phone_number' => "(407) 555-0100\"><script>alert('x')</script>" ) ),
+        'company_emails'       => array( array( 'email_address' => 'contact@example.com' ) ),
+        'company_social_media' => array(),
+    ),
+    array(),
+    array()
+);
+$h1 = rms_header_render( 'header-one.php' );
+rms_header_assert( false !== strpos( $h1, 'tel:4075550100' ), 'test_header_variants_contact_links_use_sanitized_protocols (injection stripped from href)', 'header-one tel URI retained non-digit payload' );
+rms_header_assert( false === strpos( $h1, '<script>alert' ), 'test_header_variants_contact_links_use_sanitized_protocols (no raw script)', 'header-one emitted unescaped <script>' );
+rms_header_assert( false !== strpos( $h1, '&lt;script&gt;' ), 'test_header_variants_contact_links_use_sanitized_protocols (script escaped)', 'header-one did not escape <script> in visible text' );
+
+// ─── Scenario 4: CTA fallback + contact slug alias ─────────────────────────
+
+// No Contact page: fallback to home_url('/#contact').
+rms_header_setup(
+    array(
+        'company_phones'       => array( array( 'phone_number' => '(407) 555-0100' ) ),
+        'company_emails'       => array( array( 'email_address' => 'contact@example.com' ) ),
+        'company_social_media' => array(),
+    ),
+    array(),
+    array()
+);
+$h1 = rms_header_render( 'header-one.php' );
+$h2 = rms_header_render( 'header-two.php' );
+rms_header_assert( false !== strpos( $h1, 'https://example.test/#contact' ), 'test_header_one_and_v2_estimate_cta_resolves (header-one fallback)', 'header-one CTA did not fall back to home_url(/#contact)' );
+rms_header_assert( false !== strpos( $h2, 'https://example.test/#contact' ), 'test_header_one_and_v2_estimate_cta_resolves (header-two fallback)', 'header-two CTA did not fall back to home_url(/#contact)' );
+rms_header_assert( false === strpos( $h1, 'href="#"' ) && false === strpos( $h2, 'href="#"' ), 'test_header_one_and_v2_estimate_cta_resolves (fallback no dead href)', 'CTA still has dead href="#"' );
+
+// Legacy 'contact' slug resolves too.
+rms_header_setup(
+    array(
+        'company_phones'       => array( array( 'phone_number' => '(407) 555-0100' ) ),
+        'company_emails'       => array(),
+        'company_social_media' => array(),
+    ),
+    array( 'contact' => 7 ),
+    array( 7 => 'https://example.test/contact/' )
+);
+$h1 = rms_header_render( 'header-one.php' );
+rms_header_assert( false !== strpos( $h1, 'https://example.test/contact/' ), 'test_header_one_and_v2_estimate_cta_resolves (contact slug alias)', 'header-one CTA did not resolve the legacy contact slug' );
+
+// ─── Scenario 5: social links stay dynamic ─────────────────────────────────
+
+rms_header_setup(
+    array(
+        'company_phones'       => array( array( 'phone_number' => '(407) 555-0100' ) ),
+        'company_emails'       => array( array( 'email_address' => 'contact@example.com' ) ),
+        'company_social_media' => array(
+            array(
+                'social_is_active' => true,
+                'social_url'       => 'https://facebook.com/raven',
+                'social_platform'  => 'facebook',
+                'social_label'     => 'Facebook',
+            ),
+        ),
+    ),
+    array(),
+    array()
+);
+$h1 = rms_header_render( 'header-one.php' );
+$h2 = rms_header_render( 'header-two.php' );
+$h3 = rms_header_render( 'header-three.php' );
+rms_header_assert( false !== strpos( $h1, 'https://facebook.com/raven' ), 'test_header_variants_social_links_remain_dynamic (header-one)', 'header-one social links are no longer dynamic' );
+rms_header_assert( false !== strpos( $h2, 'https://facebook.com/raven' ), 'test_header_variants_social_links_remain_dynamic (header-two)', 'header-two social links are no longer dynamic' );
+rms_header_assert( false !== strpos( $h3, 'https://facebook.com/raven' ), 'test_header_variants_social_links_remain_dynamic (header-three)', 'header-three social links are no longer dynamic' );
+
+// ─── Summary ───────────────────────────────────────────────────────────────
+
+if ( $failures > 0 ) {
+    fwrite( STDERR, "Harness failed: {$failures} check(s).\n" );
+    exit( 1 );
+}
+
+echo "Harness passed: all header contact + CTA checks.\n";
+exit( 0 );


### PR DESCRIPTION
Closes #55

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- All three shipped header variants (`header-one`, `header-two`, `header-three`) now consume Theme Options contact facts (phone, email, assembled address) instead of hardcoded demo literals.
- Estimate CTAs resolve to the Contact page permalink — with a safe `home_url('/#contact')` fallback — instead of a dead `href="#"`.
- Two new helpers in `inc/acf-theme-options.php` centralize `tel:` sanitization and Contact page resolution, with output escaping (`esc_url`, `esc_attr`, `esc_html`) at every render site.

## Changes

| File | Change |
|------|--------|
| `inc/acf-theme-options.php` | Add `rms_format_tel_uri()` (digits-only `tel:` URI, single leading `+` preserved) and `rms_get_contact_page_url()` (contact-us/contact slug lookup, `home_url('/#contact')` fallback) |
| `templates/header-one.php` | Render Theme Options phone (`tel:` + visible text) and assembled address; resolve estimate CTA via contact permalink |
| `templates/header-two.php` | Render Theme Options phone and email (`tel:`/`mailto:`); resolve estimate CTA via contact permalink |
| `templates/header-three.php` | Render Theme Options phone on both desktop and mobile surfaces |

## Test Plan
- [x] Regression harness: `php tests/header-variants-contact-harness.php` — 40/40 PASS at this branch HEAD (harness delivered by stacked child PR #92)
- [x] PHP lint on all changed files (`php -l`): clean
- [x] Diff check: production diff is 108 authored lines (98 insertions / 10 deletions) — within the 400-line review budget
- [x] No `Co-Authored-By` trailers in commits.

## Contributor Checklist
- [x] Linked an approved issue (#55, `status:approved`)
- [x] Added exactly one type:* label (type:bug)
- [x] Ran shellcheck on modified scripts: N/A — no shell scripts in this PR
- [x] Skills tested in at least one agent: N/A
- [x] Docs updated if behavior changed: no docs affected; issue #55 tracks the hardcoded contact details
- [x] Conventional commit format (`fix(header): consume Theme Options in variants`)
- [x] No `Co-Authored-By` trailers

## Chain Context

This is a **stacked PR** — the production half of the #55 fix. **It MUST NOT be merged until PR #92 (stacked child, the 393-line regression harness) is integrated into this branch.** Merging this PR first would land the fix on main without its coverage and would leave the review-budget warning from independent verify unresolved.

| Field | Value |
|-------|-------|
| Position | 1 / 2 (parent of stack) |
| Base | main @ da603d4 |
| Head | fix/header-variants-theme-options @ 3ef1d23 |
| Stacked child | #92 test/header-variants-theme-options @ f38f6a7 (393-line harness, 40/40 PASS) |
| Review budget | 108 authored lines (98 insertions / 10 deletions) — within 400 |
| Rollback boundary | Single commit `3ef1d23` on main. Reverting it restores the previous (hardcoded) headers with no other collateral; the harness rides separately via #92 |
| Out of scope | `.codegraph/` and `.playwright-mcp/` excluded; no Local sites / databases / browsers accessed |

### Merge Topology (read before merging)

1. **Merge #92 FIRST** (test → fix/header-variants-theme-options). This integrates the 393-line regression harness into this branch, solving the review-budget warning from independent verify and locking the fix behind 40/40 passing tests.
2. **THEN merge this PR** (fix → main). One merge lands both the 108-line production fix and its harness on main, so main never holds the fix without coverage.
3. **Issue #55 closes only when THIS PR merges into main.** Merging #92 into the non-default fix branch does not close the issue — closing keywords only fire on the default branch.

### Dependency Diagram

```
main
 └── 📍 #91 fix/header-variants-theme-options  <-- this PR (merge SECOND; closes #55)
      └── #92 test/header-variants-theme-options  (merge FIRST: 393-line harness)
```