### PR TITLE
feat(cf7): wire landing form into theme settings

### DIFF
--- a/acf-json/group_rms_theme_settings.json
+++ b/acf-json/group_rms_theme_settings.json
@@ -1554,6 +1554,42 @@
             "max_height": 0,
             "max_size": 0,
             "mime_types": ""
+        },
+        {
+            "key": "field_rms_tab_cf7",
+            "label": "Contact Form 7",
+            "name": "",
+            "aria-label": "",
+            "type": "tab",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": false,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "placement": "left",
+            "endpoint": 0,
+            "selected": 0
+        },
+        {
+            "key": "field_rms_cf7_landing_form_control",
+            "label": "Landing Form Control",
+            "name": "cf7_landing_form_control",
+            "aria-label": "",
+            "type": "message",
+            "instructions": "Read-only control for the theme-managed hero form. Generate creates the form once and reuses it afterwards; the shortcode goes into the Hero Form Shortcode field.",
+            "required": 0,
+            "conditional_logic": false,
+            "wrapper": {
+                "width": "",
+                "class": "rms-cf7-control",
+                "id": ""
+            },
+            "message": "",
+            "new_lines": "",
+            "esc_html": 1
         }
     ],
     "location": [

--- a/inc/cf7-landing-form.php
+++ b/inc/cf7-landing-form.php
@@ -10,8 +10,9 @@
  * `rms_cf7_landing_form_id`. A form is never adopted or modified because
  * of its title alone.
  *
- * The admin-only Theme Settings control (ACF `message` field) renders a
- * read-only state machine and a separate POST target; it never creates
+ * The admin-only Theme Settings control (ACF `message` field) forces an
+ * empty sanitized message and delivers its read-only state machine plus
+ * separate POST target through a dedicated render hook; it never creates
  * forms at render time and is inert without ACF/CF7.
  *
  * @package Simple_RMS_Theme
@@ -211,8 +212,17 @@ function rms_cf7_landing_form_control_state(): array {
 	);
 }
 
-/** Inject the read-only control markup into the ACF message field. */
+/** Force an empty harmless message: the control markup never depends on ACF sanitization. */
 function rms_cf7_landing_form_control_field( array $field ): array {
+	$field['message'] = '';
+
+	return $field;
+}
+
+/** Echo the already escaped control markup after ACF's default field output. */
+function rms_cf7_landing_form_control_render( array $field = array() ): void {
+	unset( $field );
+
 	$state = rms_cf7_landing_form_control_state();
 	$html  = '';
 
@@ -238,9 +248,7 @@ function rms_cf7_landing_form_control_field( array $field ): array {
 		esc_html( 'Generate RMS Landing Form' )
 	);
 
-	$field['message'] = $html;
-
-	return $field;
+	echo $html;
 }
 
 /** Print the separate POST target after the ACF options form (no nested forms). */
