### PR TITLE
feat(header): render global primary CTA

### DIFF
--- a/inc/acf-theme-options.php
+++ b/inc/acf-theme-options.php
@@ -270,6 +270,58 @@ function rms_get_contact_page_url(): string {
     return home_url('/#contact');
 }
 
+/**
+ * Resolve the site-wide Header Primary CTA (link) from Theme Options.
+ *
+ * Reads the optional `company_header_primary_cta` ACF link field (array return
+ * format) and returns a normalized `[url, title, target]` contract. Empty or
+ * malformed link data falls back to the Contact page permalink (or
+ * `home_url('/#contact')`) with the default "Get a Free Estimate" label and
+ * `_self` target. The target is restricted to `_self`/`_blank`; any other value
+ * becomes `_self`.
+ *
+ * @return array{url:string,title:string,target:string}
+ */
+function rms_get_header_primary_cta(): array {
+    $default = array(
+        'url'    => rms_get_contact_page_url(),
+        'title'  => __('Get a Free Estimate', 'simple-rms-theme'),
+        'target' => '_self',
+    );
+
+    if (!function_exists('get_field')) {
+        return $default;
+    }
+
+    $link = get_field('company_header_primary_cta', 'option');
+
+    if (!is_array($link)) {
+        return $default;
+    }
+
+    $url = isset($link['url']) && is_string($link['url']) ? trim($link['url']) : '';
+
+    // A bare fragment is a dead link; treat it like an empty value.
+    if ('' === $url || '#' === $url) {
+        return $default;
+    }
+
+    $title = isset($link['title']) && is_string($link['title']) && '' !== trim($link['title'])
+        ? trim($link['title'])
+        : $default['title'];
+
+    $target = isset($link['target']) && is_string($link['target']) ? $link['target'] : '';
+    if ('_blank' !== $target && '_self' !== $target) {
+        $target = '_self';
+    }
+
+    return array(
+        'url'    => $url,
+        'title'  => $title,
+        'target' => $target,
+    );
+}
+
 // ─── Company Palette → CSS Custom Properties Bridge ────────────────────────
 
 /**

--- a/templates/header-one.php
+++ b/templates/header-one.php
@@ -16,7 +16,7 @@ $header_address = implode(', ', array_filter(array(
     is_string($header_addr_zip) ? $header_addr_zip : '',
 )));
 
-$header_cta_url = rms_get_contact_page_url();
+$header_cta = rms_get_header_primary_cta();
 ?>
 <header class="rms-header" role="banner">
     <!-- Top Bar -->
@@ -24,7 +24,12 @@ $header_cta_url = rms_get_contact_page_url();
         <div class="container">
             <div class="rms-header__top-bar-inner">
                 <div class="rms-header__top-bar-left">
-                    <a href="<?php echo esc_url($header_cta_url); ?>" class="rms-header__cta-btn">GET A FREE ESTIMATE</a>
+                    <a
+                        href="<?php echo esc_url($header_cta['url']); ?>"
+                        class="rms-header__cta-btn"
+                        target="<?php echo esc_attr($header_cta['target']); ?>"
+                        <?php if ('_blank' === $header_cta['target']) : ?>rel="noopener noreferrer"<?php endif; ?>
+                    ><?php echo esc_html($header_cta['title']); ?></a>
                 </div>
                 <div class="rms-header__top-bar-right">
                     <span class="rms-header__social-label">Follow us on:</span>

--- a/templates/header-two.php
+++ b/templates/header-two.php
@@ -2,7 +2,7 @@
 $header_phone       = rms_get_primary_phone();
 $header_phone_clean = rms_format_tel_uri($header_phone);
 $header_email       = trim(rms_get_primary_email());
-$header_cta_url     = rms_get_contact_page_url();
+$header_cta         = rms_get_header_primary_cta();
 ?>
 <header class="rms-header-v2" role="banner">
     <!-- Top Bar -->
@@ -50,7 +50,7 @@ $header_cta_url     = rms_get_contact_page_url();
                         <?php endforeach; ?>
                     </div>
                     <?php endif; ?>
-                    <a href="<?php echo esc_url($header_cta_url); ?>" class="btn rms-header-v2__cta-btn">Get a Free Estimate</a>
+                    <a href="<?php echo esc_url($header_cta['url']); ?>" class="btn rms-header-v2__cta-btn" target="<?php echo esc_attr($header_cta['target']); ?>"<?php if ('_blank' === $header_cta['target']) : ?> rel="noopener noreferrer"<?php endif; ?>><?php echo esc_html($header_cta['title']); ?></a>
                 </div>
             </div>
         </div>

--- a/tests/header-primary-cta-behavior-harness.php
+++ b/tests/header-primary-cta-behavior-harness.php
@@ -1,0 +1,267 @@
+<?php
+/**
+ * Focused behavior harness for issue #56 (header primary CTA getter + render).
+ *
+ * Proves:
+ *   1. `rms_get_header_primary_cta()` returns a normalized url/title/target
+ *      contract for configured links (internal page + custom/external URL).
+ *   2. Header One and Header Two render the configured URL/title/target and
+ *      preserve their existing CTA classes.
+ *   3. `_blank` adds `rel="noopener noreferrer"`; target is restricted to
+ *      `_self`/`_blank`.
+ *   4. Empty/malformed link data falls back to the Contact permalink (then
+ *      `home_url('/#contact')`) with label "Get a Free Estimate" and `_self`.
+ *   5. url/title/target are escaped.
+ *
+ * No framework. Single process; `get_field` and the page resolver are stubbed
+ * via globals and toggled between scenarios.
+ *
+ * Usage: php tests/header-primary-cta-behavior-harness.php
+ */
+
+if ( PHP_SAPI !== 'cli' ) {
+    fwrite( STDERR, "CLI only.\n" );
+    exit( 1 );
+}
+
+$theme_root = dirname( __DIR__ );
+
+require __DIR__ . '/support/header-cta-support.php';
+
+/**
+ * Call the primary-CTA getter without fataling when it does not yet exist.
+ */
+function rms_cta_get(): array {
+    if ( function_exists( 'rms_get_header_primary_cta' ) ) {
+        return rms_get_header_primary_cta();
+    }
+    return array( 'url' => '__missing__', 'title' => '__missing__', 'target' => '__missing__' );
+}
+
+// ─── Test 2: getter configured with an internal page link ──────────────────
+
+rms_cta_assert(
+    function_exists( 'rms_get_header_primary_cta' ),
+    'test_getter_defined',
+    'rms_get_header_primary_cta() is not defined in inc/acf-theme-options.php'
+);
+
+rms_cta_setup(
+    array(
+        'company_header_primary_cta' => array(
+            'url'    => 'https://example.test/free-estimate/',
+            'title'  => 'Get Estimate',
+            'target' => '_self',
+        ),
+        'company_phones'       => array(),
+        'company_emails'       => array(),
+        'company_social_media' => array(),
+    ),
+    array( 'contact-us' => 42 ),
+    array( 42 => 'https://example.test/contact-us/' )
+);
+
+$cta = rms_cta_get();
+rms_cta_assert( 'https://example.test/free-estimate/' === $cta['url'], 'test_header_one_and_two_render_internal_page_cta (getter url)', 'configured internal page URL not returned' );
+rms_cta_assert( 'Get Estimate' === $cta['title'], 'test_header_one_and_two_render_internal_page_cta (getter title)', 'configured title not returned' );
+rms_cta_assert( '_self' === $cta['target'], 'test_header_one_and_two_render_internal_page_cta (getter target)', 'configured _self target not returned' );
+
+$h1 = rms_cta_render( 'header-one.php' );
+$h2 = rms_cta_render( 'header-two.php' );
+
+rms_cta_assert( false !== strpos( $h1, 'https://example.test/free-estimate/' ), 'test_header_one_and_two_render_internal_page_cta (header-one href)', 'header-one did not render configured internal page URL' );
+rms_cta_assert( false !== strpos( $h1, 'Get Estimate' ), 'test_header_one_and_two_render_internal_page_cta (header-one label)', 'header-one did not render configured title' );
+rms_cta_assert( false !== strpos( $h2, 'https://example.test/free-estimate/' ), 'test_header_one_and_two_render_internal_page_cta (header-two href)', 'header-two did not render configured internal page URL' );
+rms_cta_assert( false !== strpos( $h2, 'Get Estimate' ), 'test_header_one_and_two_render_internal_page_cta (header-two label)', 'header-two did not render configured title' );
+
+// Configured field must win over the contact permalink fallback.
+rms_cta_assert( false === strpos( $h1, 'https://example.test/contact-us/' ), 'test_header_one_and_two_render_internal_page_cta (header-one overrides fallback)', 'header-one rendered contact fallback instead of configured URL' );
+rms_cta_assert( false === strpos( $h2, 'https://example.test/contact-us/' ), 'test_header_one_and_two_render_internal_page_cta (header-two overrides fallback)', 'header-two rendered contact fallback instead of configured URL' );
+
+// ─── Test 3: custom/external URL ───────────────────────────────────────────
+
+rms_cta_setup(
+    array(
+        'company_header_primary_cta' => array(
+            'url'    => 'https://client.example.com/book',
+            'title'  => 'Book Your Service',
+            'target' => '_self',
+        ),
+        'company_phones'       => array(),
+        'company_emails'       => array(),
+        'company_social_media' => array(),
+    ),
+    array( 'contact-us' => 42 ),
+    array( 42 => 'https://example.test/contact-us/' )
+);
+
+$h1 = rms_cta_render( 'header-one.php' );
+$h2 = rms_cta_render( 'header-two.php' );
+
+rms_cta_assert( false !== strpos( $h1, 'https://client.example.com/book' ), 'test_header_one_and_two_render_custom_url_cta (header-one)', 'header-one did not render custom external URL' );
+rms_cta_assert( false !== strpos( $h2, 'https://client.example.com/book' ), 'test_header_one_and_two_render_custom_url_cta (header-two)', 'header-two did not render custom external URL' );
+
+// ─── Test 4: _blank target adds safe rel ───────────────────────────────────
+
+rms_cta_setup(
+    array(
+        'company_header_primary_cta' => array(
+            'url'    => 'https://client.example.com/book',
+            'title'  => 'Book Now',
+            'target' => '_blank',
+        ),
+        'company_phones'       => array(),
+        'company_emails'       => array(),
+        'company_social_media' => array(),
+    ),
+    array(),
+    array()
+);
+
+$h1 = rms_cta_render( 'header-one.php' );
+$h2 = rms_cta_render( 'header-two.php' );
+
+rms_cta_assert( false !== strpos( $h1, 'target="_blank"' ), 'test_header_cta_blank_target_adds_noopener_noreferrer (header-one target)', 'header-one missing target="_blank"' );
+rms_cta_assert( false !== strpos( $h1, 'rel="noopener noreferrer"' ), 'test_header_cta_blank_target_adds_noopener_noreferrer (header-one rel)', 'header-one missing rel="noopener noreferrer" for _blank' );
+rms_cta_assert( false !== strpos( $h2, 'target="_blank"' ), 'test_header_cta_blank_target_adds_noopener_noreferrer (header-two target)', 'header-two missing target="_blank"' );
+rms_cta_assert( false !== strpos( $h2, 'rel="noopener noreferrer"' ), 'test_header_cta_blank_target_adds_noopener_noreferrer (header-two rel)', 'header-two missing rel="noopener noreferrer" for _blank' );
+
+// `_self` (and any non-blank) must NOT add the blank-target rel.
+rms_cta_setup(
+    array(
+        'company_header_primary_cta' => array(
+            'url'    => 'https://example.test/estimate',
+            'title'  => 'Get Estimate',
+            'target' => '_self',
+        ),
+        'company_phones'       => array(),
+        'company_emails'       => array(),
+        'company_social_media' => array(),
+    ),
+    array(),
+    array()
+);
+$h1_self = rms_cta_render( 'header-one.php' );
+rms_cta_assert( false === strpos( $h1_self, 'rel="noopener noreferrer"' ), 'test_header_cta_blank_target_adds_noopener_noreferrer (self no rel)', 'header-one added rel for _self target' );
+rms_cta_assert( false !== strpos( $h1_self, 'target="_self"' ), 'test_header_cta_blank_target_adds_noopener_noreferrer (self target)', 'header-one missing target="_self"' );
+
+// ─── Test 5: empty/malformed link data falls back safely ───────────────────
+
+// 5a. Field key absent entirely.
+rms_cta_setup(
+    array(
+        'company_phones'       => array(),
+        'company_emails'       => array(),
+        'company_social_media' => array(),
+    ),
+    array( 'contact-us' => 42 ),
+    array( 42 => 'https://example.test/contact-us/' )
+);
+$cta = rms_cta_get();
+rms_cta_assert( 'https://example.test/contact-us/' === $cta['url'], 'test_header_cta_empty_uses_contact_permalink_or_hash_fallback (getter contact permalink)', 'empty field did not resolve contact permalink' );
+rms_cta_assert( 'Get a Free Estimate' === $cta['title'], 'test_header_cta_empty_uses_contact_permalink_or_hash_fallback (getter default label)', 'empty field did not use default label' );
+rms_cta_assert( '_self' === $cta['target'], 'test_header_cta_empty_uses_contact_permalink_or_hash_fallback (getter self target)', 'empty field did not default to _self' );
+
+$h1 = rms_cta_render( 'header-one.php' );
+$h2 = rms_cta_render( 'header-two.php' );
+rms_cta_assert( false !== strpos( $h1, 'https://example.test/contact-us/' ), 'test_header_cta_empty_uses_contact_permalink_or_hash_fallback (header-one permalink)', 'header-one empty CTA did not use contact permalink' );
+rms_cta_assert( false !== strpos( $h1, 'Get a Free Estimate' ), 'test_header_cta_empty_uses_contact_permalink_or_hash_fallback (header-one label)', 'header-one empty CTA did not use default label' );
+rms_cta_assert( false !== strpos( $h2, 'Get a Free Estimate' ), 'test_header_cta_empty_uses_contact_permalink_or_hash_fallback (header-two label)', 'header-two empty CTA did not use default label' );
+rms_cta_assert( false === strpos( $h1, 'href="#"' ) && false === strpos( $h2, 'href="#"' ), 'test_header_cta_empty_uses_contact_permalink_or_hash_fallback (no dead href)', 'empty CTA produced dead href="#"' );
+
+// 5b. No Contact page: fall back to home_url('/#contact'); never a bare `#`.
+rms_cta_setup(
+    array(
+        'company_phones'       => array(),
+        'company_emails'       => array(),
+        'company_social_media' => array(),
+    ),
+    array(),
+    array()
+);
+$h1 = rms_cta_render( 'header-one.php' );
+$h2 = rms_cta_render( 'header-two.php' );
+rms_cta_assert( false !== strpos( $h1, 'https://example.test/#contact' ), 'test_header_cta_empty_uses_contact_permalink_or_hash_fallback (header-one hash fallback)', 'header-one did not fall back to home_url(/#contact)' );
+rms_cta_assert( false !== strpos( $h2, 'https://example.test/#contact' ), 'test_header_cta_empty_uses_contact_permalink_or_hash_fallback (header-two hash fallback)', 'header-two did not fall back to home_url(/#contact)' );
+rms_cta_assert( false === strpos( $h1, 'href="#"' ) && false === strpos( $h2, 'href="#"' ), 'test_header_cta_empty_uses_contact_permalink_or_hash_fallback (hash fallback no dead href)', 'hash fallback still produced bare href="#"' );
+
+// 5c. Malformed link data: non-array, empty array, empty url, bare '#' url.
+foreach ( array( 'garbage', 42, null, array(), array( 'url' => '', 'title' => 'X', 'target' => '_blank' ), array( 'url' => '#', 'title' => 'X', 'target' => '_blank' ) ) as $malformed ) {
+    rms_cta_setup(
+        array_merge(
+            array( 'company_header_primary_cta' => $malformed ),
+            array( 'company_phones' => array(), 'company_emails' => array(), 'company_social_media' => array() )
+        ),
+        array( 'contact-us' => 42 ),
+        array( 42 => 'https://example.test/contact-us/' )
+    );
+    $cta = rms_cta_get();
+    $ok = ( 'https://example.test/contact-us/' === $cta['url'] )
+        && ( 'Get a Free Estimate' === $cta['title'] )
+        && ( '_self' === $cta['target'] );
+    rms_cta_assert( $ok, 'test_header_cta_empty_uses_contact_permalink_or_hash_fallback (malformed ' . gettype( $malformed ) . ')', 'malformed link data did not fall back safely' );
+}
+
+// 5d. Partial link data: url present but title/target missing.
+rms_cta_setup(
+    array(
+        'company_header_primary_cta' => array( 'url' => 'https://example.test/only-url' ),
+        'company_phones'       => array(),
+        'company_emails'       => array(),
+        'company_social_media' => array(),
+    ),
+    array(),
+    array()
+);
+$cta = rms_cta_get();
+rms_cta_assert( 'https://example.test/only-url' === $cta['url'], 'test_getter_handles_malformed_link_data (url kept)', 'partial link lost its URL' );
+rms_cta_assert( 'Get a Free Estimate' === $cta['title'], 'test_getter_handles_malformed_link_data (title defaulted)', 'partial link did not default its title' );
+rms_cta_assert( '_self' === $cta['target'], 'test_getter_handles_malformed_link_data (target defaulted)', 'partial link did not default its target' );
+
+// 5e. Invalid target values are restricted to _self.
+foreach ( array( '_top', 'foo', '', null, array( 'nested' ) ) as $bad_target ) {
+    rms_cta_setup(
+        array(
+            'company_header_primary_cta' => array( 'url' => 'https://example.test/estimate', 'title' => 'Get Estimate', 'target' => $bad_target ),
+            'company_phones'       => array(),
+            'company_emails'       => array(),
+            'company_social_media' => array(),
+        ),
+        array(),
+        array()
+    );
+    $cta = rms_cta_get();
+    rms_cta_assert( '_self' === $cta['target'], 'test_getter_handles_malformed_link_data (target restricted ' . gettype( $bad_target ) . ')', 'invalid target was not restricted to _self' );
+}
+
+// ─── Test 6: url/title/target escaping ─────────────────────────────────────
+
+rms_cta_setup(
+    array(
+        'company_header_primary_cta' => array(
+            'url'    => 'javascript:alert(1)',
+            'title'  => '<script>alert("x")</script> & "quotes"',
+            'target' => '_blank',
+        ),
+        'company_phones'       => array(),
+        'company_emails'       => array(),
+        'company_social_media' => array(),
+    ),
+    array(),
+    array()
+);
+$h1 = rms_cta_render( 'header-one.php' );
+rms_cta_assert( false === strpos( $h1, 'javascript:' ), 'test_header_cta_escapes_url_title_target (url protocol stripped)', 'header-one emitted a javascript: href' );
+rms_cta_assert( false === strpos( $h1, '<script>alert' ), 'test_header_cta_escapes_url_title_target (no raw script)', 'header-one emitted unescaped <script> in title' );
+rms_cta_assert( false !== strpos( $h1, '&lt;script&gt;' ), 'test_header_cta_escapes_url_title_target (title escaped)', 'header-one did not escape <script> in title' );
+rms_cta_assert( false !== strpos( $h1, '&quot;quotes&quot;' ), 'test_header_cta_escapes_url_title_target (quotes escaped)', 'header-one did not escape double quotes in title' );
+
+// ─── Summary ───────────────────────────────────────────────────────────────
+
+if ( $failures > 0 ) {
+    fwrite( STDERR, "Behavior harness failed: {$failures} check(s).\n" );
+    exit( 1 );
+}
+
+echo "Behavior harness passed: getter + render behavior for header primary CTA.\n";
+exit( 0 );

