### PR TITLE
fix(wizard): define landing keyword intent contract

### DIFF
--- a/inc/wizard/class-ai-content-harness.php
+++ b/inc/wizard/class-ai-content-harness.php
@@ -614,12 +614,115 @@ PROMPT;
 	}
 
 	/**
+	 * Landing keyword prompt block; keywords are interpolated directly (never
+	 * through a placeholder token) so nested tokens cannot survive the template pass.
+	 *
+	 * @param array<string,mixed> $keywords   Raw keyword payload.
+	 * @param string              $occurrence Deterministic placement scope: hero, first_seo, later_seo, or ''.
+	 *
+	 * @return string
+	 */
+	public function keyword_block( array $keywords, string $occurrence = '' ): string {
+		$normalized = $this->normalize_keywords( $keywords );
+		$primary    = $normalized['primary_keyword'];
+		$secondary  = implode( ', ', $normalized['subkeywords'] );
+
+		$placement = "- Naturally incorporate the primary keyword in headlines and body copy where it fits.\n";
+
+		if ( 'hero' === $occurrence ) {
+			$placement = "- Place the exact primary keyword once in hero_title.\n";
+		} elseif ( 'first_seo' === $occurrence ) {
+			$placement = "- Place the exact primary keyword in seo_headline or within the first 100 words of seo_text.\n";
+		} elseif ( 'later_seo' === $occurrence ) {
+			$placement = "- Do not force the primary keyword here; write naturally without repeating it.\n";
+		}
+
+		return "KEYWORD CONTEXT (mandatory for this section only):\n"
+			. '- Primary keyword: ' . ( '' !== $primary ? $primary : '(none provided)' ) . "\n"
+			. '- Subkeywords: ' . ( '' !== $secondary ? $secondary : '(none)' ) . "\n"
+			. $placement
+			. "- Use subkeywords sparingly and only when natural. Do not keyword-stuff.\n"
+			. '- Do not invent services, locations, or proof to force keyword usage.';
+	}
+
+	/**
+	 * Deterministic landing keyword placement check.
+	 *
+	 * hero: hero_title contains the exact primary keyword exactly once.
+	 * first_seo: seo_headline contains it, or the first 100 words of seo_text do.
+	 * later_seo, empty occurrence, or empty keyword: nothing is forced, so true.
+	 *
+	 * @param string              $layout     Layout key.
+	 * @param array<string,mixed> $payload    Decoded section payload.
+	 * @param array<string,mixed> $keywords   Keyword payload (normalized internally).
+	 * @param string              $occurrence Placement scope.
+	 *
+	 * @return bool True when the required placement is satisfied.
+	 */
+	public function check_landing_keyword_fidelity( string $layout, array $payload, array $keywords, string $occurrence ): bool {
+		$occurrence = in_array( $occurrence, [ 'hero', 'first_seo', 'later_seo' ], true ) ? $occurrence : '';
+
+		if ( '' === $occurrence || 'later_seo' === $occurrence ) {
+			return true;
+		}
+
+		$normalized = $this->normalize_keywords( $keywords );
+		$needle     = $this->keyword_identity( $this->collapse_keyword( (string) ( $normalized['primary_keyword'] ?? '' ) ) );
+
+		if ( '' === $needle ) {
+			return true;
+		}
+
+		if ( 'hero' === $occurrence ) {
+			if ( 'hero' !== $layout ) {
+				return true;
+			}
+
+			return 1 === $this->count_keyword_occurrences( (string) ( $payload['hero_title'] ?? '' ), $needle );
+		}
+
+		if ( 'seo-content' !== $layout ) {
+			return true;
+		}
+
+		if ( $this->count_keyword_occurrences( (string) ( $payload['seo_headline'] ?? '' ), $needle ) >= 1 ) {
+			return true;
+		}
+
+		return $this->count_keyword_occurrences( $this->first_words( (string) ( $payload['seo_text'] ?? '' ), 100 ), $needle ) >= 1;
+	}
+
+	/**
+	 * Exact-phrase occurrence count bounded by Unicode letter/number edges: the
+	 * keyword never matches inside a larger word, but punctuation-separated
+	 * occurrences count. Fails closed to 0 when the subject is not valid UTF-8.
+	 */
+	private function count_keyword_occurrences( string $haystack, string $needle ): int {
+		if ( '' === $needle ) {
+			return 0;
+		}
+
+		$haystack = $this->keyword_identity( $this->collapse_keyword( $haystack ) );
+		$matches  = preg_match_all( '/(?<![\\p{L}\\p{N}])' . preg_quote( $needle, '/' ) . '(?![\\p{L}\\p{N}])/u', $haystack );
+
+		return is_int( $matches ) ? $matches : 0;
+	}
+
+	private function first_words( string $text, int $limit ): string {
+		$words = preg_split( '/\s+/u', trim( (string) preg_replace( '/<[^>]+>/', ' ', $text ) ), -1, PREG_SPLIT_NO_EMPTY );
+
+		return is_array( $words ) ? implode( ' ', array_slice( $words, 0, max( 0, $limit ) ) ) : '';
+	}
+
+	/**
 	 * @param array<string,mixed> $client_context Approved client context.
 	 * @param array<string,mixed> $keywords       Optional keywords. Landing uses PAGE_LANDING + keyword layouts.
 	 *                                            Homepage injects only when PAGE_HOME, layout is keyword-eligible,
 	 *                                            and a primary keyword is present.
+	 * @param string              $occurrence     Landing deterministic placement scope: hero, first_seo,
+	 *                                            later_seo, or ''.
 	 */
