### PR TITLE
fix(footer): share copyright setting across templates

### DIFF
--- a/acf-json/group_rms_theme_settings.json
+++ b/acf-json/group_rms_theme_settings.json
@@ -942,11 +942,31 @@
             "default_value": "",
             "new_lines": "",
             "maxlength": "",
-            "placeholder": "",
-            "rows": ""
-        },
-        {
-            "key": "field_rms_tab_header",
+                "placeholder": "",
+                "rows": ""
+            },
+            {
+                "key": "field_rms_company_footer_copyright",
+                "label": "Footer Copyright",
+                "name": "company_footer_copyright",
+                "aria-label": "",
+                "type": "text",
+                "instructions": "Optional copyright line shared by every footer template. Leave empty to use the current year and site identity.",
+                "required": false,
+                "conditional_logic": false,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "placeholder": "e.g. © 2026 Acme Painting. All rights reserved.",
+                "default_value": "",
+                "maxlength": "",
+                "prepend": "",
+                "append": ""
+            },
+            {
+                "key": "field_rms_tab_header",
             "label": "Header",
             "name": "",
             "aria-label": "",
@@ -1500,5 +1520,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1788036197
+    "modified": 1788905238
 }

--- a/inc/acf-theme-options.php
+++ b/inc/acf-theme-options.php
@@ -192,6 +192,38 @@ function rms_get_footer_about_text(): string {
 }
 
 /**
+ * Resolve the shared footer copyright line.
+ *
+ * A trimmed Theme Settings value wins. Otherwise the helper builds a
+ * safe fallback from wp_date('Y') plus company name, then the site name.
+ *
+ * @return string Plain text ready for escaping at the template boundary.
+ */
+function rms_get_footer_copyright(): string {
+    $configured = rms_get_option('company_footer_copyright');
+    if (is_string($configured)) {
+        $configured = trim($configured);
+        if ('' !== $configured) {
+            return $configured;
+        }
+    }
+
+    $year = function_exists('wp_date') ? (string) wp_date('Y') : (string) gmdate('Y');
+
+    $identity = rms_get_option('company_name');
+    if (!is_string($identity) || '' === trim($identity)) {
+        $identity = function_exists('get_bloginfo') ? get_bloginfo('name') : '';
+    }
+    $identity = is_string($identity) ? trim($identity) : '';
+
+    if ('' !== $identity) {
+        return '© ' . $year . ' ' . $identity . '. All rights reserved.';
+    }
+
+    return '© ' . $year . '. All rights reserved.';
+}
+
+/**
  * Get the primary phone number from theme options.
  *
  * @return string

--- a/templates/footer-v1.php
+++ b/templates/footer-v1.php
@@ -12,7 +12,6 @@ $footer_logo   = rms_get_option('company_logo_footer');
 $phone         = rms_get_primary_phone();
 $email         = rms_get_primary_email();
 $socials       = rms_get_social_links();
-$year          = (int) gmdate('Y');
 
 $addr_line1 = rms_get_option('company_address_line_1');
 $addr_city  = rms_get_option('company_city');
@@ -125,11 +124,7 @@ if (is_array($socials)) {
         <?php endif; ?>
 
         <p class="footer-v1__copyright">
-            <?php if ($identity_name !== '') : ?>
-                <?php echo esc_html('© ' . $year . ' ' . $identity_name . '. All rights reserved.'); ?>
-            <?php else : ?>
-                <?php echo esc_html('© ' . $year . '. All rights reserved.'); ?>
-            <?php endif; ?>
+            <?php echo esc_html(rms_get_footer_copyright()); ?>
         </p>
     </div>
 </footer>

--- a/templates/footer-v2.php
+++ b/templates/footer-v2.php
@@ -203,7 +203,7 @@
 
     <div class="footer-v2__copyright">
         <div class="container">
-            <p>© 2026 Simple RMS Theme. All rights reserved.</p>
+            <p><?php echo esc_html(rms_get_footer_copyright()); ?></p>
         </div>
     </div>
 </footer>

--- a/tests/footer-copyright-harness.php
+++ b/tests/footer-copyright-harness.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Focused harness for issue #116 (shared footer copyright).
+ * Proves: optional Theme Settings text field `company_footer_copyright`;
+ * helper `rms_get_footer_copyright()` returns the trimmed managed value when
+ * present and otherwise a safe fallback from wp_date('Y') plus site identity;
+ * Footer V1 and Footer V2 both render through that helper with no independent
+ * literals or duplicated formatting. Usage: php tests/footer-copyright-harness.php
+ */
+
+if ( PHP_SAPI !== 'cli' ) { fwrite( STDERR, "CLI only.\n" ); exit( 1 ); }
+$GLOBALS['rms_copy_theme_root'] = dirname( __DIR__ );
+$GLOBALS['rms_copy_fields']     = array();
+$GLOBALS['rms_copy_year']       = '2031';
+$failures = 0;
+
+function rms_copy_assert( bool $condition, string $name, string $message ): void {
+	global $failures;
+	if ( $condition ) { fwrite( STDOUT, "PASS {$name}\n" ); }
+	else { $failures++; fwrite( STDERR, "FAIL {$name}: {$message}\n" ); }
+}
+
+if ( ! function_exists( '__' ) ) { function __( $text, $domain = 'default' ) { return $text; } }
+if ( ! function_exists( 'esc_html' ) ) { function esc_html( $text ) { return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' ); } }
+if ( ! function_exists( 'esc_attr' ) ) { function esc_attr( $text ) { return esc_html( $text ); } }
+if ( ! function_exists( 'esc_url' ) ) { function esc_url( $url ) { $url = trim( (string) $url ); return ( '' === $url || preg_match( '#^(javascript|data):#i', $url ) ) ? '' : $url; } }
+if ( ! function_exists( 'esc_attr__' ) ) { function esc_attr__( $text, $domain = 'default' ) { return esc_attr( $text ); } }
+if ( ! function_exists( 'home_url' ) ) { function home_url( $path = '/' ) { return 'https://example.test' . $path; } }
+if ( ! function_exists( 'get_bloginfo' ) ) { function get_bloginfo( $show = '' ) { if ( 'name' === $show ) { return (string) ( $GLOBALS['rms_copy_fields']['blogname'] ?? '' ); } return ''; } }
+if ( ! function_exists( 'add_action' ) ) { function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) { return true; } }
+if ( ! function_exists( 'get_field' ) ) { function get_field( $selector, $post_id = false ) { return $GLOBALS['rms_copy_fields'][ $selector ] ?? null; } }
+if ( ! function_exists( 'has_custom_logo' ) ) { function has_custom_logo() { return false; } }
+if ( ! function_exists( 'the_custom_logo' ) ) { function the_custom_logo() {} }
+if ( ! function_exists( 'has_nav_menu' ) ) { function has_nav_menu( $location ) { return false; } }
+if ( ! function_exists( 'wp_nav_menu' ) ) { function wp_nav_menu( $args = array() ) { return ''; } }
+if ( ! function_exists( 'wp_date' ) ) { function wp_date( $format, $timestamp = null, $timezone = null ) { return (string) ( $GLOBALS['rms_copy_year'] ?? gmdate( (string) $format ) ); } }
+
+require $GLOBALS['rms_copy_theme_root'] . '/inc/acf-theme-options.php';
+
+function rms_copy_copyright(): string {
+	if ( ! function_exists( 'rms_get_footer_copyright' ) ) {
+		return '';
+	}
+	// pi-lens-ignore: intelephense:P1010
+	return rms_get_footer_copyright();
+}
+
+function rms_copy_render( string $template, array $fields ): string {
+	$GLOBALS['rms_copy_fields'] = $fields;
+	ob_start();
+	include $GLOBALS['rms_copy_theme_root'] . '/templates/' . $template;
+	return (string) ob_get_clean();
+}
+
+// ─── 1. Schema: optional Footer copyright text field ─────────────────────────
+$group  = json_decode( (string) file_get_contents( $GLOBALS['rms_copy_theme_root'] . '/acf-json/group_rms_theme_settings.json' ), true );
+$fields = is_array( $group ) ? ( $group['fields'] ?? array() ) : array();
+$copyright_field = null;
+$about_idx       = null;
+$copyright_idx   = null;
+$header_tab_idx  = null;
+foreach ( $fields as $i => $field ) {
+	if ( ! is_array( $field ) ) { continue; }
+	if ( 'company_footer_about' === ( $field['name'] ?? '' ) ) { $about_idx = $i; }
+	if ( 'company_footer_copyright' === ( $field['name'] ?? '' ) ) { $copyright_field = $field; $copyright_idx = $i; }
+	if ( 'tab' === ( $field['type'] ?? '' ) && 'Header' === ( $field['label'] ?? '' ) ) { $header_tab_idx = $i; }
+}
+rms_copy_assert( null !== $copyright_field, 'test_theme_settings_footer_copyright_field_exists', 'group_rms_theme_settings.json has no company_footer_copyright field' );
+if ( null !== $copyright_field ) {
+	rms_copy_assert( 'text' === ( $copyright_field['type'] ?? '' ), 'test_footer_copyright_is_text', 'company_footer_copyright must be a text field, got ' . json_encode( $copyright_field['type'] ?? null ) );
+	rms_copy_assert( empty( $copyright_field['required'] ), 'test_footer_copyright_is_optional', 'company_footer_copyright must be optional' );
+}
+if ( isset( $about_idx, $copyright_idx, $header_tab_idx ) ) {
+	rms_copy_assert( $about_idx < $copyright_idx && $copyright_idx < $header_tab_idx, 'test_footer_copyright_lives_on_footer_tab', 'company_footer_copyright must sit after Footer About and before the Header tab' );
+}
+
+// ─── 2. Helper contract ──────────────────────────────────────────────────────
+rms_copy_assert( function_exists( 'rms_get_footer_copyright' ), 'test_helper_exists', 'rms_get_footer_copyright() must exist' );
+
+$GLOBALS['rms_copy_fields'] = array( 'company_footer_copyright' => '  © 2024 Acme Painting. Custom line.  ' );
+rms_copy_assert( '© 2024 Acme Painting. Custom line.' === rms_copy_copyright(), 'test_helper_returns_trimmed_configured_value', 'configured copyright must return trimmed managed text, got ' . json_encode( rms_copy_copyright() ) );
+
+$GLOBALS['rms_copy_fields'] = array( 'company_footer_copyright' => "  \t\n  ", 'company_name' => 'Acme Painting', 'blogname' => 'Ignored Site' );
+rms_copy_assert( '© 2031 Acme Painting. All rights reserved.' === rms_copy_copyright(), 'test_helper_whitespace_falls_back', 'whitespace-only copyright must use the dynamic fallback, got ' . json_encode( rms_copy_copyright() ) );
+
+$GLOBALS['rms_copy_fields'] = array( 'company_name' => 'Acme Painting' );
+rms_copy_assert( '© 2031 Acme Painting. All rights reserved.' === rms_copy_copyright(), 'test_helper_blank_uses_company_name', 'blank copyright must use wp_date year plus company_name, got ' . json_encode( rms_copy_copyright() ) );
+
+$GLOBALS['rms_copy_fields'] = array( 'blogname' => 'RMS Test Co' );
+rms_copy_assert( '© 2031 RMS Test Co. All rights reserved.' === rms_copy_copyright(), 'test_helper_blank_uses_site_name', 'missing company_name must fall back to the site name, got ' . json_encode( rms_copy_copyright() ) );
+
+$GLOBALS['rms_copy_fields'] = array();
+rms_copy_assert( '© 2031. All rights reserved.' === rms_copy_copyright(), 'test_helper_missing_site_name', 'missing site identity must omit the name, got ' . json_encode( rms_copy_copyright() ) );
+
+$GLOBALS['rms_copy_year']   = '1999';
+$GLOBALS['rms_copy_fields'] = array( 'company_name' => 'Year Probe' );
+rms_copy_assert( '© 1999 Year Probe. All rights reserved.' === rms_copy_copyright(), 'test_helper_uses_wp_date_year', 'fallback year must come from wp_date(), got ' . json_encode( rms_copy_copyright() ) );
+$GLOBALS['rms_copy_year'] = '2031';
+
+$v1_src = (string) file_get_contents( $GLOBALS['rms_copy_theme_root'] . '/templates/footer-v1.php' );
+$v2_src = (string) file_get_contents( $GLOBALS['rms_copy_theme_root'] . '/templates/footer-v2.php' );
+rms_copy_assert( false !== strpos( $v1_src, 'rms_get_footer_copyright()' ) && false === strpos( $v1_src, 'All rights reserved.' ), 'test_footer_v1_uses_helper_only', 'footer-v1.php must render copyright only through the helper' );
+rms_copy_assert( false !== strpos( $v2_src, 'rms_get_footer_copyright()' ) && false === strpos( $v2_src, 'Simple RMS Theme' ) && false === strpos( $v2_src, '© 2026' ), 'test_footer_v2_has_no_literal_copyright', 'footer-v2.php must not keep a hardcoded copyright literal' );
+
+// ─── 3. Both templates render the helper output, escaped ─────────────────────
+$configured = array( 'company_footer_copyright' => 'Custom <script> line & more' );
+$v1_html    = rms_copy_render( 'footer-v1.php', $configured );
+$v2_html    = rms_copy_render( 'footer-v2.php', $configured );
+rms_copy_assert( false !== strpos( $v1_html, 'Custom &lt;script&gt; line &amp; more' ) && false === strpos( $v1_html, '<script>' ), 'test_footer_v1_renders_escaped_configured_copyright', 'Footer V1 must escape the managed copyright' );
+rms_copy_assert( false !== strpos( $v2_html, 'Custom &lt;script&gt; line &amp; more' ) && false === strpos( $v2_html, '<script>' ), 'test_footer_v2_renders_escaped_configured_copyright', 'Footer V2 must escape the managed copyright' );
+
+$fallback = array( 'company_name' => 'Acme Painting' );
+$v1_fb    = rms_copy_render( 'footer-v1.php', $fallback );
+$v2_fb    = rms_copy_render( 'footer-v2.php', $fallback );
+rms_copy_assert( false !== strpos( $v1_fb, '© 2031 Acme Painting. All rights reserved.' ), 'test_footer_v1_renders_dynamic_fallback', 'Footer V1 must render the shared fallback when the field is empty' );
+rms_copy_assert( false !== strpos( $v2_fb, '© 2031 Acme Painting. All rights reserved.' ) && false === strpos( $v2_fb, 'Simple RMS Theme' ), 'test_footer_v2_renders_dynamic_fallback', 'Footer V2 must render the shared fallback instead of the theme-branded literal' );
+
+if ( $failures > 0 ) { fwrite( STDERR, "\n{$failures} footer copyright check(s) failed.\n" ); exit( 1 ); }
+fwrite( STDOUT, "\nAll footer copyright checks passed.\n" );
+exit( 0 );


### PR DESCRIPTION
Closes #116

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Adds one optional Footer copyright field in Theme Settings.
- Routes Footer V1 and Footer V2 through a shared escaped helper.
- Replaces the hardcoded Footer V2 theme-branded copyright with a dynamic fallback.

## Changes

| File | Change |
|------|--------|
| `inc/acf-theme-options.php` | Adds `rms_get_footer_copyright()` with managed-value and year/identity fallbacks. |
| `acf-json/group_rms_theme_settings.json` | Adds optional `company_footer_copyright` on the Footer tab. |
| `templates/footer-v1.php` | Renders copyright only through the shared helper. |
| `templates/footer-v2.php` | Removes the hardcoded 2026 Simple RMS Theme literal. |
| `tests/footer-copyright-harness.php` | Covers configured, blank, whitespace, dynamic-year, missing-name, and escaped rendering. |

## Test Plan

- [x] `php tests/footer-copyright-harness.php` — 17/17 checks passed.
- [x] `php tests/footer-v2-nav-schema-harness.php` — 30/30 checks passed.
- [x] `php scripts/test-footer-variants.php` — all regression checks passed.
- [x] PHP lint passed for all modified PHP files.
- [x] LocalWP Theme Settings exposes Footer Copyright; live Footer V1 fallback rendered the current year and company identity.

## Contributor Checklist

- [x] Linked approved issue #116.
- [x] Exactly one PR type selected and `type:bug` applied.
- [x] No shell scripts modified; shellcheck is not applicable.
- [x] Relevant WordPress guidance was applied.
- [x] No standalone documentation update is required for this corrective behavior.
- [x] Conventional commit format used.
- [x] No `Co-Authored-By` trailer added.