--- a/tests/header-primary-cta-harness.php
+++ b/tests/header-primary-cta-harness.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Aggregate runner for the #56 header primary CTA harness family.
+ *
+ * Executes the three focused harnesses in isolated sub-processes and surfaces a
+ * single pass/fail rollup. Individual assertions live in:
+ *   - tests/header-primary-cta-schema-harness.php
+ *   - tests/header-primary-cta-behavior-harness.php
+ *   - tests/header-primary-cta-regression-harness.php
+ *
+ * No framework. Parent process shells out; stubs are isolated per harness.
+ *
+ * Usage: php tests/header-primary-cta-harness.php
+ */
+
+if ( PHP_SAPI !== 'cli' ) {
+    fwrite( STDERR, "CLI only.\n" );
+    exit( 1 );
+}
+
+$php    = PHP_BINARY;
+$dir    = __DIR__;
+$suites = array(
+    'schema'     => $dir . '/header-primary-cta-schema-harness.php',
+    'behavior'   => $dir . '/header-primary-cta-behavior-harness.php',
+    'regression' => $dir . '/header-primary-cta-regression-harness.php',
+);
+
+$failed = 0;
+
+foreach ( $suites as $name => $path ) {
+    $cmd    = '"' . $php . '" ' . escapeshellarg( $path );
+    $output = array();
+    $code   = 0;
+    exec( $cmd, $output, $code );
+    if ( 0 !== $code ) {
+        fwrite( STDERR, "FAIL {$name}\n" . implode( "\n", $output ) . "\n" );
+        $failed++;
+        continue;
+    }
+    echo "PASS {$name}\n";
+    echo implode( "\n", $output ) . "\n";
+}
+
+if ( $failed > 0 ) {
+    fwrite( STDERR, "Harness failed: {$failed} suite(s).\n" );
+    exit( 1 );
+}
+
+echo 'Harness passed: ' . count( $suites ) . " suites.\n";
+exit( 0 );