-	public function get_layer3( string $layout, int $item_count, array $client_context, string $page_type = self::PAGE_HOME, array $keywords = [] ): string {
+	public function get_layer3( string $layout, int $item_count, array $client_context, string $page_type = self::PAGE_HOME, array $keywords = [], string $occurrence = '' ): string {
 		$layout        = $this->normalize_layout_key( $layout );
 		$fillable      = $this->get_fillable_fields( $layout );
 		$blocked       = $this->get_blocked_fields( $layout );
@@ -639,12 +742,7 @@ PROMPT;
 			$normalized    = $this->normalize_keywords( $keywords );
 			$primary       = $normalized['primary_keyword'];
 			$subkeywords   = implode( ', ', $normalized['subkeywords'] );
-			$keyword_block = "\n\nKEYWORD CONTEXT (mandatory for this section only):\n"
-				. '- Primary keyword: ' . ( '' !== $primary ? $primary : '(none provided)' ) . "\n"
-				. '- Subkeywords: ' . ( '' !== $subkeywords ? $subkeywords : '(none)' ) . "\n"
-				. "- Naturally incorporate the primary keyword in headlines and body copy where it fits.\n"
-				. "- Use subkeywords sparingly and only when natural. Do not keyword-stuff.\n"
-				. "- Do not invent services, locations, or proof to force keyword usage.";
+				$keyword_block = "\n\n" . $this->keyword_block( $keywords, $occurrence );
 		} elseif ( $inject_home ) {
 			$normalized    = $home_keywords;
 			$primary       = $normalized['primary_keyword'];

--- a/inc/wizard/class-ai-content-reviewer.php
+++ b/inc/wizard/class-ai-content-reviewer.php
@@ -86,8 +86,18 @@ final class AI_Content_Reviewer {
 		],
 	];
 
+	/**
+	 * Occurrence-specific landing placement rules; '' is the neutral no-scope rule.
+	 */
+	private const LANDING_OCCURRENCE_RULES = [
+		'hero'      => 'hero_title must contain the exact primary keyword once.',
+		'first_seo' => 'the first SEO section must contain it in seo_headline or within the first 100 words of seo_text.',
+		'later_seo' => 'later SEO sections must not force or repeat the primary keyword; write naturally.',
+		''          => 'no keyword placement is enforced for this section.',
+	];
+
 	private const PROMPT_CRITIQUE = <<<'PROMPT'
-You are the quality reviewer for one WordPress wizard home-page section.
+You are the quality reviewer for one WordPress wizard section.
 
 Evaluate the decoded JSON against these primary quality sources only:
 - Google Helpful Content: people-first, useful, original content.
@@ -144,11 +154,20 @@ PROMPT;
 			}
 
 			$diagnoses = $this->diagnose( $critique );
