### PR TITLE
fix(services-v2): space and center section CTA

### DIFF
--- a/src/scss/templates/services-v2.scss
+++ b/src/scss/templates/services-v2.scss
@@ -72,4 +72,10 @@
   padding: 0 $space-6 $space-6;
 }
 
-// Button uses global .btn — no section-specific override needed
+    // ─── CTA ─────────────────────────────────────────────────────
+    .services-v2__cta {
+      text-align: center;
+      margin-top: $space-12;
+    }
+
+    // Button uses global .btn — no section-specific override needed

--- a/tests/services-v2-cta-harness.php
+++ b/tests/services-v2-cta-harness.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Focused harness for issue #103 (Services V2 section CTA spacing).
+ * Proves `.services-v2__cta` is centered with `$space-12` top margin,
+ * matching Services V1, without changing template markup or other CTAs.
+ * Usage: php tests/services-v2-cta-harness.php
+ */
+
+if ( PHP_SAPI !== 'cli' ) { fwrite( STDERR, "CLI only.\n" ); exit( 1 ); }
+$theme_root = dirname( __DIR__ );
+$failures   = 0;
+
+function rms_s2_assert( bool $condition, string $name, string $message ): void {
+	global $failures;
+	if ( $condition ) { fwrite( STDOUT, "PASS {$name}\n" ); }
+	else { $failures++; fwrite( STDERR, "FAIL {$name}: {$message}\n" ); }
+}
+
+$v2_scss = (string) file_get_contents( $theme_root . '/src/scss/templates/services-v2.scss' );
+$v1_scss = (string) file_get_contents( $theme_root . '/src/scss/templates/services-v1.scss' );
+$v2_php  = (string) file_get_contents( $theme_root . '/templates/services-v2.php' );
+
+rms_s2_assert(
+	(bool) preg_match( '/<div class="services-v2__cta">\s*<a href="[^"]+" class="btn services-v2__cta-btn">/', $v2_php ),
+	'test_services_v2_template_keeps_cta_wrapper',
+	'templates/services-v2.php must keep the existing CTA wrapper and global button class'
+);
+
+rms_s2_assert(
+	(bool) preg_match( '/\.services-v1__cta\s*\{\s*text-align:\s*center;\s*margin-top:\s*\$space-12;\s*\}/', $v1_scss ),
+	'test_services_v1_cta_unchanged',
+	'services-v1 CTA spacing must remain the canonical reference'
+);
+
+rms_s2_assert(
+	(bool) preg_match( '/\.services-v2__cta\s*\{\s*text-align:\s*center;\s*margin-top:\s*\$space-12;\s*\}/', $v2_scss ),
+	'test_services_v2_cta_matches_v1_spacing',
+	'.services-v2__cta must set text-align:center and margin-top:$space-12'
+);
+
+rms_s2_assert(
+	! preg_match( '/^\s*\.btn\b/m', $v2_scss ) && ! preg_match( '/^\s*\.services-v2__cta-btn\b/m', $v2_scss ),
+	'test_services_v2_does_not_override_global_button',
+	'services-v2.scss must not add button-level overrides'
+);
+
+if ( $failures > 0 ) { fwrite( STDERR, "\n{$failures} services-v2 CTA check(s) failed.\n" ); exit( 1 ); }
+fwrite( STDOUT, "\nAll services-v2 CTA checks passed.\n" );
+exit( 0 );


### PR DESCRIPTION
Closes #103

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Adds the missing Services V2 section CTA wrapper styles.
- Centers the CTA and applies `$space-12` (3rem) separation from the service grid.
- Leaves template markup, global button styles, and Services V1/V3 unchanged.

## Changes

| File | Change |
|------|--------|
| `src/scss/templates/services-v2.scss` | Adds `.services-v2__cta { text-align: center; margin-top: $space-12; }`. |
| `tests/services-v2-cta-harness.php` | Guards the V2 CTA contract and V1 non-regression. |

## Test Plan

- [x] `php tests/services-v2-cta-harness.php` — 4/4 checks passed.
- [x] `npm run build` compiled `.services-v2__cta{text-align:center;margin-top:3rem}`.
- [x] Generated `dist/` output remained untracked.
- [x] No shell scripts modified; shellcheck is not applicable.

## Contributor Checklist

- [x] Linked approved issue #103.
- [x] Exactly one PR type selected and `type:bug` applied.
- [x] No shell scripts modified; shellcheck is not applicable.
- [x] Relevant WordPress and frontend guidance was applied.
- [x] No standalone documentation update is required for this CSS correction.
- [x] Conventional commit format used.
- [x] No `Co-Authored-By` trailer added.