--- a/tests/header-primary-cta-regression-harness.php
+++ b/tests/header-primary-cta-regression-harness.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Focused regression harness for issue #56 (header primary CTA locality + no
+ * collateral change to other header variants or existing contact wiring).
+ *
+ * Proves:
+ *   1. Header Three is unchanged and has no CTA.
+ *   2. Flexible-content section CTAs stay local (no read of the global field).
+ *   3. Existing #55 contact wiring (phone/social/address/email) remains intact.
+ *
+ * No framework. Single process; `get_field` and the page resolver are stubbed
+ * via globals and toggled between scenarios.
+ *
+ * Usage: php tests/header-primary-cta-regression-harness.php
+ */
+
+if ( PHP_SAPI !== 'cli' ) {
+    fwrite( STDERR, "CLI only.\n" );
+    exit( 1 );
+}
+
+$theme_root = dirname( __DIR__ );
+
+require __DIR__ . '/support/header-cta-support.php';
+
+// ─── Test 7: header three unchanged / no CTA ───────────────────────────────
+
+$h3 = rms_cta_render( 'header-three.php' );
+rms_cta_assert( false === strpos( $h3, 'cta-btn' ), 'test_header_three_has_no_cta (no cta button)', 'header-three rendered a CTA button' );
+rms_cta_assert( false === strpos( $h3, 'rms-header-v3__cta' ), 'test_header_three_has_no_cta (no v3 cta class)', 'header-three rendered a CTA class' );
+
+// ─── Test 8: flexible-content CTAs stay local (static) ─────────────────────
+
+$templates_dir = $theme_root . '/templates';
+$consumers = array();
+$it = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $templates_dir, FilesystemIterator::SKIP_DOTS ) );
+foreach ( $it as $file ) {
+    if ( 'php' !== $file->getExtension() ) {
+        continue;
+    }
+    $content = file_get_contents( $file->getPathname() );
+    if ( false !== strpos( $content, 'rms_get_header_primary_cta' ) || false !== strpos( $content, 'company_header_primary_cta' ) ) {
+        $consumers[] = $file->getFilename();
+    }
+}
+sort( $consumers );
+rms_cta_assert(
+    array( 'header-one.php', 'header-two.php' ) === $consumers,
+    'test_flexible_content_ctas_remain_local (only header-one/two consume)',
+    'unexpected consumers of the global primary CTA: ' . implode( ', ', $consumers )
+);
+
+// ─── Test 9: existing contact wiring remains intact ────────────────────────
+
+rms_cta_setup(
+    array(
+        'company_header_primary_cta' => array(
+            'url'    => 'https://example.test/estimate',
+            'title'  => 'Get Estimate',
+            'target' => '_self',
+        ),
+        'company_phones'       => array( array( 'phone_number' => '(407) 555-0100' ) ),
+        'company_emails'       => array( array( 'email_address' => 'contact@example.com' ) ),
+        'company_social_media' => array(
+            array(
+                'social_is_active' => true,
+                'social_url'       => 'https://facebook.com/raven',
+                'social_platform'  => 'facebook',
+                'social_label'     => 'Facebook',
+            ),
+        ),
+        'company_address_line_1' => '1 Test Way',
+        'company_city'           => 'Testville',
+        'company_state'          => 'TX',
+        'company_postal_code'    => '75001',
+    ),
+    array( 'contact-us' => 42 ),
+    array( 42 => 'https://example.test/contact-us/' )
+);
+
+$h1 = rms_cta_render( 'header-one.php' );
+$h2 = rms_cta_render( 'header-two.php' );
+
+rms_cta_assert( false !== strpos( $h1, 'tel:4075550100' ), 'test_existing_contact_wiring_remains_intact (header-one phone)', 'header-one phone wiring regressed' );
+rms_cta_assert( false !== strpos( $h1, 'https://facebook.com/raven' ), 'test_existing_contact_wiring_remains_intact (header-one social)', 'header-one social wiring regressed' );
+rms_cta_assert( false !== strpos( $h1, '1 Test Way, Testville, TX, 75001' ), 'test_existing_contact_wiring_remains_intact (header-one address)', 'header-one address wiring regressed' );
+rms_cta_assert( false !== strpos( $h2, 'mailto:contact@example.com' ), 'test_existing_contact_wiring_remains_intact (header-two email)', 'header-two email wiring regressed' );
+rms_cta_assert( false !== strpos( $h2, 'https://facebook.com/raven' ), 'test_existing_contact_wiring_remains_intact (header-two social)', 'header-two social wiring regressed' );
+
+// ─── Summary ───────────────────────────────────────────────────────────────
+
+if ( $failures > 0 ) {
+    fwrite( STDERR, "Regression harness failed: {$failures} check(s).\n" );
+    exit( 1 );
+}
+
+echo "Regression harness passed: locality + existing contact wiring intact.\n";
+exit( 0 );