+
+			// Deterministic fidelity gate feeds intent_mismatch even when the model critique misses it.
+			$keyword_status = $this->landing_keyword_status( $layout, $current, $ai_config );
+
+			if ( 'missing_required_occurrence' === $keyword_status && ! in_array( 'intent_mismatch', $diagnoses, true ) ) {
+				$diagnoses[] = 'intent_mismatch';
+			}
+
 			$history[] = [
 				'pass'      => $pass,
 				'verdict'   => (string) ( $critique['verdict'] ?? 'fail' ),
 				'diagnoses' => $diagnoses,
 				'fields'    => is_array( $critique['fields'] ?? null ) ? $critique['fields'] : [],
+				'keyword_fidelity' => $keyword_status,
 			];
 
 			if ( [] === $diagnoses ) {
@@ -291,6 +310,11 @@ PROMPT;
 
 			if ( [] !== $keyword_intent ) {
 				$data['declared_keyword_intent'] = $keyword_intent;
+
+				// Preservation directives only apply where an occurrence is actually forced.
+				if ( AI_Content_Harness::PAGE_LANDING === (string) ( $keyword_intent['page_type'] ?? '' ) && in_array( (string) ( $keyword_intent['occurrence'] ?? '' ), [ 'hero', 'first_seo' ], true ) ) {
+					$data['keyword_preservation_directive'] = 'Preserve all valid existing copy. When a required keyword occurrence is missing, insert it naturally into the required field without removing supportable content or inventing facts.';
+				}
 			}
 
 		$json = \wp_json_encode( $data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
@@ -315,12 +339,46 @@ PROMPT;
 				? $raw['secondary_keywords']
 				: ( is_array( $raw['subkeywords'] ?? null ) ? $raw['subkeywords'] : [] );
 
-			return [
+			$is_landing = AI_Content_Harness::PAGE_LANDING === (string) ( $raw['page_type'] ?? '' );
+
+			$intent = [
 				'primary_keyword'     => $primary,
 				'secondary_keywords'  => array_values( array_map( 'strval', $secondary ) ),
-				'role'                => 'Editorial search intent for this homepage section only. Not evidence. Distinguish natural target-keyword usage from keyword stuffing and flag intent mismatch. Do not invent services, locations, credentials, guarantees, statistics, or business facts.',
+				'role'                => $is_landing
+					? 'Declared landing keyword intent for this section. ' . ( self::LANDING_OCCURRENCE_RULES[ (string) ( $raw['occurrence'] ?? '' ) ] ?? self::LANDING_OCCURRENCE_RULES[''] ) . ' One or two natural exact occurrences are not keyword stuffing. Flag intent_mismatch when a required occurrence is missing and keyword_stuffing only for clearly forced repetition. Do not invent services, locations, credentials, guarantees, statistics, or business facts.'
+					: 'Editorial search intent for this homepage section only. Not evidence. Distinguish natural target-keyword usage from keyword stuffing and flag intent mismatch. Do not invent services, locations, credentials, guarantees, statistics, or business facts.',
 			];
+
+			if ( $is_landing ) {
+				$intent['page_type']  = AI_Content_Harness::PAGE_LANDING;
+				$intent['occurrence'] = (string) ( $raw['occurrence'] ?? '' );
+			}
+
+			return $intent;
 		}
+
+	/**
+	 * Deterministic landing keyword fidelity status for the current payload:
+	 * 'n/a' when no landing keyword placement applies, 'ok', or 'missing_required_occurrence'.
+	 */
+	private function landing_keyword_status( string $layout, array $payload, array $ai_config ): string {
+		$raw       = is_array( $ai_config['keyword_intent'] ?? null ) ? $ai_config['keyword_intent'] : [];
+		$page_type = (string) ( $raw['page_type'] ?? '' );
+
+		if ( AI_Content_Harness::PAGE_LANDING !== $page_type ) {
+			return 'n/a';
+		}
+
+		$occurrence = (string) ( $raw['occurrence'] ?? '' );
+
+		if ( '' === $occurrence || 'later_seo' === $occurrence ) {
+			return 'n/a';
+		}
+
+		return $this->harness->check_landing_keyword_fidelity( $layout, $payload, $raw, $occurrence )
+			? 'ok'
+			: 'missing_required_occurrence';
+	}
 
 		private function decode_json( string $content ): array {
 		$content = trim( preg_replace( '/^```(?:json)?|```$/m', '', $content ) ?? $content );

--- a/tests/wizard-landing-lifecycle-protection-harness.php
+++ b/tests/wizard-landing-lifecycle-protection-harness.php
@@ -17,6 +17,8 @@
 
 require_once __DIR__ . '/wizard-landing-phase4-bootstrap.php';
 
+use Inc\Wizard\AI_Content_Harness;
+use Inc\Wizard\AI_Content_Reviewer;
 use Inc\Wizard\Canonical_Section_Store;
 use Inc\Wizard\Logger;
 use Inc\Wizard\Step_Generate_Pages;
@@ -319,6 +321,108 @@ function rms_run_landing_lifecycle_protection_tests(): int {
 	echo "PASS generate-pages-landing-deletion-guard\n";
 	++$passed;
 
+	// =========================================================================
+	// 7. Keyword fidelity: deterministic placement rules per occurrence scope
+	// =========================================================================
+
+	rms_lpb_reset();
+	$fidelity_harness = new AI_Content_Harness();
+	$kw               = array( 'primary_keyword' => 'Concrete   Repair', 'subkeywords' => array( 'driveway' ) );
+
+	// hero: exactly one normalized occurrence in hero_title.
+	rms_lpb_assert( true === $fidelity_harness->check_landing_keyword_fidelity( 'hero', array( 'hero_title' => 'Expert concrete repair that lasts' ), $kw, 'hero' ), 'hero fidelity matches case-insensitively' );
+	rms_lpb_assert( true === $fidelity_harness->check_landing_keyword_fidelity( 'hero', array( 'hero_title' => 'Expert  Concrete	Repair today' ), $kw, 'hero' ), 'hero fidelity collapses whitespace and case' );
+	rms_lpb_assert( false === $fidelity_harness->check_landing_keyword_fidelity( 'hero', array( 'hero_title' => 'Expert patios that last' ), $kw, 'hero' ), 'hero fidelity fails when the keyword is missing' );
+	rms_lpb_assert( false === $fidelity_harness->check_landing_keyword_fidelity( 'hero', array( 'hero_title' => 'Concrete Repair and Concrete Repair' ), $kw, 'hero' ), 'hero fidelity requires exactly one occurrence' );
+	rms_lpb_assert( false === $fidelity_harness->check_landing_keyword_fidelity( 'hero', array(), $kw, 'hero' ), 'hero fidelity fails on missing hero_title' );
+
+	// Exact-phrase edges: embedded words and joined variants never count; the exact
+	// phrase bounded by punctuation or normalized in case/whitespace always does.
+	rms_lpb_assert( false === $fidelity_harness->check_landing_keyword_fidelity( 'hero', array( 'hero_title' => 'Expert concrete repairman at work' ), $kw, 'hero' ), 'hero fidelity rejects the keyword embedded in a larger word' );
+	rms_lpb_assert( true === $fidelity_harness->check_landing_keyword_fidelity( 'hero', array( 'hero_title' => 'Trusted "Concrete   Repair", done right' ), $kw, 'hero' ), 'hero fidelity counts the punctuation-bounded exact phrase' );
+	rms_lpb_assert( true === $fidelity_harness->check_landing_keyword_fidelity( 'hero', array( 'hero_title' => 'CONCRETE REPAIR experts on call' ), $kw, 'hero' ), 'hero fidelity counts the case-normalized exact phrase' );
+
+	// first_seo: seo_headline, or within the first 100 words of seo_text.
+	rms_lpb_assert( true === $fidelity_harness->check_landing_keyword_fidelity( 'seo-content', array( 'seo_headline' => 'concrete repair done right', 'seo_text' => 'no keyword here' ), $kw, 'first_seo' ), 'first_seo fidelity passes via headline' );
+	$later_fill = implode( ' ', array_fill( 0, 110, 'filler' ) );
+	rms_lpb_assert( false === $fidelity_harness->check_landing_keyword_fidelity( 'seo-content', array( 'seo_headline' => 'No keyword', 'seo_text' => $later_fill . ' concrete repair' ), $kw, 'first_seo' ), 'first_seo fails when the keyword only appears after 100 words' );
+	$early_body = '<p>we do concrete repair work daily</p> ' . $later_fill;
+	rms_lpb_assert( true === $fidelity_harness->check_landing_keyword_fidelity( 'seo-content', array( 'seo_headline' => 'No keyword', 'seo_text' => $early_body ), $kw, 'first_seo' ), 'first_seo passes when the keyword is within the first 100 body words' );
+	rms_lpb_assert( false === $fidelity_harness->check_landing_keyword_fidelity( 'seo-content', array( 'seo_headline' => 'No keyword', 'seo_text' => 'nothing useful' ), $kw, 'first_seo' ), 'first_seo fails without any occurrence' );
+
+	// later_seo and non-applicable scopes never gate.
+	rms_lpb_assert( true === $fidelity_harness->check_landing_keyword_fidelity( 'seo-content', array( 'seo_headline' => 'No keyword' ), $kw, 'later_seo' ), 'later_seo does not force repetition' );
+	rms_lpb_assert( true === $fidelity_harness->check_landing_keyword_fidelity( 'hero', array( 'hero_title' => 'Neutral' ), $kw, '' ), 'no occurrence scope imposes no gate' );
+	rms_lpb_assert( true === $fidelity_harness->check_landing_keyword_fidelity( 'hero', array( 'hero_title' => 'Neutral' ), array( 'primary_keyword' => '   ' ), 'hero' ), 'empty keyword imposes no gate' );
+
+	// Occurrence-aware prompt contract.
+	$hero_prompt  = $fidelity_harness->get_layer3( 'hero', 1, array( 'company_name' => 'Acme' ), AI_Content_Harness::PAGE_LANDING, $kw, 'hero' );
+	$first_prompt = $fidelity_harness->get_layer3( 'seo-content', 1, array( 'company_name' => 'Acme' ), AI_Content_Harness::PAGE_LANDING, $kw, 'first_seo' );
+	$later_prompt = $fidelity_harness->get_layer3( 'seo-content', 1, array( 'company_name' => 'Acme' ), AI_Content_Harness::PAGE_LANDING, $kw, 'later_seo' );
+	rms_lpb_assert( false !== strpos( $hero_prompt, '- Place the exact primary keyword once in hero_title.' ), 'hero prompt carries the deterministic placement rule' );
+	rms_lpb_assert( false !== strpos( $first_prompt, '- Place the exact primary keyword in seo_headline or within the first 100 words of seo_text.' ), 'first SEO prompt carries the deterministic placement rule' );
+	rms_lpb_assert( false !== strpos( $later_prompt, '- Do not force the primary keyword here' ), 'later SEO prompt forbids forced repetition' );
+	rms_lpb_assert( false === strpos( $later_prompt, '- Place the exact primary keyword' ), 'later SEO prompt does not require placement' );
+
+	// Nested tokens cannot survive keyword_block interpolation.
+	$token_kw     = array( 'primary_keyword' => '{{layout}} concrete repair', 'subkeywords' => array() );
+	$token_prompt = $fidelity_harness->get_layer3( 'hero', 1, array( 'company_name' => 'Acme' ), AI_Content_Harness::PAGE_LANDING, $token_kw, 'hero' );
+	rms_lpb_assert( false !== strpos( $token_prompt, '- Primary keyword: {{layout}} concrete repair' ), 'keyword containing token-like text stays verbatim' );
+	rms_lpb_assert( false === strpos( $token_prompt, '{{primary_keyword}}' ), 'no unresolved primary keyword token survives' );
+	rms_lpb_assert( true === $fidelity_harness->check_landing_keyword_fidelity( 'hero', array( 'hero_title' => 'Expert {{LAYOUT}} Concrete Repair today' ), $token_kw, 'hero' ), 'token-like keyword fidelity matches normalized text' );
+	echo "PASS keyword-fidelity-deterministic-placement\n";
+	++$passed;
+
+	// =========================================================================
+	// 8. Reviewer keyword context: landing authorization + preservation directive
+	// =========================================================================
+
+	rms_lpb_reset();
+	$reviewer        = new AI_Content_Reviewer();
+	$prompt_method   = new ReflectionMethod( AI_Content_Reviewer::class, 'json_prompt' );
+	$prompt_method->setAccessible( true );
+
+	$landing_intent_config = array(
+		'client_context' => array( 'company_name' => 'Acme' ),
+		'keyword_intent' => array(
+			'primary_keyword' => 'concrete repair',
+			'subkeywords'     => array( 'driveway' ),
+			'page_type'       => AI_Content_Harness::PAGE_LANDING,
+			'occurrence'      => 'hero',
+		),
+	);
+	$landing_rewrite_json = $prompt_method->invoke(
+		$reviewer,
+		'Rewrite only the diagnosed failures using these directives.',
+		'hero',
+		array( 'hero_title' => 'Headline' ),
+		array(),
+		$landing_intent_config,
+		array( 'intent_mismatch' => 'Realign the copy to the required keyword placement.' )
+	);
+	$landing_rewrite_data = json_decode( $landing_rewrite_json, true );
+	rms_lpb_assert( is_array( $landing_rewrite_data ) && isset( $landing_rewrite_data['declared_keyword_intent'] ), 'landing rewrite prompt carries declared keyword intent' );
+	rms_lpb_assert( 'PAGE_LANDING' === ( $landing_rewrite_data['declared_keyword_intent']['page_type'] ?? '' ), 'landing keyword intent declares the page type' );
+	rms_lpb_assert( 'hero' === ( $landing_rewrite_data['declared_keyword_intent']['occurrence'] ?? '' ), 'landing keyword intent declares the occurrence' );
+	rms_lpb_assert( false !== strpos( (string) ( $landing_rewrite_data['declared_keyword_intent']['role'] ?? '' ), 'One or two natural exact occurrences are not keyword stuffing' ), 'landing role authorizes 1-2 natural occurrences' );
+	rms_lpb_assert( false !== strpos( (string) ( $landing_rewrite_data['declared_keyword_intent']['role'] ?? '' ), 'intent_mismatch' ), 'landing role names intent_mismatch for missing required occurrence' );
+	rms_lpb_assert( false !== strpos( (string) ( $landing_rewrite_data['keyword_preservation_directive'] ?? '' ), 'Preserve all valid existing copy' ), 'landing rewrite prompt carries the preservation directive' );
+
+	$home_intent_config = array(
+		'client_context' => array( 'company_name' => 'Acme' ),
+		'keyword_intent' => array( 'primary_keyword' => 'deck builder', 'subkeywords' => array() ),
+	);
+	$home_json = $prompt_method->invoke( $reviewer, 'Review this section and diagnose failures before any rewrite.', 'hero', array( 'hero_title' => 'Headline' ), array(), $home_intent_config, array() );
+	$home_data = json_decode( $home_json, true );
+	rms_lpb_assert( false !== strpos( (string) ( $home_data['declared_keyword_intent']['role'] ?? '' ), 'Not evidence' ), 'home keyword role keeps non-evidence language' );
+	rms_lpb_assert( ! isset( $home_data['declared_keyword_intent']['page_type'] ), 'home keyword intent does not gain a landing page type' );
+	rms_lpb_assert( ! isset( $home_data['keyword_preservation_directive'] ), 'home prompts do not gain the landing preservation directive' );
+
+	$neutral_json = $prompt_method->invoke( $reviewer, 'Review this section and diagnose failures before any rewrite.', 'about-us', array( 'about_headline' => 'Story' ), array(), array( 'client_context' => array( 'company_name' => 'Acme' ) ), array() );
+	$neutral_data = json_decode( $neutral_json, true );
+	rms_lpb_assert( ! isset( $neutral_data['declared_keyword_intent'] ), 'neutral sections stay keyword-free' );
+	echo "PASS reviewer-keyword-context-authorization\n";
+	++$passed;
 	return $passed;
 }
 

--- a/tests/wizard-landing-phase4-stubs.php
+++ b/tests/wizard-landing-phase4-stubs.php
@@ -327,6 +327,77 @@ if ( ! function_exists( 'get_sub_field' ) ) { function get_sub_field( $s = null 
 if ( ! function_exists( 'get_template_part' ) ) { function get_template_part( $slug, $name = null ) { unset( $name ); $GLOBALS['_template_parts'][] = (string) $slug; } }
 if ( ! function_exists( 'locate_template' ) ) { function locate_template( $t, $l = false, $r = true ) { unset( $l, $r ); return ''; } }
 
+/**
+ * Parse the primary keyword out of a landing KEYWORD CONTEXT generation prompt.
+ *
+ * Returns '' for neutral prompts, homepage KEYWORD INTENT prompts, later SEO
+ * blocks (no forced repetition), and empty keyword placeholders.
+ */
+function rms_lpb_parse_landing_keyword( string $prompt ): string {
+	if ( false === strpos( $prompt, 'KEYWORD CONTEXT (mandatory' ) || false !== strpos( $prompt, '- Do not force the primary keyword here' ) ) {
+		return '';
+	}
+
+	if ( preg_match( '/- Primary keyword: ([^\r\n]+)/', $prompt, $m ) ) {
+		$keyword = trim( (string) $m[1] );
+
+		return in_array( $keyword, array( '(none provided)', '(none)' ), true ) ? '' : $keyword;
+	}
+
+	return '';
+}
+
+/**
+ * Parse the declared primary keyword out of a landing reviewer rewrite JSON prompt.
+ */
+function rms_lpb_parse_declared_keyword( string $prompt ): string {
+	if ( false === strpos( $prompt, '"page_type":"PAGE_LANDING"' ) || ! preg_match( '/"primary_keyword":"([^"]+)"/', $prompt, $m ) ) {
+		return '';
+	}
+
+	return (string) $m[1];
+}
+
+/**
+ * Layout-scoped fake payload; $keyword is echoed into the keyword-required fields.
+ */
+function rms_lpb_fake_layout_payload( string $layout, string $keyword ): array {
+	if ( 'hero' === $layout ) {
+		return array( 'hero_title' => '' !== $keyword ? 'Expert ' . $keyword . ' That Lasts' : 'Hero Headline', 'hero_description' => 'Hero body copy for the landing hero.' );
+	}
+
+	if ( 'seo-content' === $layout ) {
+		return array( 'seo_headline' => '' !== $keyword ? $keyword . ' Done Right' : 'SEO Headline', 'seo_subheadline' => 'SEO subheadline', 'seo_text' => 'SEO body copy.' );
+	}
+
+	return array( 'headline' => 'Section Headline', 'subheadline' => 'Section subheadline', 'text' => 'Section body copy.' );
+}
+
+/**
+ * Deterministic fake provider response.
+ *
+ * The test-only model sentinel 'test-keyword-miss' persistently omits the primary
+ * keyword from generation AND rewrite stages. Normal models echo the parsed landing
+ * keyword into hero_title / seo_headline for hero and first SEO generation prompts;
+ * later SEO blocks and neutral prompts stay neutral.
+ */
+function rms_lpb_fake_ai_content( string $model, string $prompt, array $context ): array {
+	$static = array( 'hero_title' => 'Hero Headline', 'hero_description' => 'Hero body copy for the landing hero.', 'seo_headline' => 'SEO Headline', 'seo_subheadline' => 'SEO subheadline', 'seo_text' => 'SEO body copy.', 'headline' => 'Section Headline', 'subheadline' => 'Section subheadline', 'text' => 'Section body copy.', 'verdict' => 'pass', 'diagnoses' => array() );
+
+	if ( 'test-keyword-miss' === $model ) {
+		return $static;
+	}
+
+	if ( 'rewrite' === (string) ( $context['review_stage'] ?? '' ) ) {
+		// Rewrites must return only layout-allowed keys to survive reviewer guardrails.
+		return rms_lpb_fake_layout_payload( (string) ( $context['section_key'] ?? '' ), rms_lpb_parse_declared_keyword( $prompt ) );
+	}
+
+	$keyword = rms_lpb_parse_landing_keyword( $prompt );
+
+	return '' === $keyword ? $static : rms_lpb_fake_layout_payload( (string) ( $context['section_key'] ?? '' ), $keyword );
+}
+
 // AI provider registry stubs.
 if ( ! class_exists( 'Inc\Wizard\AI_Credential_Store' ) ) {
 	eval( 'namespace Inc\Wizard; class AI_Credential_Store { public static function has($p){ return "test" === $p; } public static function save($p,$k){ return true; } public static function status($p){ return ["has_key"=>true,"status"=>"saved"]; } public static function mask_status($p){ return "saved"; } public static function normalize_api_key($k){ return (string) $k; } }' );
@@ -340,7 +411,7 @@ if ( ! class_exists( 'Inc\Wizard\AI_Provider_Registry' ) ) {
 	eval(
 		'namespace Inc\Wizard; class AI_Provider_Registry { ' .
 		'public static function make_provider($p,$k=""){ return new class extends AI_Provider { ' .
-		'public function generate($model, $prompt, $context = [], $system = "") { $GLOBALS["_ai_prompt_log"][] = ["model"=>$model,"prompt"=>$prompt,"context"=>$context,"system"=>$system]; if ( ! empty( $GLOBALS["_ai_fail"] ) ) { return ["success"=>false,"content"=>"","error"=>"HTTP 500 provider error"]; } return ["success"=>true,"content"=>json_encode(["hero_title"=>"Hero Headline","hero_description"=>"Hero body copy for the landing hero.","seo_headline"=>"SEO Headline","seo_subheadline"=>"SEO subheadline","seo_text"=>"SEO body copy.","headline"=>"Section Headline","subheadline"=>"Section subheadline","text"=>"Section body copy.","verdict"=>"pass","diagnoses"=>[]])]; } }; } ' .
+		'public function generate($model, $prompt, $context = [], $system = "") { $GLOBALS["_ai_prompt_log"][] = ["model"=>$model,"prompt"=>$prompt,"context"=>$context,"system"=>$system]; if ( ! empty( $GLOBALS["_ai_fail"] ) ) { return ["success"=>false,"content"=>"","error"=>"HTTP 500 provider error"]; } return ["success"=>true,"content"=>json_encode(rms_lpb_fake_ai_content((string) $model, (string) $prompt, is_array($context) ? $context : []))]; } }; } ' .
 		'public static function provider_exists($p){ return "test" === $p; } ' .
 		'public static function default_provider(){ return "test"; } ' .
 		'public static function get_provider_label($p){ return "Test"; } ' .


### PR DESCRIPTION
Part of #104 (first of two stacked PRs; PR 2 will close the issue after the enforcement slice merges).

## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling

## Summary

- Define occurrence-aware keyword placement for landing hero and SEO sections.
- Make AI review prompts understand declared landing keyword intent without treating natural occurrences as unsupported claims or stuffing.
- Add deterministic exact-phrase matching and a representative keyword-aware test provider.

## Changes Table

| File | Change |
|------|--------|
| `inc/wizard/class-ai-content-harness.php` | Add occurrence-aware keyword prompts, direct interpolation, and deterministic Unicode-boundary fidelity checks |
| `inc/wizard/class-ai-content-reviewer.php` | Add page-aware keyword intent, occurrence-specific rules, and rewrite preservation directives |
| `tests/wizard-landing-phase4-stubs.php` | Make the shared provider honor `KEYWORD CONTEXT`; add a test-only model sentinel for omission |
| `tests/wizard-landing-lifecycle-protection-harness.php` | Prove placement, exact-phrase boundaries, interpolation, and reviewer context |

## Test Plan

- [x] `php tests/wizard-landing-lifecycle-protection-harness.php` — 8/8 scenarios on this isolated slice
- [x] `php tests/wizard-landing-identity-canonical-harness.php` — 8/8
- [x] `php tests/wizard-home-seo-targeting-harness.php` — 9/9
- [x] PHP lint passes on all four touched files
- [x] `git diff --cached --check` clean before commit
- [ ] Live provider behavior is verified in PR 2 with the builder enforcement path

## Contributor Checklist

- [x] Linked approved issue #104 (`status:approved`)
- [x] Exactly one `type:*` label (`type:bug`)
- [x] Relevant automated tests pass
- [x] Documentation updated if behavior changed (N/A — internal prompt/runtime contract)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Chain Context

```text
main
  └── PR 1 📍 fix/landing-keyword-intent
        └── PR 2 fix/landing-keyword-enforcement (Closes #104)
```

**Scope:** deterministic keyword contract, reviewer context, and direct contract tests.

**Out of scope:** builder fail-closed enforcement, existing-content preservation, Yoast focus keyphrase persistence, and end-to-end omission tests; those belong to PR 2.

**Dependency:** PR 2 targets this branch and must be retargeted to `main` after PR 1 merges.

**Changed lines:** 353 (342 additions + 11 deletions) — within the 400-line review budget.

**Rollback:** revert commit `a4b4e2c`; no data migration or persistence behavior is introduced by this slice.