@@ -315,6 +323,7 @@ function rms_cf7_landing_form_admin_notice(): void {
 
 if ( function_exists( 'is_admin' ) && is_admin() ) {
 	add_filter( 'acf/load_field/key=field_rms_cf7_landing_form_control', 'rms_cf7_landing_form_control_field' );
+	add_action( 'acf/render_field/key=field_rms_cf7_landing_form_control', 'rms_cf7_landing_form_control_render' );
 	add_action( 'admin_footer', 'rms_cf7_landing_form_control_hidden_form', 20 );
 	add_action( 'admin_post_' . RMS_CF7_CONTROL_ACTION, 'rms_cf7_landing_form_handle_generate' );
 	add_action( 'admin_notices', 'rms_cf7_landing_form_admin_notice' );

--- a/src/scss/templates/hero.scss
+++ b/src/scss/templates/hero.scss
@@ -221,3 +221,54 @@
 
   @include focus-ring;
 }
+
+// ─── Contact Form 7 — Managed Landing Form ───────────────────────────
+// CF7 wraps the managed form in its own containers. Every override is
+// scoped under .hero__form-card so other CF7 usages keep stock styling.
+.hero__form-card {
+  .wpcf7 {
+    position: relative;
+  }
+
+  .wpcf7-form-control-wrap {
+    display: block;
+    position: relative;
+
+    .hero__form-input {
+      @include focus-ring;
+
+      &.wpcf7-not-valid {
+        border-color: $color-error;
+      }
+    }
+    }
+
+  // Validation tips sit directly under the invalid field
+  .wpcf7-not-valid-tip {
+    display: block;
+    margin-top: $space-1;
+    color: $color-error;
+    font-size: $font-size-sm;
+  }
+
+  // CF7 response output (success/error status messages)
+  .wpcf7-response-output {
+    margin: $space-4 0 0;
+    padding: $space-3 $space-4;
+    border: 1px solid $color-gray-300;
+    border-radius: $radius-md;
+    color: $color-gray-700;
+    font-size: $font-size-sm;
+  }
+
+  // Spinner rendered by CF7 next to the submit button while sending
+  .wpcf7-spinner {
+    visibility: hidden;
+    margin-left: $space-2;
+    vertical-align: middle;
+
+    &.is-active {
+      visibility: visible;
+    }
+  }
+}

--- a/templates/hero.php
+++ b/templates/hero.php
@@ -2,27 +2,32 @@
 /**
  * Hero Section
  *
- * Reads ACF flexible content sub-fields and falls back to default
- * hardcoded content when fields are empty.
+ * Reads ACF flexible content sub-fields and falls back to generic content
+ * when fields are empty. The optional `hero_form_shortcode` renders a managed
+ * contact form (e.g. the Contact Form 7 landing form); the value is
+ * string-normalized, so a whitespace-only value renders no form column. The
+ * two-column grid is applied only when a form exists. The template never
+ * creates forms and never injects the generated shortcode by itself.
  */
 
 $hero_bg_image      = get_sub_field('hero_bg_image');
 $hero_reviews_label = get_sub_field('hero_reviews_label');
 $hero_title         = get_sub_field('hero_title');
 $hero_description   = get_sub_field('hero_description');
-$hero_form_shortcode = get_sub_field('hero_form_shortcode');
+$hero_form_shortcode = trim( (string) get_sub_field('hero_form_shortcode') );
+$has_hero_form       = '' !== $hero_form_shortcode;
 
 $bg_url            = !empty($hero_bg_image) ? esc_url($hero_bg_image) : 'https://images.unsplash.com/photo-1486406146926-c627a92ad1ab?w=1920&q=80';
 $reviews_label     = !empty($hero_reviews_label) ? esc_html($hero_reviews_label) : '5.0 Google Reviews';
-$title             = !empty($hero_title) ? esc_html($hero_title) : 'Professional Roofing Solutions You Can Trust';
-$description       = !empty($hero_description) ? wp_kses_post($hero_description) : 'We deliver high-quality roofing services for residential and commercial properties. Our experienced team ensures durable, weather-resistant installations backed by industry-leading warranties. From inspections to full replacements, we handle every project with precision and care.';
+$title             = !empty($hero_title) ? esc_html($hero_title) : 'Professional Services You Can Trust';
+$description       = !empty($hero_description) ? wp_kses_post($hero_description) : 'We deliver high-quality services for residential and commercial properties. Our experienced team ensures durable, reliable results backed by industry-leading warranties. From first inspection to full completion, we handle every project with precision and care.';
 ?>
 
 <!-- Hero Section -->
 <section class="hero" style="--hero-bg: url('<?php echo $bg_url; ?>');">
     <div class="hero__overlay hero__overlay--dark"></div>
     <div class="container">
-        <div class="grid-2">
+        <div class="<?php echo esc_attr( $has_hero_form ? 'grid-2' : 'grid-1' ); ?>">
 
             <!-- Left Column -->
             <div class="hero__col-left">
@@ -36,53 +41,14 @@ $description       = !empty($hero_description) ? wp_kses_post($hero_description)
                 </div>
             </div>
 
-            <!-- Right Column — Free Estimate Form -->
-            <div class="hero__col-right">
-                <div class="hero__form-card">
-                    <?php if (!empty($hero_form_shortcode)) : ?>
+            <?php if ( $has_hero_form ) : ?>
+                <!-- Right Column — Managed Contact Form -->
+                <div class="hero__col-right">
+                    <div class="hero__form-card">
                         <?php echo do_shortcode($hero_form_shortcode); ?>
-                    <?php else : ?>
-                        <h2 class="hero__form-title">FREE Estimate</h2>
-                        <form class="hero__form" method="post">
-                            <div class="hero__form-group">
-                                <label for="hero-name">Full Name</label>
-                                <input type="text" id="hero-name" name="name" placeholder="Your name" required>
-                            </div>
-                            <div class="hero__form-group">
-                                <label for="hero-email">Email</label>
-                                <input type="email" id="hero-email" name="email" placeholder="your@email.com" required>
-                            </div>
-                            <div class="hero__form-row">
-                                <div class="hero__form-group">
-                                    <label for="hero-phone">Phone</label>
-                                    <input type="tel" id="hero-phone" name="phone" placeholder="(555) 123-4567" required>
-                                </div>
-                                <div class="hero__form-group">
-                                    <label for="hero-zip">Zip Code</label>
-                                    <input type="text" id="hero-zip" name="zip" placeholder="00000" required>
-                                </div>
-                            </div>
-                            <div class="hero__form-group">
-                                <label for="hero-service">Service Interested In</label>
-                                <select id="hero-service" name="service" required>
-                                    <option value="" disabled selected>Select a service</option>
-                                    <option value="roof-installation">Roof Installation</option>
-                                    <option value="roof-repair">Roof Repair</option>
-                                    <option value="roof-replacement">Roof Replacement</option>
-                                    <option value="inspection">Roof Inspection</option>
-                                    <option value="gutters">Gutter Installation</option>
-                                    <option value="other">Other</option>
-                                </select>
-                            </div>
-                            <div class="hero__form-group">
-                                <label for="hero-summary">Project Summary</label>
-                                <textarea id="hero-summary" name="summary" rows="4" placeholder="Briefly describe your project..."></textarea>
-                            </div>
-                            <button type="submit" class="btn hero__form-submit">Get My Free Estimate</button>
-                        </form>
-                    <?php endif; ?>
+                    </div>
                 </div>
-            </div>
+            <?php endif; ?>
 
         </div>
     </div>

--- a/tests/cf7-hero-integration-harness.php
+++ b/tests/cf7-hero-integration-harness.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * Focused runtime harness for issue #121 — PR3 Hero + ACF control integration.
+ * One isolated child process per scenario: ACF JSON tab+message schema and
+ * template/SCSS source contracts; sanitizer-independent empty-message load
+ * path with a dedicated admin render hook; readonly input + button form
+ * association; Hero shortcode/whitespace/no-form paths with conditional grid.
+ * Read-only over theme assets; never builds dist or creates forms.
+ * Usage: php tests/cf7-hero-integration-harness.php
+ */
+
+if ( PHP_SAPI !== 'cli' ) {
+	fwrite( STDERR, "CLI only.\n" );
+	exit( 1 );
+}
+
+function rms_harness_assert( $condition, string $message ): void {
+	if ( ! $condition ) { fwrite( STDERR, $message . "\n" ); exit( 1 ); }
+}
+
+/** Every needle must appear in $haystack, or must not when $should is false. */
+function rms_harness_contains( string $haystack, array $needles, bool $should = true ): void {
+	foreach ( $needles as $needle ) {
+		rms_harness_assert( ( false !== strpos( $haystack, $needle ) ) === $should, ( $should ? 'Expected' : 'Did not expect' ) . " [{$needle}]" );
+	}
+}
+
+/** Render a callable and return the buffered output. */
+function rms_harness_capture( callable $render ): string {
+	ob_start();
+	$render();
+	return (string) ob_get_clean();
+}
+
+$scenario      = getenv( 'RMS_HERO_SCENARIO' );
+$root          = dirname( __DIR__ );
+$json_path     = $root . '/acf-json/group_rms_theme_settings.json';
+$scss_path     = $root . '/src/scss/templates/hero.scss';
+$template_path = $root . '/templates/hero.php';
+$kernel_path   = $root . '/inc/cf7-landing-form.php';
+
+if ( false === $scenario || '' === $scenario ) {
+	// ─── Parent: one isolated child process per scenario ────────────────
+	$failed = 0;
+	foreach ( array( 'schema', 'hero', 'control-active', 'control-inactive' ) as $name ) {
+		putenv( "RMS_HERO_SCENARIO={$name}" );
+		exec( '"' . PHP_BINARY . '" ' . escapeshellarg( __FILE__ ), $output, $code );
+		if ( 0 !== $code ) { fwrite( STDERR, "FAIL {$name}\n" . implode( "\n", $output ) . "\n" ); $failed++; continue; }
+		echo "PASS {$name}\n" . implode( "\n", array_filter( $output ) ) . "\n";
+	}
+	putenv( 'RMS_HERO_SCENARIO' );
+	if ( $failed > 0 ) { fwrite( STDERR, "Harness failed: {$failed} scenario(s).\n" ); exit( 1 ); }
+	echo "Harness passed: 4 scenarios.\n";
+	exit( 0 );
+}
+
+switch ( $scenario ) {
+
+	// ─── ACF JSON schema + template/SCSS source contracts ────────────────
+	case 'schema':
+		$group = json_decode( (string) file_get_contents( $json_path ), true );
+		rms_harness_assert( is_array( $group ) && isset( $group['fields'] ) && is_array( $group['fields'] ), 'group JSON must decode with a fields array' );
+		$messages = array(); $editable = array(); $tab = null; $tab_at = null; $control = null; $control_at = null;
+		foreach ( $group['fields'] as $i => $field ) {
+			$key = (string) ( $field['key'] ?? '' ); $name = (string) ( $field['name'] ?? '' ); $type = (string) ( $field['type'] ?? '' );
+			if ( 'message' === $type ) { $messages[] = $field; }
+			if ( 'field_rms_tab_cf7' === $key ) { $tab = $field; $tab_at = $i; }
+			if ( 'field_rms_cf7_landing_form_control' === $key ) { $control = $field; $control_at = $i; }
+			if ( 'hero_form_shortcode' === $name ) { $editable[] = $field; }
+		}
+		rms_harness_assert( 1 === count( $messages ), 'exactly one message field may exist in Theme Settings' );
+		rms_harness_assert( null !== $control, 'the CF7 control field must exist' );
+		rms_harness_assert( null !== $tab && 'tab' === $tab['type'] && 'Contact Form 7' === $tab['label'] && $tab_at + 1 === $control_at, 'a clear Contact Form 7 tab must immediately precede the control field' );
+		rms_harness_assert( 'message' === $control['type'], 'the control must be a read-only message field, not an editable shortcode option' );
+		rms_harness_assert( array() === $editable, 'the editable hero_form_shortcode option must not live in Theme Settings' );
+		rms_harness_assert( '' === trim( (string) ( $control['message'] ?? 'x' ) ), 'the stored message must default to empty so rendering never depends on ACF sanitization' );
+
+		$scss   = (string) file_get_contents( $scss_path );
+		$marker = strpos( $scss, 'Contact Form 7 — Managed Landing Form' );
+		rms_harness_assert( false !== $marker, 'hero SCSS must contain the CF7 scoped block' );
+		$block = (string) substr( $scss, (int) $marker );
+		rms_harness_contains( $block, array( '.hero__form-card', '.wpcf7 {', '.wpcf7-form-control-wrap', '.wpcf7-not-valid-tip', '.wpcf7-response-output', '.wpcf7-spinner', '.wpcf7-not-valid', '$color-error', 'focus-ring' ) );
+		rms_harness_contains( strtolower( $block ), array( 'hero-name', 'roofing' ), false );
+
+		$template = (string) file_get_contents( $template_path );
+		rms_harness_contains( $template, array( 'trim(', '$has_hero_form', "'grid-2'", "'grid-1'", 'hero_form_shortcode', 'do_shortcode' ) );
+		rms_harness_contains( strtolower( $template ), array( 'roofing', '<form', 'hero-name', 'hero-email', 'hero-phone', 'hero-zip', 'rms_cf7_landing_form_shortcode', 'rms_cf7_landing_form_id', 'get_option' ), false );
+		break;
+
+	// ─── Hero template runtime paths ─────────────────────────────────────
+	case 'hero':
+		function esc_url( $url ) { return (string) $url; } function esc_html( $t ) { return htmlspecialchars( (string) $t, ENT_QUOTES, 'UTF-8' ); }
+		function esc_attr( $t ) { return htmlspecialchars( (string) $t, ENT_QUOTES, 'UTF-8' ); } function wp_kses_post( $t ) { return (string) $t; }
+		function get_sub_field( $selector ) { return $GLOBALS['rms_hero_fields'][ $selector ] ?? ''; }
+		function do_shortcode( $content = '' ) { return '<div class="wpcf7" data-harness-form="1"></div>'; }
+		$GLOBALS['rms_template'] = $template_path;
+		$render_hero             = function(): string {
+			ob_start();
+			require $GLOBALS['rms_template'];
+			return (string) ob_get_clean();
+		};
+
+		// Form present: two-column grid renders the managed form card.
+		$GLOBALS['rms_hero_fields'] = array( 'hero_bg_image' => '', 'hero_reviews_label' => '', 'hero_title' => '', 'hero_description' => '', 'hero_form_shortcode' => '[contact-form-7 id="7" title="RMS Landing Form" html_class="hero__form"]' );
+		$html = $render_hero();
+		rms_harness_contains( $html, array( 'hero__col-left', 'hero__col-right', 'hero__form-card', 'grid-2', 'data-harness-form="1"' ) );
+
+		// Whitespace-only shortcode must behave as empty: single column, no card.
+		$GLOBALS['rms_hero_fields']['hero_form_shortcode'] = "  \n\t ";
+		$html = $render_hero();
+		rms_harness_contains( $html, array( 'hero__col-right', 'hero__form-card', 'grid-2', 'data-harness-form="1"' ), false );
+
+		// Missing field: single column, no card, hero content intact.
+		unset( $GLOBALS['rms_hero_fields']['hero_form_shortcode'] );
+		$html = $render_hero();
+		rms_harness_contains( $html, array( 'hero__col-right', 'hero__form-card', 'grid-2', 'data-harness-form="1"' ), false );
+		rms_harness_contains( $html, array( 'hero__col-left', 'hero__title', 'grid-1' ) );
+		break;
+
+	// ─── ACF control: active CF7 (ready + existing states) ───────────────
+	case 'control-active':
+		rms_harness_wp_stubs();
+		rms_harness_install_cf7();
+		require $kernel_path; $h =& $GLOBALS['rms_harness'];
+		rms_harness_assert( isset( $h['hooks']['acf/load_field/key=field_rms_cf7_landing_form_control'], $h['hooks']['acf/render_field/key=field_rms_cf7_landing_form_control'] ), 'load filter and dedicated render hook must be registered in admin' );
+
+		// Hostile stored markup must never reach the message value.
+		$clean = rms_cf7_landing_form_control_field( array( 'key' => 'field_rms_cf7_landing_form_control', 'message' => '<button onclick="alert(1)">Generate</button><input type="text" value="stale" /><p>stale</p>' ) );
+		rms_harness_assert( is_array( $clean ) && '' === $clean['message'], 'the load filter must force an empty harmless message, never sanitizer-dependent markup' );
+
+		// Ready state: enabled primary Generate targeting the separate footer form.
+		$out = rms_harness_capture( 'rms_cf7_landing_form_control_render' );
+		rms_harness_contains( $out, array( 'Generate RMS Landing Form', 'button-primary', 'form="rms-cf7-landing-form-generate"', 'type="submit"' ) );
+		rms_harness_contains( $out, array( 'disabled', 'readonly', 'color:#b32d2e' ), false );
+		rms_harness_assert( 0 === $h['save_calls'] && 0 === $h['option_writes'] && 0 === $h['meta_stamps'], 'ready render must not create or persist anything' );
+
+		// Existing state: escaped readonly shortcode, enabled button, no overwrite.
+		$h['posts'][1] = array( 'status' => 'publish', 'type' => 'wpcf7_contact_form', 'meta' => array( '_rms_theme_managed' => 'landing_form' ), 'title' => 'RMS Landing Form' );
+		$h['options']['rms_cf7_landing_form_id'] = 1;
+		$out = rms_harness_capture( 'rms_cf7_landing_form_control_render' );
+		rms_harness_contains( $out, array( 'readonly', 'aria-label="Managed hero form shortcode"', 'html_class=&quot;hero__form&quot;', 'id=&quot;1&quot;', 'Generate RMS Landing Form', 'form="rms-cf7-landing-form-generate"' ) );
+		rms_harness_contains( $out, array( 'disabled', '<button onclick' ), false );
+		break;
+
+	// ─── ACF control: CF7 inactive (red warning + disabled generate) ─────
+	case 'control-inactive':
+		rms_harness_wp_stubs();
+		require $kernel_path; $h =& $GLOBALS['rms_harness'];
+		rms_harness_assert( isset( $h['hooks']['acf/render_field/key=field_rms_cf7_landing_form_control'] ), 'the render hook must be registered even when CF7 is inactive' );
+		$clean = rms_cf7_landing_form_control_field( array( 'key' => 'field_rms_cf7_landing_form_control', 'message' => '<p>stale</p>' ) );
+		rms_harness_assert( '' === $clean['message'], 'the inactive load path must also force an empty message' );
+		$out = rms_harness_capture( 'rms_cf7_landing_form_control_render' );
+		rms_harness_contains( $out, array( 'Enable the Contact Form 7 plugin before adding the theme form.', 'color:#b32d2e', 'disabled', 'form="rms-cf7-landing-form-generate"', 'Generate RMS Landing Form' ) );
+		rms_harness_contains( $out, array( 'readonly', 'button-primary' ), false );
+		rms_harness_assert( 0 === $h['save_calls'] && 0 === $h['option_writes'] && 0 === $h['meta_stamps'], 'inactive render must not create anything' );
+		break;
+
+	default:
+		fwrite( STDERR, "Unknown scenario: {$scenario}\n" );
+		exit( 1 );
+}
+
+function rms_harness_wp_stubs(): void {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	$GLOBALS['rms_harness'] = array(
+		'options' => array(), 'posts' => array(), 'save_calls' => 0, 'option_writes' => 0, 'meta_stamps' => 0, 'hooks' => array(),
+	);
+
+	function get_option( $name, $default = false ) { return $GLOBALS['rms_harness']['options'][ $name ] ?? $default; }
+	function update_option( $name, $value, $autoload = null ) { $GLOBALS['rms_harness']['option_writes']++; $GLOBALS['rms_harness']['options'][ $name ] = $value; return true; }
+	function get_post_meta( $post_id, $key, $single = false ) { return $GLOBALS['rms_harness']['posts'][ (int) $post_id ]['meta'][ $key ] ?? ''; }
+	function add_post_meta( $post_id, $key, $value, $unique = false ) { $GLOBALS['rms_harness']['meta_stamps']++; $GLOBALS['rms_harness']['posts'][ (int) $post_id ]['meta'][ $key ] = $value; return true; }
+	function get_post_status( $post_id ) { return $GLOBALS['rms_harness']['posts'][ (int) $post_id ]['status'] ?? ''; }
+	function get_post_type( $post_id ) { return $GLOBALS['rms_harness']['posts'][ (int) $post_id ]['type'] ?? ''; }
+	function get_posts( $args ) { $ids = array(); foreach ( $GLOBALS['rms_harness']['posts'] as $id => $post ) { if ( ( $args['post_status'] ?? '' ) !== $post['status'] || ( $args['post_type'] ?? '' ) !== $post['type'] || ( $post['meta'][ $args['meta_key'] ?? '' ] ?? '' ) !== ( $args['meta_value'] ?? '' ) ) { continue; } $ids[] = $id; } return $ids; }
+	function get_locale() { return 'en_US'; } function is_admin() { return true; } function __( $text, $domain = 'default' ) { return $text; }
+	function esc_html( $text ) { return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' ); } function esc_attr( $text ) { return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' ); }
+	function esc_url( $url ) { return (string) $url; } function wp_unslash( $value ) { return $value; }
+	function add_filter( $tag, $callback ) { $GLOBALS['rms_harness']['hooks'][ $tag ] = $callback; return true; } function add_action( $tag, $callback, $priority = 10, $accepted_args = 1 ) { $GLOBALS['rms_harness']['hooks'][ $tag ] = $callback; return true; }
+	function sanitize_key( $key ) { return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', (string) $key ) ); }
+	function admin_url( $path = '' ) { return 'https://example.com/wp-admin/' . $path; }
+	function add_query_arg( $args, $url = '' ) { return $url . ( false === strpos( $url, '?' ) ? '?' : '&' ) . http_build_query( $args ); }
+	function wp_nonce_field( $action = -1, $name = '_wpnonce', $referer = true, $echo = true ) { $html = '<input type="hidden" name="' . $name . '" value="rms-nonce-token" />'; if ( $echo ) { echo $html; } return $html; }
+	function check_admin_referer( $action = -1, $query_arg = false ) { $key = $query_arg ? $query_arg : '_wpnonce'; if ( ( $_POST[ $key ] ?? '' ) !== 'rms-nonce-token' ) { throw new Exception( 'bad nonce' ); } return true; }
+	function current_user_can( $capability ) { return true; }
+	function wp_die( $message = '', $title = '', $args = array() ) { throw new Exception( 'wp_die' ); } function wp_safe_redirect( $url ) { throw new Exception( 'redirect ' . $url ); }
+}
+
+function rms_harness_install_cf7(): void {
+	class WPCF7_ContactForm {
+		public $harness_id = 0; public $harness_title = '';
+		public function __construct( int $id, string $title ) { $this->harness_id = $id; $this->harness_title = $title; }
+		public function id(): int { return $this->harness_id; }
+		public function title(): string { return $this->harness_title; }
+	}
+
+	function wpcf7_save_contact_form( $args = array(), $context = 'save' ) { $h =& $GLOBALS['rms_harness']; $h['save_calls']++; $id = (int) ( $args['id'] ?? -1 ); if ( $id < 1 ) { $ids = array_keys( $h['posts'] ); $id = $ids ? max( $ids ) + 1 : 1; $h['posts'][ $id ] = array( 'title' => (string) ( $args['title'] ?? '' ), 'status' => 'publish', 'type' => 'wpcf7_contact_form', 'meta' => array() ); } return new WPCF7_ContactForm( $id, (string) ( $args['title'] ?? '' ) ); }
+
+	function wpcf7_contact_form( $id ) { $post = $GLOBALS['rms_harness']['posts'][ (int) $id ] ?? null; $valid = null !== $post && 'wpcf7_contact_form' === $post['type'] && 'publish' === $post['status']; return $valid ? new WPCF7_ContactForm( (int) $id, $post['title'] ) : false; }
+}

--- a/tests/cf7-theme-settings-control-harness.php
+++ b/tests/cf7-theme-settings-control-harness.php
@@ -134,7 +134,7 @@ switch ( $scenario ) {
 		require $kernel_path; $h =& $GLOBALS['rms_harness'];
 		rms_harness_assert( isset( $h['hooks']['acf/load_field/key=field_rms_cf7_landing_form_control'], $h['hooks']['admin_post_rms_cf7_generate_landing_form'], $h['hooks']['admin_footer'], $h['hooks']['admin_notices'] ), 'control filter, handler, footer form, and notices must be hooked' );
 
-		$msg = (string) ( rms_cf7_landing_form_control_field( array( 'key' => 'field_rms_cf7_landing_form_control', 'message' => '' ) )['message'] ?? '' );
+		$msg = rms_harness_capture( 'rms_cf7_landing_form_control_render' );
 		rms_harness_contains( $msg, array( 'Enable the Contact Form 7 plugin before adding the theme form.', 'Generate RMS Landing Form', 'form="rms-cf7-landing-form-generate"', 'disabled', 'color:#b32d2e' ) );
 		rms_harness_contains( $msg, array( 'readonly', '[contact-form-7' ), false );
 		rms_harness_assert( 0 === $h['save_calls'] && 0 === $h['option_writes'] && 0 === $h['meta_stamps'], 'inactive render must not create or persist anything' );
@@ -155,7 +155,7 @@ switch ( $scenario ) {
 		require $kernel_path; $h =& $GLOBALS['rms_harness'];
 
 		// Ready state: enabled primary button, no warning, no shortcode, no creation.
-		$msg = (string) ( rms_cf7_landing_form_control_field( array( 'key' => 'field_rms_cf7_landing_form_control', 'message' => '' ) )['message'] ?? '' );
+		$msg = rms_harness_capture( 'rms_cf7_landing_form_control_render' );
 		rms_harness_contains( $msg, array( 'Generate RMS Landing Form', 'form="rms-cf7-landing-form-generate"', 'button-primary' ) );
 		rms_harness_contains( $msg, array( 'disabled', 'readonly', 'Enable the Contact Form 7' ), false );
 		rms_harness_assert( 0 === $h['save_calls'] && 0 === $h['option_writes'] && 0 === $h['meta_stamps'], 'Theme Settings render must not create a form' );
@@ -176,7 +176,7 @@ switch ( $scenario ) {
 		rms_harness_assert( $id > 0 && 1 === $h['save_calls'] && 1 === $h['meta_stamps'] && 'landing_form' === get_post_meta( $id, '_rms_theme_managed', true ), 'kernel must create exactly one marked form and persist it' );
 
 		// Existing state: escaped readonly shortcode, enabled button, no overwrite.
-		$msg = (string) ( rms_cf7_landing_form_control_field( array( 'key' => 'field_rms_cf7_landing_form_control', 'message' => '' ) )['message'] ?? '' );
+		$msg = rms_harness_capture( 'rms_cf7_landing_form_control_render' );
 		rms_harness_contains( $msg, array( 'readonly', 'html_class=&quot;hero__form&quot;', 'id=&quot;' . $id . '&quot;', 'Generate RMS Landing Form', 'form="rms-cf7-landing-form-generate"' ) );
 		rms_harness_contains( $msg, array( 'disabled' ), false );
 		rms_harness_assert( 1 === $h['save_calls'] && 1 === $h['meta_stamps'], 'existing-state render must not overwrite or restamp the form' );


### PR DESCRIPTION
Closes #121

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Chain

**Part 3 of 3**

1. #122 — managed CF7 form kernel
2. #123 — secure Theme Settings control runtime
3. This PR — ACF wiring, Hero integration, CF7 styling, and end-to-end verification

## Summary

- Adds the Contact Form 7 control to Theme Settings through an ACF tab and read-only message field.
- Renders the escaped control through a dedicated ACF render hook so ACF sanitation cannot strip its readonly input or separate-form association.
- Removes the non-submitting hardcoded roofing form from the Hero.
- Renders a two-column Hero only when a trimmed page-level shortcode exists; generated shortcodes are never auto-injected.
- Adds Hero-scoped CF7 validation, response, wrapper, spinner, and focus styles.

## LocalWP verification

- Opening Theme Settings created no CF7 form.
- First Generate created `RMS Landing Form` ID 439.
- Second Generate reused ID 439; exactly one managed form remained.
- Readonly shortcode: `[contact-form-7 id="439" title="RMS Landing Form" html_class="hero__form"]`.
- Generated form uses `email*`, `tel*`, and generic `text* your-service`; no roofing literals.

## Test Plan

- [x] `php tests/cf7-hero-integration-harness.php` — 4/4 scenarios passed.
- [x] `php tests/cf7-theme-settings-control-harness.php` — 2/2 scenarios passed.
- [x] `php tests/cf7-landing-form-service-harness.php` — 6/6 scenarios passed.
- [x] PHP lint and JSON parse passed.
- [x] `npm run build` passed; compiled Hero CSS contains scoped `.wpcf7` selectors.
- [x] `git diff --check` passed.
- [x] Independent verifier approved the 385-line slice.

## Contributor Checklist

- [x] Closes approved issue #121.
- [x] Exactly one PR type selected and `type:bug` applied.
- [x] No production WordPress/ACF/CF7 stubs added.
- [x] `dist/` remains untracked.
- [x] Conventional commit format used.
- [x] No `Co-Authored-By` trailer added.