### PR DESCRIPTION
Closes #56

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds `rms_get_header_primary_cta()` in `inc/acf-theme-options.php`: reads the `company_header_primary_cta` ACF link field (added by PR A) and returns a normalized `[url, title, target]` contract with sane fallbacks — Contact page permalink (or `home_url('/#contact')`), default label, `_self`-restricted target.
- Rewires `templates/header-one.php` and `templates/header-two.php` to render the global Primary CTA from Theme Options instead of hardcoded contact-page links, honoring `_blank` with `noopener noreferrer`.
- Proves behavior with a 267-line, 46-assertion harness covering field-backed values, fallbacks, malformed link data, fragment/empty URLs, target sanitization, and injection escaping.

### Visual Note (contract-conformant fallback, title case)
In `header-one.php` the old hardcoded label was `GET A FREE ESTIMATE` (all caps). The fallback title from the resolver contract is **"Get a Free Estimate"** (title case), matching the header-two label and the ACF default. So when the CTA field is empty, the header-one button now shows "Get a Free Estimate" instead of "GET A FREE ESTIMATE". **No CSS change** — the button keeps `rms-header__cta-btn`; only the text casing differs. This is contract-conformant, not a styling regression.

## Changes

| File | Change |
|------|--------|
| `inc/acf-theme-options.php` | Add `rms_get_header_primary_cta()` (+52 lines): normalized link contract with fallbacks, `_blank`/`_self` target restriction, fragment/empty-URL handling |
| `templates/header-one.php` | Replace hardcoded `rms_get_contact_page_url()` CTA with `rms_get_header_primary_cta()`; render title + target + conditional `rel` |
| `templates/header-two.php` | Same rewire for the header-two CTA button |
| `tests/header-primary-cta-behavior-harness.php` | New 267-line harness: 46 assertions — resolver contract, fallbacks, sanitization, template rendering, escaping |

