### PR TITLE
fix(wizard): enforce landing keyword fidelity

### DIFF
--- a/inc/wizard/class-step-landing-page-builder.php
+++ b/inc/wizard/class-step-landing-page-builder.php
@@ -1305,6 +1305,7 @@ class Step_Landing_Page_Builder {
 		$local_priors = $prior_payloads;
 		$section_rows = is_array( $row['sections'] ?? null ) ? $row['sections'] : [];
 		$existing_id  = (int) $row['id'];
+		$seo_sections_seen = 0;
 
 		foreach ( $section_rows as $section_row ) {
 			$layout   = $this->normalize_layout( (string) ( $section_row['layout'] ?? '' ) );
@@ -1319,6 +1320,15 @@ class Step_Landing_Page_Builder {
 			$section_context['layout']  = $layout;
 
 			if ( $this->harness->is_keyword_layout( $layout ) ) {
+				// Deterministic placement scope: hero, first SEO block, or later SEO blocks.
+				$occurrence = 'hero' === $layout
+					? 'hero'
+					: ( 0 === $seo_sections_seen ? 'first_seo' : 'later_seo' );
+
+				if ( 'seo-content' === $layout ) {
+					++$seo_sections_seen;
+				}
+
 				$copy = $this->generate_section_copy(
 					$layout,
 					$count,
@@ -1328,7 +1338,8 @@ class Step_Landing_Page_Builder {
 					$keywords,
 					$local_priors,
 					true,
-					$section_context
+					$section_context,
+					$occurrence
 				);
 
 				if ( \is_wp_error( $copy ) ) {
@@ -1892,12 +1903,30 @@ class Step_Landing_Page_Builder {
 		array $keywords,
 		array $prior_section_payloads,
 		bool $require_ai = false,
-		array $log_context = []
+		array $log_context = [],
+		string $occurrence = ''
 	) {
 		$fillable = $this->harness->get_fillable_fields( $section_key );
 
 		if ( [] === $fillable ) {
 			return [];
+		}
+
+		// Landing keyword sections carry page-scoped intent into review and the
+		// deterministic fidelity gate. Blank keywords stay untracked (neutral prompt).
+		$keyword_intent = [];
+
+		if ( AI_Content_Harness::PAGE_LANDING === $page_type && '' !== $occurrence ) {
+			$normalized_keywords = $this->harness->normalize_keywords( $keywords );
+
+			if ( '' !== $normalized_keywords['primary_keyword'] ) {
+				$keyword_intent = [
+					'primary_keyword' => $normalized_keywords['primary_keyword'],
+					'subkeywords'     => $normalized_keywords['subkeywords'],
+					'page_type'       => AI_Content_Harness::PAGE_LANDING,
+					'occurrence'      => $occurrence,
+				];
+			}
 		}
 
 		$context = array_merge(
@@ -1916,7 +1945,7 @@ class Step_Landing_Page_Builder {
 		$provider = \sanitize_key( (string) $ai_config['provider'] );
 		$model    = \sanitize_text_field( (string) $ai_config['model'] );
 		$system   = $this->harness->get_layer1() . "\n\n" . $this->harness->get_layer2( $page_type );
-		$prompt   = $this->harness->get_layer3( $section_key, $item_count, $client_context, $page_type, $keywords );
+		$prompt   = $this->harness->get_layer3( $section_key, $item_count, $client_context, $page_type, $keywords, $occurrence );
 		$result   = AI_Provider_Registry::make_provider( $provider )->generate(
 			$model,
 			$prompt,
@@ -1990,11 +2019,32 @@ class Step_Landing_Page_Builder {
 			$client_context,
 			$item_count,
 			$require_ai,
-			$context
+			$context,
+			$keyword_intent
 		);
 
 		if ( \is_wp_error( $reviewed ) ) {
 			return $reviewed;
+		}
+
+		// Deterministic keyword fidelity gate: never publish a landing section that
+		// is missing its required primary keyword occurrence after review.
+		if ( [] !== $keyword_intent && ! $this->harness->check_landing_keyword_fidelity( $section_key, $reviewed, $keywords, $occurrence ) ) {
+			$this->logger->log(
+				'error',
+				'Wizard landing keyword fidelity check failed after review.',
+				array_merge( $context, [ 'occurrence' => $occurrence ] )
+			);
+
+			return new \WP_Error(
+				'rms_wizard_landing_keyword_fidelity_failed',
+				sprintf(
+					/* translators: %s: layout key. */
+					\__( 'Keyword section "%s" is missing its required primary keyword occurrence. Landing was not published with deficient copy.', 'simple-rms-theme' ),
+					$section_key
+				),
+				array_merge( [ 'status' => 502, 'provider' => $provider ], $context )
+			);
 		}
 
 		$validated = $this->harness->validate_fields( $section_key, $reviewed );
@@ -2026,6 +2076,7 @@ class Step_Landing_Page_Builder {
 	 * @param array<string,mixed>            $ai_config
 	 * @param array<string,mixed>            $client_context
 	 * @param array<string,mixed>            $log_context
+	 * @param array<string,mixed>            $keyword_intent Landing keyword intent threaded into review config.
 	 *
 	 * @return array<string,mixed>|\WP_Error
 	 */
@@ -2037,7 +2088,8 @@ class Step_Landing_Page_Builder {
 		array $client_context,
 		int $item_count,
 		bool $require_ai = false,
-		array $log_context = []
+		array $log_context = [],
+		array $keyword_intent = []
 	) {
 		if ( ! $this->is_review_enabled() ) {
 			return $decoded;
@@ -2046,6 +2098,10 @@ class Step_Landing_Page_Builder {
 		$review_config                   = $ai_config;
 		$review_config['client_context'] = $client_context;
 		$review_config['item_count']     = $item_count;
+
+		if ( [] !== $keyword_intent ) {
+			$review_config['keyword_intent'] = $keyword_intent;
+		}
 
 		try {
 			$result = $this->reviewer()->review( $section_key, $decoded, $prior_section_payloads, $review_config );

--- a/inc/wizard/class-yoast-meta-writer.php
+++ b/inc/wizard/class-yoast-meta-writer.php
@@ -16,6 +16,7 @@ class Yoast_Meta_Writer {
 	public const TITLE_KEY       = '_yoast_wpseo_title';
 	public const DESCRIPTION_KEY = '_yoast_wpseo_metadesc';
 	public const NOINDEX_KEY     = '_yoast_wpseo_meta-robots-noindex';
+	public const FOCUS_KEYWORD_KEY = '_yoast_wpseo_focuskw';
 
 	/** Common SERP-friendly max length for SEO titles. */
 	public const TITLE_MAX_LENGTH = 60;
@@ -83,6 +84,8 @@ class Yoast_Meta_Writer {
 	/**
 	 * Write per-landing Yoast title/metadesc from keyword + type when Yoast is active.
 	 *
+	 * The focus keyword (`_yoast_wpseo_focuskw`) is Yoast storage and is written
+	 * regardless of plugin activation, mirroring the Ads noindex storage convention.
 	 * When Yoast is absent, skips title/metadesc writes and logs once per request.
 	 *
 	 * @param int    $post_id         Landing page ID.
@@ -101,6 +104,10 @@ class Yoast_Meta_Writer {
 		if ( $post_id <= 0 || '' === $primary_keyword ) {
 			return false;
 		}
+
+		// Focus keyword is Yoast storage: persist regardless of activation, like the
+		// Ads noindex key, so downstream SEO tooling can read it without Yoast active.
+		\update_post_meta( $post_id, self::FOCUS_KEYWORD_KEY, $primary_keyword );
 
 		if ( ! self::is_yoast_active() ) {
 			if ( ! self::$missing_yoast_logged ) {

--- a/tests/wizard-landing-lifecycle-protection-harness.php
+++ b/tests/wizard-landing-lifecycle-protection-harness.php
@@ -423,7 +423,274 @@ function rms_run_landing_lifecycle_protection_tests(): int {
 	rms_lpb_assert( ! isset( $neutral_data['declared_keyword_intent'] ), 'neutral sections stay keyword-free' );
 	echo "PASS reviewer-keyword-context-authorization\n";
 	++$passed;
+
+	// =========================================================================
+	// 9. Keyword generation fidelity: green path + focus keyword persistence
+	// =========================================================================
+
+	rms_lpb_reset();
+	rms_lpb_seed_page( 21, 'home', 'Home' );
+	$sm_green = rms_lpb_seed_landing_state();
+	$st_green                    = $sm_green->get_state();
+	$st_green['generated_pages'] = array( array( 'id' => 21, 'slug' => 'home', 'role' => 'home' ) );
+	$st_green['home_page_slug']  = 'home';
+	$sm_green->save_state( $st_green );
+	$GLOBALS['_yoast_active'] = true;
+	$green_builder = new Step_Landing_Page_Builder( new Logger(), $sm_green );
+	$green_res     = $green_builder->run(
+		array(
+			'landing_action' => 'start',
+			'landings'       => array( rms_lpb_landing_payload_item( 'lk_kw', 'keyword-page' ) ),
+		)
+	);
+	rms_lpb_assert( ! is_wp_error( $green_res ), 'keyword landing start succeeds' );
+	$safety = 0;
+	while ( true ) {
+		$run = $sm_green->get_state()['landing_run'];
+		if ( is_array( $run ) && in_array( (string) ( $run['status'] ?? '' ), array( 'completed', 'failed' ), true ) ) {
+			break;
+		}
+		if ( ++$safety > 8 ) {
+			break;
+		}
+		$green_builder->run( array( 'landing_action' => 'process' ) );
+	}
+	$green_pages = $sm_green->get_state()['landing_pages'];
+	rms_lpb_assert( 1 === count( $green_pages ), 'keyword landing completed' );
+	$green_post_id = (int) ( $green_pages[0]['id'] ?? 0 );
+	$green_sections = is_array( $GLOBALS['_post_meta'][ $green_post_id ]['page_sections'] ?? null ) ? $GLOBALS['_post_meta'][ $green_post_id ]['page_sections'] : array();
+	$green_hero = null;
+	$green_seo  = null;
+	foreach ( $green_sections as $row ) {
+		if ( ! is_array( $row ) ) {
+			continue;
+		}
+		if ( 'hero' === ( $row['acf_fc_layout'] ?? '' ) && null === $green_hero ) {
+			$green_hero = $row;
+		}
+		if ( 'seo-content' === ( $row['acf_fc_layout'] ?? '' ) && null === $green_seo ) {
+			$green_seo = $row;
+		}
+	}
+	rms_lpb_assert( is_array( $green_hero ) && false !== strpos( (string) ( $green_hero['hero_title'] ?? '' ), 'concrete repair' ), 'hero title contains the exact primary keyword' );
+	rms_lpb_assert( is_array( $green_seo ) && false !== strpos( (string) ( $green_seo['seo_headline'] ?? '' ), 'concrete repair' ), 'first SEO section contains the primary keyword' );
+	rms_lpb_assert( 'concrete repair' === (string) ( $GLOBALS['_post_meta'][ $green_post_id ][ Yoast_Meta_Writer::FOCUS_KEYWORD_KEY ] ?? '' ), 'sanitized focus keyword persisted on the landing' );
+
+	// Canonical/reusable generation stayed keyword-neutral: reviewer critique/rewrite
+	// prompts legitimately carry the generated payload, so scope the check to generation.
+	$green_neutral = true;
+	foreach ( $GLOBALS['_ai_prompt_log'] as $entry ) {
+		$entry_prompt = (string) ( $entry['prompt'] ?? '' );
+		$entry_ctx    = is_array( $entry['context'] ?? null ) ? $entry['context'] : array();
+		$is_review    = '' !== (string) ( $entry_ctx['review_stage'] ?? '' );
+
+		if ( ! $is_review && false === strpos( $entry_prompt, 'KEYWORD CONTEXT (mandatory' ) && false !== strpos( $entry_prompt, 'concrete repair' ) ) {
+			$green_neutral = false;
+			break;
+		}
+	}
+	rms_lpb_assert( $green_neutral, 'only landing keyword prompts contain the primary keyword' );
+	echo "PASS keyword-generation-fidelity-green\n";
+	++$passed;
+
+	// =========================================================================
+	// 10. Keyword omission: bounded rewrite then fail closed (new landing)
+	// =========================================================================
+
+	rms_lpb_reset();
+	rms_lpb_seed_page( 21, 'home', 'Home' );
+	$sm_miss = rms_lpb_seed_landing_state();
+	$st_miss                    = $sm_miss->get_state();
+	$st_miss['generated_pages'] = array( array( 'id' => 21, 'slug' => 'home', 'role' => 'home' ) );
+	$st_miss['home_page_slug']  = 'home';
+	$st_miss['ai_config']       = array( 'provider' => 'test', 'model' => 'test-keyword-miss', 'has_credentials' => true );
+	$sm_miss->save_state( $st_miss );
+	$miss_builder = new Step_Landing_Page_Builder( new Logger(), $sm_miss );
+	$miss_res     = $miss_builder->run(
+		array(
+			'landing_action' => 'start',
+			'landings'       => array( rms_lpb_landing_payload_item( 'lk_miss', 'miss-page' ) ),
+		)
+	);
+	// The single-item run may fail inside start or during the first process tick:
+	// either surface is acceptable, only the terminal state is asserted below.
+	$safety = 0;
+	while ( true ) {
+		$run = $sm_miss->get_state()['landing_run'];
+		if ( is_array( $run ) && in_array( (string) ( $run['status'] ?? '' ), array( 'completed', 'failed' ), true ) ) {
+			break;
+		}
+		if ( ++$safety > 8 ) {
+			break;
+		}
+		$miss_builder->run( array( 'landing_action' => 'process' ) );
+	}
+	$run = $sm_miss->get_state()['landing_run'];
+	rms_lpb_assert( 'failed' === (string) ( $run['status'] ?? '' ), 'keyword omission run fails' );
+	$failed_items = array_values(
+		array_filter(
+			is_array( $run['items'] ?? null ) ? $run['items'] : array(),
+			static function ( $item ) {
+				return is_array( $item ) && 'failed' === ( $item['status'] ?? '' );
+			}
+		)
+	);
+	rms_lpb_assert( 1 === count( $failed_items ) && 'rms_wizard_landing_keyword_fidelity_failed' === ( $failed_items[0]['error_code'] ?? '' ), 'omission fails closed with the fidelity error code' );
+	rms_lpb_assert( array() === ( $sm_miss->get_state()['landing_pages'] ?? array() ), 'deficient landing never persisted' );
+	rms_lpb_assert( ! isset( $GLOBALS['_page_by_path']['miss-page'] ), 'deficient landing never published' );
+
+	// The bounded rewrite path ran inside the existing two-pass maximum.
+	$rewrite_attempts = 0;
+	foreach ( $GLOBALS['_ai_prompt_log'] as $entry ) {
+		$entry_ctx = is_array( $entry['context'] ?? null ) ? $entry['context'] : array();
+		if ( 'rewrite' === ( $entry_ctx['review_stage'] ?? '' ) ) {
+			++$rewrite_attempts;
+		}
+	}
+	rms_lpb_assert( 2 === $rewrite_attempts, 'bounded rewrite attempts ran exactly at the existing two-pass budget' );
+	echo "PASS keyword-omission-fails-closed\n";
+	++$passed;
+
+	// =========================================================================
+	// 11. Keyword omission preserves existing landing content
+	// =========================================================================
+
+	rms_lpb_reset();
+	rms_lpb_seed_page( 21, 'home', 'Home' );
+	$sm_keep = rms_lpb_seed_landing_state(
+		array(
+			array( 'id' => 202, 'landing_key' => 'lk_keep', 'slug' => 'keep-page', 'landing_type' => 'seo', 'menu_eligible' => true, 'primary_keyword' => 'concrete repair', 'subkeywords' => array() ),
+		)
+	);
+	$st_keep                    = $sm_keep->get_state();
+	$st_keep['generated_pages'] = array( array( 'id' => 21, 'slug' => 'home', 'role' => 'home' ) );
+	$st_keep['home_page_slug']  = 'home';
+	$st_keep['ai_config']       = array( 'provider' => 'test', 'model' => 'test-keyword-miss', 'has_credentials' => true );
+	$sm_keep->save_state( $st_keep );
+	rms_lpb_seed_page( 202, 'keep-page', 'Keep Page' );
+	$GLOBALS['_post_meta'][202]['rms_landing_type']  = 'seo';
+	$GLOBALS['_post_meta'][202]['_wp_page_template'] = 'pages/landing-page.php';
+	$GLOBALS['_post_meta'][202]['page_sections']     = array(
+		array( 'acf_fc_layout' => 'hero', 'hero_title' => 'Original Hero', 'hero_description' => 'Original copy.' ),
+		array( 'acf_fc_layout' => 'seo-content', 'seo_headline' => 'Original SEO', 'seo_subheadline' => 'Original subheadline', 'seo_text' => 'Original body.' ),
+	);
+	$keep_builder = new Step_Landing_Page_Builder( new Logger(), $sm_keep );
+	$keep_res     = $keep_builder->run(
+		array(
+			'landing_action' => 'start',
+			'landings'       => array( rms_lpb_landing_payload_item( 'lk_keep', 'keep-page', array( 'id' => 202 ) ) ),
+		)
+	);
+	// Same as scenario 10: the fidelity failure may surface on start or process.
+	$safety = 0;
+	while ( true ) {
+		$run = $sm_keep->get_state()['landing_run'];
+		if ( is_array( $run ) && in_array( (string) ( $run['status'] ?? '' ), array( 'completed', 'failed' ), true ) ) {
+			break;
+		}
+		if ( ++$safety > 8 ) {
+			break;
+		}
+		$keep_builder->run( array( 'landing_action' => 'process' ) );
+	}
+	$run = $sm_keep->get_state()['landing_run'];
+	// Preservation completes the run: the existing landing stays published with
+	// untouched sections instead of a fidelity-failed rebuild.
+	rms_lpb_assert( 'completed' === (string) ( $run['status'] ?? '' ), 'preservation completes the run without rebuilding' );
+	$keep_pages = $sm_keep->get_state()['landing_pages'];
+	rms_lpb_assert( 1 === count( $keep_pages ) && 202 === (int) ( $keep_pages[0]['id'] ?? 0 ) && true === ( $keep_pages[0]['preserved'] ?? false ), 'existing landing preserved after fidelity failure' );
+	$keep_sections = is_array( $GLOBALS['_post_meta'][202]['page_sections'] ?? null ) ? $GLOBALS['_post_meta'][202]['page_sections'] : array();
+	rms_lpb_assert( 'Original Hero' === ( $keep_sections[0]['hero_title'] ?? '' ), 'existing hero copy untouched' );
+	rms_lpb_assert( 'Original SEO' === ( $keep_sections[1]['seo_headline'] ?? '' ), 'existing SEO copy untouched' );
+	rms_lpb_assert( 'concrete repair' === (string) ( $GLOBALS['_post_meta'][202][ Yoast_Meta_Writer::FOCUS_KEYWORD_KEY ] ?? '' ), 'focus keyword refreshed on the preserved landing' );
+	echo "PASS keyword-omission-preserves-existing\n";
+	++$passed;
+
+	// =========================================================================
+	// 12. Review-disabled omission still fails closed deterministically
+	// =========================================================================
+
+	// WIZARD_REVIEW_ENABLED=false leaves the builder's deterministic fidelity gate
+	// as the only enforcement layer: no reviewer loop, no rewrite, no publication.
+	// PHP constants cannot be undefined, so this scenario runs last in this file;
+	// each suite is a separate PHP process, and the trailing reset restores every
+	// mutable global so later scenarios in this process cannot leak state.
+	define( 'WIZARD_REVIEW_ENABLED', false );
+	rms_lpb_reset();
+	$noreview = rms_lpb_run_omission_to_terminal( rms_lpb_landing_payload_item( 'lk_noreview', 'noreview-page' ) );
+	rms_lpb_assert( 'failed' === (string) ( $noreview['run']['status'] ?? '' ), 'review-disabled omission run still fails' );
+	$noreview_failed_items = array_values(
+		array_filter(
+			is_array( $noreview['run']['items'] ?? null ) ? $noreview['run']['items'] : array(),
+			static function ( $item ) {
+				return is_array( $item ) && 'failed' === ( $item['status'] ?? '' );
+			}
+		)
+	);
+	rms_lpb_assert( 1 === count( $noreview_failed_items ) && 'rms_wizard_landing_keyword_fidelity_failed' === ( $noreview_failed_items[0]['error_code'] ?? '' ), 'review-disabled omission fails closed with the deterministic fidelity error code' );
+	rms_lpb_assert( array() === ( $noreview['state']->get_state()['landing_pages'] ?? array() ), 'review-disabled deficient landing never persisted' );
+	rms_lpb_assert( ! isset( $GLOBALS['_page_by_path']['noreview-page'] ), 'review-disabled omission never published' );
+	$noreview_review_prompts = 0;
+	foreach ( $GLOBALS['_ai_prompt_log'] as $entry ) {
+		$entry_ctx = is_array( $entry['context'] ?? null ) ? $entry['context'] : array();
+		if ( '' !== (string) ( $entry_ctx['review_stage'] ?? '' ) ) {
+			++$noreview_review_prompts;
+		}
+	}
+	rms_lpb_assert( 0 === $noreview_review_prompts, 'review-disabled run never invoked the reviewer' );
+	rms_lpb_reset();
+	echo "PASS keyword-omission-review-disabled-fails-closed\n";
+	++$passed;
+
 	return $passed;
+}
+
+/**
+ * Shared keyword-omission scenario runner: resets the harness globals, seeds the
+ * home page and landing wizard state with the persistent-omission model, applies
+ * scenario overrides, starts the landing run with the given payload item, and
+ * drives process ticks until the run reaches a terminal status.
+ *
+ * The single-item run may fail inside start or during the first process tick;
+ * either surface is acceptable, only the terminal state is asserted by callers.
+ *
+ * @param array<string,mixed> $landing_item    Landing payload item.
+ * @param array<string,mixed> $state_overrides Extra wizard-state overrides.
+ *
+ * @return array{state:\Inc\Wizard\State_Manager,run:array<string,mixed>}
+ */
+function rms_lpb_run_omission_to_terminal( array $landing_item, array $state_overrides = array() ): array {
+	rms_lpb_reset();
+	rms_lpb_seed_page( 21, 'home', 'Home' );
+	$sm                    = rms_lpb_seed_landing_state();
+	$st                    = $sm->get_state();
+	$st['generated_pages'] = array( array( 'id' => 21, 'slug' => 'home', 'role' => 'home' ) );
+	$st['home_page_slug']  = 'home';
+	$st['ai_config']       = array( 'provider' => 'test', 'model' => 'test-keyword-miss', 'has_credentials' => true );
+	foreach ( $state_overrides as $key => $value ) {
+		$st[ $key ] = $value;
+	}
+	$sm->save_state( $st );
+	$builder = new Step_Landing_Page_Builder( new Logger(), $sm );
+	$builder->run(
+		array(
+			'landing_action' => 'start',
+			'landings'       => array( $landing_item ),
+		)
+	);
+	$safety = 0;
+	while ( true ) {
+		$run = $sm->get_state()['landing_run'];
+		if ( is_array( $run ) && in_array( (string) ( $run['status'] ?? '' ), array( 'completed', 'failed' ), true ) ) {
+			break;
+		}
+		if ( ++$safety > 8 ) {
+			break;
+		}
+		$builder->run( array( 'landing_action' => 'process' ) );
+	}
+
+	return array( 'state' => $sm, 'run' => $sm->get_state()['landing_run'] );
 }
 
 if ( basename( $argv[0] ?? '' ) === basename( __FILE__ ) ) {


### PR DESCRIPTION
Closes #104

Supersedes #111, which GitHub automatically closed when its merged parent branch was deleted. The candidate commit is unchanged.

## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling

## Summary

- Thread occurrence-specific landing keyword intent through generation and review.
- Enforce deterministic post-review fidelity before persistence, failing closed after the existing two-pass budget.
- Preserve existing landing content on failure and persist the sanitized Yoast focus keyphrase.

## Changes Table

| File | Change |
|------|--------|
| `inc/wizard/class-step-landing-page-builder.php` | Assign hero/first-SEO/later-SEO occurrence roles, thread reviewer context, and fail closed before publish |
| `inc/wizard/class-yoast-meta-writer.php` | Persist sanitized `_yoast_wpseo_focuskw` independently of Yoast activation |
| `tests/wizard-landing-lifecycle-protection-harness.php` | Prove green generation, exact two-pass exhaustion, no publication, existing-content preservation, focuskw, canonical neutrality, and review-disabled enforcement |

## Test Plan

- [x] `php tests/wizard-landing-lifecycle-protection-harness.php` — 12/12
- [x] `php tests/wizard-landing-identity-canonical-harness.php` — 8/8
- [x] `php tests/wizard-landing-final-state-harness.php` — 20/20
- [x] `php tests/wizard-landing-controller-harness.php` — 7/7
- [x] `php tests/wizard-landing-render-harness.php` — 5/5
- [x] `php tests/wizard-landing-acf-missing-harness.php` — 1/1
- [x] `php tests/wizard-home-seo-targeting-harness.php` — 9/9
- [x] PHP lint passes on all three touched files
- [x] `git diff --cached --check` clean before commit
- [ ] Regenerate representative landings against a real provider and verify rendered H1/SEO copy plus Yoast focus keyphrase

## Contributor Checklist

- [x] Linked approved issue #104 (`status:approved`)
- [x] Exactly one `type:*` label (`type:bug`)
- [x] Relevant automated tests pass
- [x] Documentation updated if behavior changed (N/A — internal runtime contract)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Chain Context

```text
main
  └── PR #110 merged
        └── PR 2 📍 fix/landing-keyword-enforcement (this PR)
```

**Scope:** runtime enforcement, preservation, persistence, and integration proof.

**Dependency:** PR #110 is merged into `main`; this PR now contains only the second slice.

**Out of scope:** unrelated `.gitignore` exclusions and live provider regeneration.

**Changed lines:** 340 (335 additions + 5 deletions) — within the 400-line review budget.

**Rollback:** revert commit `ee58589`. No migration is required; failed new landings are never published and existing content remains intact.