## Test Plan
- [x] Behavior harness without errors: `php tests/header-primary-cta-behavior-harness.php` — 46/46 PASS at HEAD `0493ecc`
- [x] Aggregate suite across the stack: 61/61 PASS (schema 7 + behavior 46 + regression 8)
- [x] Pre-existing #55 regression suite unaffected: 40/40 PASS
- [x] ACF inactive case: 11/11 PASS (resolver falls back cleanly without ACF)
- [x] PHP lint on changed files (`php -l`): clean
- [x] Diff check: 332 authored lines (328 insertions / 4 deletions) — within the 400-line review budget; no `.codegraph/` or `.playwright-mcp/` paths

## Contributor Checklist
- [x] Linked an approved issue (#56, `status:approved`)
- [x] Added exactly one type:* label (type:feature)
- [x] Ran shellcheck on modified scripts: N/A — no shell scripts in this PR
- [x] Skills tested in at least one agent: N/A
- [x] Docs updated if behavior changed: N/A — behavior covered by harness assertions
- [x] Conventional commit format (`feat(header): render global primary CTA`)
- [x] No `Co-Authored-By` trailers

## Chain Context

This is **PR B (2 of 3)** — the behavior slice of the #56 stack. It builds on PR A's schema branch and is the base for PR C's regression coverage.

⚠️ **DO NOT MERGE until its child (PR C) is integrated into this branch.** Required merge order: **C → B → A** (details below).

| Field | Value |
|-------|-------|
| Chain | #56 header primary CTA (stacked PRs to main) |
| Position | 2 of 3 (behavior) |
| Head | `feat/header-primary-cta` @ `0493ecc` |
| Base | `feat/header-primary-cta-schema` @ `1ed2340` (PR A) |
| Depends on | PR A `feat(header): add primary CTA field contract` — the `company_header_primary_cta` field and shared test stub |
| Follow-up | PR C `test(header): guard primary CTA regressions` (coverage, targets this branch) |
| Review budget | 332 authored lines / 400 |
| Starts at | PR A's schema branch — field contract in place |
| Ends with | Both header variants render the global Primary CTA through the resolver contract, guarded by 46 passing behavior assertions |
| Rollback boundary | Single commit `0493ecc`. Reverting it restores the hardcoded contact-page CTA links; the schema field from PR A becomes inert (no consumer), so rollback is safe and contained |
| Out of scope | Regression harness (PR C), schema changes (PR A); no CSS change; `.codegraph/` and `.playwright-mcp/` excluded; no Local sites / databases / browsers accessed |

### Chain Overview

```text
main
 └── A feat(header): add primary CTA field contract      (merges LAST, closes #56)
      └── 📍 B feat(header): render global primary CTA    <-- this PR (merges second)
           └── C test(header): guard primary CTA regressions (merges FIRST)
```

### Mandatory Merge Order — C → B → A

1. **Merge C FIRST** (test → this branch). The regression harness joins this behavior branch, locking the renderer behind 8 regression assertions before anything lands.
2. **Merge B SECOND** (this branch → schema branch). The renderer plus the merged regression harness join PR A's schema branch.
3. **Merge A LAST** (schema → main). Only A's merge carries the completed feature to main.
4. **Issue #56 closes only when A merges into main.** B and C target non-default branches, so their `Closes #56` lines do not fire there; the issue closes with A's merge.

### Scope
- Includes: resolver function, header template rewiring, behavior harness
- Excludes: field schema (PR A), regression harness (PR C), CSS

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit